### PR TITLE
Fix the compile error about need libefivar if disable AVB.

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -83,7 +83,10 @@ TARGET_RELEASETOOLS_EXTENSIONS ?= device/intel/common/recovery
 TARGET_RECOVERY_UPDATER_LIBS := libupdater_esp
 # Extra libraries needed to be rolled into recovery updater
 # libgpt_static and libefivar are needed by libupdater_esp
-TARGET_RECOVERY_UPDATER_EXTRA_LIBS := libcommon_recovery libgpt_static libefivar
+TARGET_RECOVERY_UPDATER_EXTRA_LIBS := libcommon_recovery libgpt_static
+ifeq ($(TARGET_SUPPORT_BOOT_OPTION),true)
+TARGET_RECOVERY_UPDATER_EXTRA_LIBS += libefivar
+endif
 {{/avb}}
 # By default recovery minui expects RGBA framebuffer
 TARGET_RECOVERY_PIXEL_FORMAT := "BGRA_8888"


### PR DESCRIPTION
Only build with libefivar if defined TARGET_SUPPORT_BOOT_OPTION,
and the user need to checkout the libefivar by self.

Jira: None.
Test: Test it in Joule, can build image without AVB and boot to UI.

Signed-off-by: Ming Tan <ming.tan@intel.com>