### PR TITLE
usb-gadget: Fix for CTS UsbDebugging test

### DIFF
--- a/groups/usb-gadget/g_ffs/product.mk
+++ b/groups/usb-gadget/g_ffs/product.mk
@@ -3,7 +3,6 @@ USB_CONFIG := mtp
 ifeq ($(TARGET_BUILD_VARIANT),user)
 # Enable Secure Debugging
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.adb.secure=1
-PRODUCT_COPY_FILES += device/intel/common/usb-gadget/adb_keys:root/adb_keys
 ifeq ($(BUILD_FOR_CTS_AUTOMATION),true)
 # Build for automated CTS
 USB_CONFIG := $(USB_CONFIG),adb


### PR DESCRIPTION
adb keys should not be present in user build.
Jira: none
Test: none

Signed-off-by: saranya <saranya.gopal@intel.com>