### PR TITLE
Add support for flag ignore_not_applicable_reset.

### DIFF
--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -6,6 +6,7 @@ assume_bios_secure_boot = false
 blpolicy_use_efi_var = true
 bootloader_len = 33
 bootloader_policy = false
+ignore_not_applicable_reset = false
 magic_key_timeout = false
 rpmb = false
 rpmb_simulate = false

--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -13,3 +13,9 @@ endif
 {{#slot-ab}}
 PRODUCT_PACKAGES += updater_ab_esp
 {{/slot-ab}}
+
+{{#ignore_not_applicable_reset}}
+# Allow Kernelflinger to ignore the RSCI reset source "not_applicable"
+# when setting the bootreason
+KERNELFLINGER_IGNORE_NOT_APPLICABLE_RESET := true
+{{/ignore_not_applicable_reset}}


### PR DESCRIPTION
Used to define a compilation flag for kernelflingerlib.
Set ignore_not_applicable_reset = true to enable it.
Default is disabled.

Jira: None.
Test: Test it in Joule and KBL NUC.
      If enable this feature, the boot reason will not be
      not_applicable, maybe unknown.

Signed-off-by: Ming Tan <ming.tan@intel.com>
Signed-off-by: Florent Auger <florent.auger@intel.com>