### PR TITLE
Disable the 'Fastboot' boot option by default.

### DIFF
--- a/groups/boot-arch/project-celadon/AndroidBoard.mk
+++ b/groups/boot-arch/project-celadon/AndroidBoard.mk
@@ -86,7 +86,9 @@ endif
 	$(hide) $(ACP) $(BOARD_FIRST_STAGE_LOADER) $(efi_root)/loader.efi
 	$(hide) $(ACP) $(BOARD_FIRST_STAGE_LOADER) $(efi_root)/EFI/BOOT/$(efi_default_name)
 	$(hide) echo "Android-IA=\\EFI\\BOOT\\$(efi_default_name)" > $(efi_root)/manifest.txt
+ifeq ($(BOARD_BOOTOPTION_FASTBOOT),true)
 	$(hide) echo "Fastboot=\\EFI\\BOOT\\$(efi_default_name);-f">> $(efi_root)/manifest.txt
+endif
 	$(hide) (cd $(efi_root) && zip -qry ../$(notdir $@) .)
 
 bootloader_info := $(intermediates)/bootloader_image_info.txt


### PR DESCRIPTION
In KBL NUC, if add the 'Fastboot' boot option, in sometimes it will
be set to default boot option.
Add BOARD_BOOTOPTION_FASTBOOT=true in make command line option to
add the 'Fastboot' boot option. Useful in Joule platform.
If the 'Fastboot' boot option is already added, will not delete.
In UEFI shell, use the command 'dmpstore -d BootOrder' to delete
the boot option setting.

Jira: None.
Test: Test it in Joule.
      Has not the 'Fastboot' boot option after install.

Signed-off-by: Ming Tan <ming.tan@intel.com>