### PR TITLE
cpuset: add autocores option

### DIFF
--- a/groups/cpuset/autocores/init.rc
+++ b/groups/cpuset/autocores/init.rc
@@ -1,0 +1,6 @@
+on late-init
+    copy /sys/devices/system/cpu/online /dev/cpuset/foreground/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/background/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/system-background/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/top-app/cpus
+    copy /sys/devices/system/cpu/online /dev/cpuset/foreground/boost/cpus

--- a/groups/cpuset/default
+++ b/groups/cpuset/default
@@ -1,1 +1,1 @@
-4cores/
+autocores


### PR DESCRIPTION
autocores option is used to detect cpu numbers dynamically
instead of hard-coded.

Jira: https://01.org/jira/browse/CEL-3
Test: Test it in UP2 board.

Change-Id: I4ec1524d68f68ab975abdf7afb24e362ea1175b0
Signed-off-by: Chen Lin Z <lin.z.chen@intel.com>