### PR TITLE
Remove the tablet sepcific config from base.

### DIFF
--- a/groups/project-celadon/default/product.mk
+++ b/groups/project-celadon/default/product.mk
@@ -41,9 +41,6 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/gpt.ini:root/gpt.$(TARGET_PRODUCT).ini \
     $(LOCAL_PATH)/init.recovery.rc:root/init.recovery.$(TARGET_PRODUCT).rc \
 
-PRODUCT_COPY_FILES += \
-	frameworks/native/data/etc/tablet_core_hardware.xml:system/etc/permissions/tablet_core_hardware.xml
-
 # Voip
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.sip.voip.xml:system/etc/permissions/android.software.sip.voip.xml \


### PR DESCRIPTION
The tablet config should not be involved in the base config.
That will cause the car device having the tablet features.
e.g. feature android.software.picture_in_picture.

Jira: OAM-64969
Test: run cts -m CtsAccessibilityServiceTestCases -t \
android.accessibilityservice.cts.AccessibilityWindowQueryTest# \
testFindPictureInPictureWindow
Signed-off-by: Walter Yan <walterx.yan@intel.com>