### PR TITLE
Fix for CtsMediaTestCases assertion failure.

### DIFF
--- a/groups/media/project-celadon/product.mk
+++ b/groups/media/project-celadon/product.mk
@@ -10,7 +10,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml \
-    frameworks/native/data/etc/android.hardware.audio.low_latency.xml:system/etc/permissions/android.hardware.audio.low_latency.xml \
     device/intel/project-celadon/common/media/media_profiles.xml:system/etc/media_profiles.xml \
     device/intel/project-celadon/common/media/media_codecs.xml:system/etc/media_codecs.xml \
     device/intel/project-celadon/common/media/media_codecs_performance.xml:system/etc/media_codecs_performance.xml


### PR DESCRIPTION
AudioRecordTests were failing due to low_latency. Removed it.

Jira: None

Test: CtsMediaTestCases.

Signed-off-by: Shree, Priya <priya.shree@intel.com>