### PR TITLE
Adapt AAPT config for display-density medium

### DIFF
--- a/groups/device-type/tablet/product.mk
+++ b/groups/device-type/tablet/product.mk
@@ -5,10 +5,4 @@ $(call inherit-product,frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-hea
 PRODUCT_COPY_FILES += \
         {{{tablet_core_hardware_path}}}/tablet_core_hardware.xml:system/etc/permissions/tablet_core_hardware.xml
 
-PRODUCT_AAPT_CONFIG := normal large xlarge mdpi hdpi xhdpi
-PRODUCT_AAPT_PREF_CONFIG :=
-
-PRODUCT_PROPERTY_OVERRIDES += \
-   ro.sf.lcd_density=160
-
 

--- a/groups/display-density/medium/product.mk
+++ b/groups/display-density/medium/product.mk
@@ -1,4 +1,4 @@
-PRODUCT_AAPT_CONFIG := {{product_aapt_config}}
+PRODUCT_AAPT_CONFIG := normal large mdpi
 PRODUCT_AAPT_PREF_CONFIG := mdpi
 
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.sf.lcd_density=160

--- a/groups/project-celadon/default/product.mk
+++ b/groups/project-celadon/default/product.mk
@@ -12,9 +12,6 @@ PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.dalvik.vm.native.bridge=libhoudini.so
 
 PRODUCT_TAGS += dalvik.gc.type-precise
 
-PRODUCT_AAPT_CONFIG := normal large xlarge mdpi hdpi xhdpi xxhdpi
-PRODUCT_AAPT_PREF_CONFIG := xxhdpi
-
 DEVICE_PACKAGE_OVERLAYS += device/intel/project-celadon/common/overlay
 
 PRODUCT_PACKAGES += $(THIRD_PARTY_APPS)


### PR DESCRIPTION
Jira: OAM-65717,OAM-65715
Test: run cts -m CtsThemeHostTestCases
              -t android.theme.cts.ThemeHostTest#testThemes
      run cts -m CtsThemeDeviceTestCases
              -t android.theme.cts.DeviceDefaultTest#testGetActionBar_DeviceDefault_Light_DialogWhenLarge

Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>