### PR TITLE
Add the setting for OEM unlocking.

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -130,23 +130,23 @@ TARGET_BOOTLOADER_POLICY := {{bootloader_policy}}
 TARGET_BOOTLOADER_POLICY_USE_EFI_VAR := {{blpolicy_use_efi_var}}
 #ifeq ($(TARGET_BOOTLOADER_POLICY),$(filter $(TARGET_BOOTLOADER_POLICY),0x0 0x2 0x4 0x6))
 # OEM Unlock reporting 1
-#ADDITIONAL_DEFAULT_PROPERTIES += \
-#	ro.oem_unlock_supported=1
+PRODUCT_PROPERTY_OVERRIDES += \
+	ro.oem_unlock_supported=1
 #endif
 ifeq ($(TARGET_BOOTLOADER_POLICY),$(filter $(TARGET_BOOTLOADER_POLICY),static external))
 # The bootloader policy is not generated build time but is supplied
 # statically in the repository or in $(PRODUCT_OUT)/.  If your
 # bootloader policy allows the device to be unlocked, uncomment the
 # following lines:
-# ADDITIONAL_DEFAULT_PROPERTIES += \
-# 	ro.oem_unlock_supported=1
+#PRODUCT_PROPERTY_OVERRIDES += \
+	ro.oem_unlock_supported=1
 endif
 {{/bootloader_policy}}
 
 
 {{^bootloader_policy}}
 # OEM Unlock reporting 2
-ADDITIONAL_DEFAULT_PROPERTIES += \
+PRODUCT_PROPERTY_OVERRIDES += \
 	ro.oem_unlock_supported=1
 {{/bootloader_policy}}
 


### PR DESCRIPTION
Also fix a compile error if disable the bootloader policy.

Jira: https://01.org/jira/browse/CEL-17
Test: Test it in KBL NUC.
      In mixins.spec, set the bootloader_policy=false, can compile success, and boot to UI.
      After boot to UI, can enable the OEM unlock.

Signed-off-by: Ming Tan <ming.tan@intel.com>