### PR TITLE
Selection of Bluetooth Build Config header file   based on device-type (car or tablet)

### DIFF
--- a/groups/bluetooth/btusb/BoardConfig.mk
+++ b/groups/bluetooth/btusb/BoardConfig.mk
@@ -1,6 +1,12 @@
 BOARD_HAVE_BLUETOOTH := true
 BOARD_HAVE_BLUETOOTH_LINUX := true
-BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := device/intel/common/bluetooth/bcm43241/
 DEVICE_PACKAGE_OVERLAYS += device/intel/common/bluetooth/overlay-bt-pan
 BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/bluetooth/common \
                        device/intel/project-celadon/sepolicy/bluetooth/intel
+{{#ivi}}
+BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := device/intel/common/bluetooth/intel/car/
+{{/ivi}}
+
+{{^ivi}}
+BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := device/intel/common/bluetooth/intel/tablet/
+{{/ivi}}

--- a/groups/bluetooth/btusb/option.spec
+++ b/groups/bluetooth/btusb/option.spec
@@ -1,0 +1,2 @@
+[defaults]
+ivi = false


### PR DESCRIPTION
Description:
- Declared a flag "ivi" in option.spec under bluetooth/btusb
  and set its default value "false".
- Set "BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR" based on
  the flag "ivi" in BoardConfig.mk file.

Jira: https://jira01.devtools.intel.com/browse/OAM-65576

Test:
- BT AVRCP should work, user shouble be able to control music
  from Bluetooth Audio App on kabylake IVI - PASS

Signed-off-by: Umesh Agarwal <umeshx.agarwal@intel.com>