### PR TITLE
Fix the conflict of build USB live boot image and grub image.

### DIFF
--- a/groups/gptbuild/true/BoardConfig.mk
+++ b/groups/gptbuild/true/BoardConfig.mk
@@ -1,3 +1,3 @@
 # can't use := here, as PRODUCT_OUT is not defined yet
-GPTIMAGE_BIN = $(PRODUCT_OUT)/$(TARGET_PRODUCT).img
-CRAFFIMAGE_BIN = $(PRODUCT_OUT)/$(TARGET_PRODUCT).craff
+GPTIMAGE_BIN = $(PRODUCT_OUT)/$(TARGET_PRODUCT)_gptimage.img
+CRAFFIMAGE_BIN = $(PRODUCT_OUT)/$(TARGET_PRODUCT)_gptimage.craff


### PR DESCRIPTION
Jira: https://01.org/jira/browse/CEL-36
Test: Test it in KBL NUC, can build usb live image and grub image.

Signed-off-by: Ming Tan <ming.tan@intel.com>