### PR TITLE
gptbuild: does not include the userdata. And delete hte dependence of efitools.

### DIFF
--- a/groups/boot-arch/project-celadon/AndroidBoard.mk
+++ b/groups/boot-arch/project-celadon/AndroidBoard.mk
@@ -161,7 +161,7 @@ GEN_BLPOLICY_OEMVARS := device/intel/build/generate_blpolicy_oemvars
 TARGET_ODM_KEY_PAIR := device/intel/build/testkeys/odm
 TARGET_OAK_KEY_PAIR := device/intel/build/testkeys/OAK
 
-$(BOOTLOADER_POLICY_OEMVARS): sign-efi-sig-list
+$(BOOTLOADER_POLICY_OEMVARS):
 	$(GEN_BLPOLICY_OEMVARS) -K $(TARGET_ODM_KEY_PAIR) \
 		-O $(TARGET_OAK_KEY_PAIR).x509.pem -B $(TARGET_BOOTLOADER_POLICY) \
 		$(BOOTLOADER_POLICY_OEMVARS)

--- a/groups/gptbuild/true/AndroidBoard.mk
+++ b/groups/gptbuild/true/AndroidBoard.mk
@@ -59,10 +59,6 @@ $(GPTIMAGE_BIN): \
 	$(hide) rm -f $(INSTALLED_CACHEIMAGE_TARGET).raw
 	{{/slot-ab}}
 
-	$(MAKE_EXT4FS) \
-		-l $(BOARD_USERDATAIMAGE_PARTITION_SIZE) -L data \
-		$(PRODUCT_OUT)/userdata.dummy
-
 	$(SIMG2IMG) $(INSTALLED_SYSTEMIMAGE) $(INSTALLED_SYSTEMIMAGE).raw
 	{{^slot-ab}}
 	$(SIMG2IMG) $(INSTALLED_CACHEIMAGE_TARGET) $(INSTALLED_CACHEIMAGE_TARGET).raw
@@ -92,7 +88,6 @@ $(GPTIMAGE_BIN): \
         {{#vendor-partition}}
 		--vendor $(INSTALLED_VENDORIMAGE_TARGET).raw \
         {{/vendor-partition}}
-		--data $(PRODUCT_OUT)/userdata.dummy \
 		--config $(raw_config) \
 		--factory $(raw_factory)
 


### PR DESCRIPTION
Jira: None.
Test: Can build the gptimage.

Signed-off-by: Ming Tan <ming.tan@intel.com>