### PR TITLE
thermal-daemon: Defining the sepolicy for thermal-daemon

### DIFF
--- a/sepolicy/thermal/thermal-daemon/file.te
+++ b/sepolicy/thermal/thermal-daemon/file.te
@@ -1,0 +1,3 @@
+type thermal-daemon_data_file, file_type, data_file_type;
+type sysfs_dmi_id, fs_type, sysfs_type;
+type thermal-daemon_run_dir, fs_type, data_file_type;

--- a/sepolicy/thermal/thermal-daemon/file_contexts
+++ b/sepolicy/thermal/thermal-daemon/file_contexts
@@ -1,0 +1,5 @@
+/vendor/bin/thermal-daemon        u:object_r:thermal-daemon_exec:s0
+/vendor/etc/thermal_daemon(/.*)?        u:object_r:thermal-daemon_data_file:s0
+/data/misc/thermal-daemon(/.*)?	u:object_r:thermal-daemon_run_dir:s0
+/sys/devices/virtual/dmi/id/product_name		u:object_r:sysfs_dmi_id:s0
+/sys/devices/virtual/dmi/id/product_uuid		u:object_r:sysfs_dmi_id:s0

--- a/sepolicy/thermal/thermal-daemon/thermal-daemon.te
+++ b/sepolicy/thermal/thermal-daemon/thermal-daemon.te
@@ -1,0 +1,25 @@
+#
+# thermal-daemon
+#
+
+type thermal-daemon, domain;
+type thermal-daemon_exec, exec_type, file_type, vendor_file_type;
+init_daemon_domain(thermal-daemon)
+
+allow thermal-daemon sysfs:dir r_dir_perms;
+allow thermal-daemon sysfs_thermal_management:dir r_dir_perms;
+allow thermal-daemon sysfs_thermal_management:file rw_file_perms;
+allow thermal-daemon sysfs_powercap:{ file lnk_file } rw_file_perms;
+allow thermal-daemon sysfs_powercap:dir r_dir_perms;
+allow thermal-daemon sysfs_thermal:file rw_file_perms;
+allow thermal-daemon sysfs_dmi_id:{ file lnk_file } rw_file_perms;
+allow thermal-daemon system_data_file:dir create_dir_perms;
+allow thermal-daemon system_data_file:dir rw_dir_perms;
+allow thermal-daemon thermal-daemon_run_dir:dir create_dir_perms;
+allow thermal-daemon thermal-daemon_run_dir:file create_file_perms;
+allow thermal-daemon thermal-daemon_data_file:dir r_file_perms;
+allow thermal-daemon thermal-daemon_data_file:file r_file_perms;
+allow thermal-daemon thermal_device:chr_file rw_file_perms;
+
+# properties
+set_prop(thermal-daemon, powerctl_prop)


### PR DESCRIPTION
Specifying sepolicy for thermal daemon.

Change-Id: I4c89c03257787f51d1cca173049b041f0102da07
Tracked-On: OAM-67241
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>