### PR TITLE
audio: Add sepolicy directory

### DIFF
--- a/groups/audio/project-celadon/BoardConfig.mk
+++ b/groups/audio/project-celadon/BoardConfig.mk
@@ -14,3 +14,5 @@ endif
 USE_XML_AUDIO_POLICY_CONF ?= 1
 # Use configurable audio policy
 USE_CONFIGURABLE_AUDIO_POLICY ?= 1
+
+BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/audio/project-celadon


### PR DESCRIPTION
Due to missing sepolicies for audio, audio server is getting
restarted and as a result bluetooth service also gets restarted.

Add sepolicies for audio to get audio and bluetooth working.

Tracked-On: OAM-67968

Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>