### PR TITLE
Enable USB Camera using External Camera HAL

### DIFF
--- a/groups/camera-ext/default
+++ b/groups/camera-ext/default
@@ -1,0 +1,1 @@
+disabled

--- a/groups/camera-ext/doc.spec
+++ b/groups/camera-ext/doc.spec
@@ -1,0 +1,43 @@
+=== Overview
+
+camera-ext is used to enable support for external camera(especially, USB/UVC web camera) in build,
+with Google's reference implementation. We are encouraged to make device- and SoC-specific optimizations,
+or even our own specific implemtation.
+
+This feature is firstly introduced on Android P-dessert.
+
+Documents from Google (Please apply Google drive access first):
+USB/UVC Integrated Cameras: https://drive.google.com/open?id=16C0pV6kcSs08g-105uaFLHsED4WerPwO
+USB web camera support: https://drive.google.com/open?id=1-hzq2L4c5UQ2Es-cQKAn0It8m7zx-W2v (P37~P43)
+
+==== Options
+
+--- enabled
+this option is used to enable support for external camera in build with internal cameras (CSI camera)
+
+    --- parameters
+
+    --- code dir
+	- hardware/interface/camera/provider/2.4/default/ExternalCamera*
+	- hardware/interface/camera/device/3.4/default/ExternalCamera*
+	- hardware/interface/camera/device/3.4/default/include/ext_device_v3_4_impl/ExternalCamera*
+
+--- ext-camera-only
+this option is used to enable support for external camera in build. There is no support for CSI Camera here, will support only USB Camera.
+
+    --- parameters
+
+    --- code dir
+        - hardware/interface/camera/provider/2.4/default/ExternalCamera*
+        - hardware/interface/camera/device/3.4/default/ExternalCamera*
+        - hardware/interface/camera/device/3.4/default/include/ext_device_v3_4_impl/ExternalCamera*
+
+--- disabled
+this option is used to disable support for external camera in build
+
+    --- parameters
+
+    --- code dir
+
+--- default
+when not explicitly selected in mixin spec file, the default option will be used.

--- a/groups/camera-ext/enabled/BoardConfig.mk
+++ b/groups/camera-ext/enabled/BoardConfig.mk
@@ -1,0 +1,1 @@
+BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/camera/usbcamera

--- a/groups/camera-ext/enabled/external_camera_config.xml
+++ b/groups/camera-ext/enabled/external_camera_config.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright (C) 2017-2018 Intel Corporation.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<ExternalCamera>
+    <Provider>
+        <ignore> <!-- Internal video devices to be ignored by external camera HAL -->
+            <id>0</id> <!-- No leading/trailing spaces -->
+            <id>1</id>
+            <id>2</id>
+            <id>3</id>
+            <id>4</id>
+            <id>5</id>
+            <id>6</id>
+            <id>7</id>
+            <id>8</id>
+            <id>9</id>
+            <id>10</id>
+            <id>11</id>
+            <id>12</id>
+            <id>13</id>
+            <id>14</id>
+            <id>15</id>
+            <id>16</id>
+            <id>17</id>
+            <id>18</id>
+            <id>19</id>
+            <id>20</id>
+            <id>21</id>
+            <id>22</id>
+            <id>23</id>
+            <id>24</id>
+            <id>25</id>
+            <id>26</id>
+            <id>27</id>
+            <id>28</id>
+            <id>29</id>
+            <id>30</id>
+            <id>31</id>
+            <id>32</id>
+            <id>33</id>
+            <id>34</id>
+            <id>35</id>
+            <id>36</id>
+            <id>37</id>
+            <id>38</id>
+            <id>39</id>
+            <id>40</id>
+            <id>41</id>
+            <id>42</id>
+            <id>43</id>
+            <id>44</id>
+        </ignore>
+    </Provider>
+    <!-- See ExternalCameraUtils.cpp for default values of Device configurations below
+-->
+    <Device>
+        <!-- Max JPEG buffer size in bytes-->
+        <MaxJpegBufferSize bytes="3145728"/> <!-- 3MB (~= 1080p YUV420) -->
+        <!-- Size of v4l2 buffer queue when streaming >= 30fps -->
+        <!-- Larger value: more request can be cached pipeline (less janky)  -->
+        <!-- Smaller value: use less memory -->
+        <NumVideoBuffers count="4"/>
+        <!-- Size of v4l2 buffer queue when streaming < 30fps -->
+        <NumStillBuffers count="2"/>
+
+        <!-- List of maximum fps for various output sizes -->
+        <!-- Any image size smaller than the size listed in Limit row will report
+            fps (as minimum frame duration) up to the fpsBound value. -->
+        <FpsList>
+            <!-- width/height must be increasing, fpsBound must be decreasing-->
+            <Limit width="640" height="480" fpsBound="30.0"/>
+            <Limit width="1280" height="720" fpsBound="15.0"/>
+            <Limit width="1920" height="1080" fpsBound="10.0"/>
+            <!-- image size larger than the last entry will not be supported-->
+        </FpsList>
+    </Device>
+</ExternalCamera>

--- a/groups/camera-ext/enabled/files.spec
+++ b/groups/camera-ext/enabled/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+external_camera_config.xml: "external camera parameters"

--- a/groups/camera-ext/enabled/product.mk
+++ b/groups/camera-ext/enabled/product.mk
@@ -1,0 +1,10 @@
+# Camera: Device-specific configuration files.
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.camera.external.xml:vendor/etc/permissions/android.hardware.camera.external.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/external_camera_config.xml:vendor/etc/external_camera_config.xml
+
+# External camera service
+PRODUCT_PACKAGES += android.hardware.camera.provider@2.4-external-service
+
+# Only include test apps in eng or userdebug builds.
+PRODUCT_PACKAGES_DEBUG += TestingCamera

--- a/groups/camera-ext/enabled/ueventd.rc
+++ b/groups/camera-ext/enabled/ueventd.rc
@@ -1,0 +1,2 @@
+# Camera
+/dev/video*       0660  system  camera

--- a/groups/camera-ext/ext-camera-only/BoardConfig.mk
+++ b/groups/camera-ext/ext-camera-only/BoardConfig.mk
@@ -1,0 +1,1 @@
+BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/camera/usbcamera

--- a/groups/camera-ext/ext-camera-only/external_camera_config.xml
+++ b/groups/camera-ext/ext-camera-only/external_camera_config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright (C) 2017-2018 Intel Corporation.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<ExternalCamera>
+    <Provider>
+        <ignore> <!-- Internal video devices to be ignored by external camera HAL -->
+        </ignore>
+    </Provider>
+    <!-- See ExternalCameraUtils.cpp for default values of Device configurations below
+-->
+    <Device>
+        <!-- Max JPEG buffer size in bytes-->
+        <MaxJpegBufferSize bytes="3145728"/> <!-- 3MB (~= 1080p YUV420) -->
+        <!-- Size of v4l2 buffer queue when streaming >= 30fps -->
+        <!-- Larger value: more request can be cached pipeline (less janky)  -->
+        <!-- Smaller value: use less memory -->
+        <NumVideoBuffers count="4"/>
+        <!-- Size of v4l2 buffer queue when streaming < 30fps -->
+        <NumStillBuffers count="2"/>
+
+        <!-- List of maximum fps for various output sizes -->
+        <!-- Any image size smaller than the size listed in Limit row will report
+            fps (as minimum frame duration) up to the fpsBound value. -->
+        <FpsList>
+            <!-- width/height must be increasing, fpsBound must be decreasing-->
+            <Limit width="640" height="480" fpsBound="30.0"/>
+            <Limit width="1280" height="720" fpsBound="15.0"/>
+            <Limit width="1920" height="1080" fpsBound="10.0"/>
+            <!-- image size larger than the last entry will not be supported-->
+        </FpsList>
+    </Device>
+</ExternalCamera>

--- a/groups/camera-ext/ext-camera-only/files.spec
+++ b/groups/camera-ext/ext-camera-only/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+external_camera_config.xml: "external camera parameters"

--- a/groups/camera-ext/ext-camera-only/product.mk
+++ b/groups/camera-ext/ext-camera-only/product.mk
@@ -1,0 +1,11 @@
+# Camera: Device-specific configuration files. Supports only External USB camera, no CSI support
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.camera.external.xml:vendor/etc/permissions/android.hardware.camera.external.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/external_camera_config.xml:vendor/etc/external_camera_config.xml
+
+# External camera service
+PRODUCT_PACKAGES += android.hardware.camera.provider@2.4-external-service \
+                    android.hardware.camera.provider@2.4-impl
+
+# Only include test apps in eng or userdebug builds.
+PRODUCT_PACKAGES_DEBUG += TestingCamera

--- a/groups/camera-ext/ext-camera-only/ueventd.rc
+++ b/groups/camera-ext/ext-camera-only/ueventd.rc
@@ -1,0 +1,2 @@
+# Camera
+/dev/video*       0660  system  camera


### PR DESCRIPTION
This feature is firstly introduced on
Android P-dessert. Hence creating a
new directory to maintain USB camera
seperately as external camera. It
enables USB webcam by using external
camera HAL with HIDL interfaces.

Tracked-On: None

Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>