### PR TITLE
Select configuration files based on device-type

### DIFF
--- a/groups/bluetooth/btusb/product.mk
+++ b/groups/bluetooth/btusb/product.mk
@@ -11,4 +11,10 @@ PRODUCT_PACKAGES += \
   android.hardware.bluetooth@1.0-service \
   libbt-vendor
 
+{{#ivi}}
 PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/bluetooth/overlay-car-disablehfp
+{{/ivi}}
+
+{{^ivi}}
+PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/bluetooth/overlay-tablet
+{{/ivi}}


### PR DESCRIPTION
Description:
Added checks to enable the configuration file 'overlay-tablet'
for celadon tablet and 'overlay-car-disablehfp' for celadon IVI

Tracked-On: OAM-67866

Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>