### PR TITLE
Fix error about the USB live boot image should set bootloader2 partit…

### DIFF
--- a/groups/gptbuild/true/AndroidBoard.mk
+++ b/groups/gptbuild/true/AndroidBoard.mk
@@ -73,7 +73,6 @@ $(GPTIMAGE_BIN): \
 		--table $(TARGET_DEVICE_DIR)/gpt.ini \
 		--size $(gptimage_size) \
 		--bootloader $(bootloader_bin) \
-		--bootloader2 $(bootloader_bin) \
 		--tos $(tos_bin) \
 		--multiboot $(multiboot_bin) \
 		--boot $(INSTALLED_BOOTIMAGE_TARGET) \


### PR DESCRIPTION

modify /device/intel/mixins/group/gptbuild/true/AndroidBoard.mk

Tracked-On: OAM-69453

Signed-off-by: mengkang <kangx.meng@intel.com>