### PR TITLE
Change the default serial port to ttyS0.

### DIFF
--- a/groups/kernel/project-celadon/BoardConfig.mk
+++ b/groups/kernel/project-celadon/BoardConfig.mk
@@ -14,7 +14,7 @@ TARGET_PRELINK_MODULE := false
 TARGET_NO_KERNEL ?= false
 
 KERNEL_LOGLEVEL ?= {{{loglevel}}}
-SERIAL_PARAMETER := console=tty0 console=ttyS2,115200n8
+SERIAL_PARAMETER ?= console=tty0 console=ttyS0,115200n8
 
 {{^slot-ab}}
 # If enable A/B, then the root should be system partition at last.


### PR DESCRIPTION
The original serial port is ttyS2.
The KBL NUC 7i5DNH use serial port ttyS0 by default.
And now can use SERIAL_PARAMETER="console=tty0 console=ttyS2,115200n8"
in make command line to use ttyS2, or use other serial port.

Jira: None
Test: Test it in KBL NUC 7i5DNH, the serial port does work.

Signed-off-by: Ming Tan <ming.tan@intel.com>