### PR TITLE
set bootloader2 partition is empty.

### DIFF
--- a/groups/gptbuild/true/AndroidBoard.mk
+++ b/groups/gptbuild/true/AndroidBoard.mk
@@ -73,7 +73,6 @@ $(GPTIMAGE_BIN): \
 		--table $(TARGET_DEVICE_DIR)/gpt.ini \
 		--size $(gptimage_size) \
 		--bootloader $(bootloader_bin) \
-		--bootloader2 $(bootloader_bin) \
 		--tos $(tos_bin) \
 		--multiboot $(multiboot_bin) \
 		--boot $(INSTALLED_BOOTIMAGE_TARGET) \


### PR DESCRIPTION
modified the device/intel/mixins/group/gptbuild/true/Andriodboard.mk

Tracked-On: OMA-69453

Signed-off-by: Meng, KangX <kangx.meng@intel.com>