### PR TITLE
set filenames_mode to cts, for heh is not be supported

### DIFF
--- a/groups/project-celadon/default/product.mk
+++ b/groups/project-celadon/default/product.mk
@@ -93,7 +93,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Set filenames_mode to cts, for heh is not available
 PRODUCT_PROPERTY_OVERRIDES += \
-	ro.crypto.volume.filenames_mode=aes-256-cts
+    ro.crypto.volume.filenames_mode=aes-256-cts
 
 # set default USB configuration
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \

--- a/groups/project-celadon/default/product.mk
+++ b/groups/project-celadon/default/product.mk
@@ -91,6 +91,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.input.noresample=1
 
+# Set filenames_mode to cts, for heh is not available
+PRODUCT_PROPERTY_OVERRIDES += \
+	ro.crypto.volume.filenames_mode=aes-256-cts
+
 # set default USB configuration
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     persist.sys.usb.config=mtp


### PR DESCRIPTION
set filenames_mode to cts, for heh is not be supported

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70236
Signed-off-by: Zhiwei Li zhiwei.li@intel.com