### PR TITLE
Add debug diff config for project celadon

### DIFF
--- a/groups/kernel/project-celadon/AndroidBoard.mk
+++ b/groups/kernel/project-celadon/AndroidBoard.mk
@@ -31,7 +31,7 @@ build_kernel := $(MAKE) -C $(TARGET_KERNEL_SRC) \
 
 KERNEL_CONFIG_FILE := device/intel/project-celadon/kernel_config/$(TARGET_KERNEL_CONFIG)
 
-ifeq ($(TARGET_BUILD_VARIANT), userdebug)
+ifneq ($(TARGET_BUILD_VARIANT), user)
 KERNEL_CONFIG_FILE += $(wildcard $(KERNEL_CONFIG_DIR)/debug_diffconfig)
 endif
 

--- a/groups/kernel/project-celadon/AndroidBoard.mk
+++ b/groups/kernel/project-celadon/AndroidBoard.mk
@@ -31,6 +31,10 @@ build_kernel := $(MAKE) -C $(TARGET_KERNEL_SRC) \
 
 KERNEL_CONFIG_FILE := device/intel/project-celadon/kernel_config/$(TARGET_KERNEL_CONFIG)
 
+ifeq ($(TARGET_BUILD_VARIANT), userdebug)
+KERNEL_CONFIG_FILE += $(wildcard $(KERNEL_CONFIG_DIR)/debug_diffconfig)
+endif
+
 KERNEL_CONFIG := $(KERNEL_OUT)/.config
 $(KERNEL_CONFIG): $(KERNEL_CONFIG_FILE)
 	$(hide) mkdir -p $(@D) && cat $(wildcard $^) > $@


### PR DESCRIPTION
Currently, both user/user debug use same kernel config,
this patch add kernel debug config for celadon.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-75275
Signed-off-by: Baofeng, Tian <baofeng.tian@intel.com>