### PR TITLE
Set overlay-car package for IVI

### DIFF
--- a/groups/bluetooth/btusb/product.mk
+++ b/groups/bluetooth/btusb/product.mk
@@ -12,7 +12,7 @@ PRODUCT_PACKAGES += \
   libbt-vendor
 
 {{#ivi}}
-PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/bluetooth/overlay-car-disablehfp
+PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/bluetooth/overlay-car
 {{/ivi}}
 
 {{^ivi}}


### PR DESCRIPTION
Description:
Set PRODUCT_OVERLAY_PACKAGES path to overlay-car
in btusb under bluetooth group so that hfp_client is 
enabled for IVI  

Tracked-On: OAM-70153

Signed-off-by: umeshagx <umeshx.agarwal@intel.com>