### PR TITLE
thermal-daemon: Update the path for the thermal config files

### DIFF
--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -12,7 +12,7 @@ on boot
     chown system system /sys/class/dmi/id/product_uuid
     chown system system /sys/class/dmi/id/product_name
     chown system system /system/vendor/etc/
-    chown system system /system/vendor/etc/thermal-conf.xml
+    chown system system /system/vendor/etc/thermal-daemon/thermal-conf.xml
     restorecon_recursive /sys/class/powercap
 
 on post-fs

--- a/groups/thermal/thermal-daemon/product.mk
+++ b/groups/thermal/thermal-daemon/product.mk
@@ -1,5 +1,5 @@
 # thermal-daemon
 PRODUCT_PACKAGES += thermal-daemon
 PRODUCT_COPY_FILES += \
-	$(LOCAL_PATH)/thermal-conf.xml:/vendor/etc/thermal-daemon/thermal-conf.xml \
-	$(LOCAL_PATH)/thermal-cpu-cdev-order.xml:/vendor/etc/thermal-daemon/thermal-cpu-cdev-order.xml
+	device/intel/project-celadon/common/thermal/thermal-conf.xml:/vendor/etc/thermal-daemon/thermal-conf.xml \
+	device/intel/project-celadon/common/thermal/thermal-cpu-cdev-order.xml:/vendor/etc/thermal-daemon/thermal-cpu-cdev-order.xml


### PR DESCRIPTION
thermal daemon's config file path was changed inorder to make
thermal daemon as a common build recipe. This change updates
the patch in mixins product.mk inorder to copy the file from
the correct path.

Tracked-On: OAM-71333
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>