### PR TITLE
boot-arch: add option self_usb_device_mode_protocol.

### DIFF
--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -14,3 +14,4 @@ rpmb = false
 rpmb_simulate = false
 tos_partition = false
 usb_storage = false
+self_usb_device_mode_protocol = false

--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -77,3 +77,7 @@ endif
 PRODUCT_PROPERTY_OVERRIDES += \
 	ro.oem_unlock_supported=1
 {{/bootloader_policy}}
+
+{{#self_usb_device_mode_protocol}}
+KERNELFLINGER_SUPPORT_SELF_USB_DEVICE_MODE_PROTOCOL := {{self_usb_device_mode_protocol}}
+{{/self_usb_device_mode_protocol}}


### PR DESCRIPTION
This option is used to set kernelflinger use self implemented USb device
mode protocol.
Set to false by default.
If the device BIOS enable USB device mode, but does not support USB
device mode protocol, then can set this option to true.

Tracked-On: OAM-70520
Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>