### PR TITLE
Disable Wifi Direct

### DIFF
--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -25,8 +25,7 @@ PRODUCT_COPY_FILES += \
 {{^tdls_auto}}
         device/intel/common/wlan/iwlwifi/wpa_supplicant_overlay_no_tdls.conf:system/etc/wifi/wpa_supplicant_overlay.conf \
 {{/tdls_auto}}
-        frameworks/native/data/etc/android.hardware.wifi.xml:system/etc/permissions/android.hardware.wifi.xml \
-        frameworks/native/data/etc/android.hardware.wifi.direct.xml:system/etc/permissions/android.hardware.wifi.direct.xml
+        frameworks/native/data/etc/android.hardware.wifi.xml:system/etc/permissions/android.hardware.wifi.xml 
 
 {{#gpp}}
 # Add Manufacturing tool


### PR DESCRIPTION
Wifi Direct will work when wifi vendor hal is supported.
Intel doesnot have wifi vendor hal implementation,
Hence to pass Concurrencytest, wifi direct is disabled.

Tracked-On: OAM-71339
Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>