### PR TITLE
thermal-daemon: Move the data files from misc folder to vendor folder

### DIFF
--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -15,8 +15,8 @@ on boot
     chown system system /system/vendor/etc/thermal-daemon/thermal-conf.xml
     restorecon_recursive /sys/class/powercap
 
-on post-fs
+on post-fs-data
     setprop persist.thermal.mode thermal-daemon
-    mkdir /data/misc/thermal-daemon 0771 system system
+    mkdir /data/vendor/thermal-daemon 0660 system system
     start thermal-daemon
 


### PR DESCRIPTION
As per VNDK rules, moving the data dir from /data/misc to
/data/vendor folder.

Tracked-On: OAM-71986
Signed-off-by: ysiyer <yegnesh.s.iyer@intel.com>