### PR TITLE
Move TARGET_BOARD_PLATFORM from boot-arch to project-celadon

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -1,7 +1,5 @@
 #TARGET_NO_RECOVERY ?= false
 
-TARGET_BOARD_PLATFORM := project-celadon
-
 ifeq ({{data_use_f2fs}},true)
 TARGET_USERIMAGES_USE_F2FS := true
 BOARD_USERDATAIMAGE_FILE_SYSTEM_TYPE := f2fs

--- a/groups/project-celadon/default/product.mk
+++ b/groups/project-celadon/default/product.mk
@@ -1,3 +1,5 @@
+TARGET_BOARD_PLATFORM := project-celadon
+
 #Product Characteristics
 PRODUCT_DIR := $(dir $(lastword $(filter-out device/common/%,$(filter device/%,$(ALL_PRODUCTS)))))
 


### PR DESCRIPTION
Move it to make sure TARGET_BOARD_PLATFORM getting definded
before using as device.mk gets running before BoardConfig.mk

Tracked-On: OAM-72181
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>