### PR TITLE
Disable tdls_auto as default from supplicant configuration.

### DIFF
--- a/groups/wlan/iwlwifi/option.spec
+++ b/groups/wlan/iwlwifi/option.spec
@@ -1,5 +1,5 @@
 [defaults]
-tdls_auto = true
+tdls_auto = false
 iwl_pnvm_hw = DEFAULT
 gpp = false
 softap_dualband_allow = false


### PR DESCRIPTION
Changes required to comply with Android CDD for Intel WiFi Chipsets.

Tracked-On: OAM-72324
Signed-off-by: Babu Chennakesavulu, Raveendra
                             <raveendra.babu.chennakesavulu@intel.com>