### PR TITLE
set loop device max_part

### DIFF
--- a/groups/kernel/project-celadon/BoardConfig.mk
+++ b/groups/kernel/project-celadon/BoardConfig.mk
@@ -21,7 +21,7 @@ SERIAL_PARAMETER ?= console=tty0 console=ttyS0,115200n8
 BOARD_KERNEL_CMDLINE += root=/dev/ram0
 {{/slot-ab}}
 
-BOARD_KERNEL_CMDLINE += androidboot.hardware=$(TARGET_PRODUCT) firmware_class.path={{{firmware_path}}} loglevel=$(KERNEL_LOGLEVEL)
+BOARD_KERNEL_CMDLINE += androidboot.hardware=$(TARGET_PRODUCT) firmware_class.path={{{firmware_path}}} loglevel=$(KERNEL_LOGLEVEL) loop.max_part=7
 
 ifneq ($(TARGET_BUILD_VARIANT),user)
 ifeq ($(SPARSE_IMG),true)


### PR DESCRIPTION
set loop device max_part so that virtual sd card can be partitioned and
formatted without error.

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-72409
Signed-off-by: Zhiwei li zhiwei.li@intel.com