### PR TITLE
celadon: Add socperf and socwatch in extra kernel module path

### DIFF
--- a/groups/kernel/project-celadon/AndroidBoard.mk
+++ b/groups/kernel/project-celadon/AndroidBoard.mk
@@ -43,6 +43,9 @@ $(PRODUCT_OUT)/kernel: $(KERNEL_CONFIG) | $(ACP)
 
 EXTMOD_SRC := ../../../../../..
 
+TARGET_EXTRA_KERNEL_MODULES := $(EXTMOD_SRC)/kernel/modules/perftools-external/soc_perf_driver/src
+TARGET_EXTRA_KERNEL_MODULES += $(EXTMOD_SRC)/kernel/modules/perftools-external/socwatch_driver
+
 ALL_EXTRA_MODULES := $(patsubst %,$(TARGET_OUT_INTERMEDIATES)/kmodule/%,$(TARGET_EXTRA_KERNEL_MODULES))
 $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kernel
 	@echo Building additional kernel module $*


### PR DESCRIPTION
Tracked-On: 71957
Signed-off-by: Punit Vara <punit.vara@intel.com>