### PR TITLE
g_ffs: Add support for writing into role sysfs

### DIFF
--- a/groups/usb-gadget/g_ffs/BoardConfig.mk
+++ b/groups/usb-gadget/g_ffs/BoardConfig.mk
@@ -1,0 +1,2 @@
+BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/usb
+

--- a/groups/usb-gadget/g_ffs/init.rc
+++ b/groups/usb-gadget/g_ffs/init.rc
@@ -42,6 +42,8 @@ on boot
     write /sys/devices/pci0000\:00/0000\:00\:15.1/dwc3.0.auto/power/control auto
     write /sys/devices/pci0000\:00/0000\:00\:15.1/dwc3.0.auto/gadget/power/control auto
     write /sys/devices/pci0000\:00/0000\:00\:15.1/dwc3.0.auto/udc/dwc3.0.auto/power/control auto
+    chown system system /sys/devices/pci0000:00/0000:00:14.0/intel_xhci_usb_sw/usb_role/intel_xhci_usb_sw-role-switch/role
+    chmod 0666 /sys/devices/pci0000:00/0000:00:14.0/intel_xhci_usb_sw/usb_role/intel_xhci_usb_sw-role-switch/role
 
 on property:sys.usb.config=none && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/os_desc/use 0


### PR DESCRIPTION
USB role should be changed to 'host' before
suspend and shutdown. This patch adds support
for that.

Jira: OAM-71244

Signed-off-by: saranya <saranya.gopal@intel.com>