### PR TITLE
bluetooth: Set BOARD_HAVE_BLUETOOTH_LINUX_PRI to true

### DIFF
--- a/groups/bluetooth/btusb/BoardConfig.mk
+++ b/groups/bluetooth/btusb/BoardConfig.mk
@@ -1,7 +1,7 @@
 BOARD_HAVE_BLUETOOTH_LINUX_PRI := true
 DEVICE_PACKAGE_OVERLAYS += device/intel/common/bluetooth/overlay-bt-pan
-BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/bluetooth/common \
-                       device/intel/project-celadon/sepolicy/bluetooth/intel
+BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/bluetooth/common
+
 {{#ivi}}
 BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := device/intel/common/bluetooth/intel/car/
 {{/ivi}}

--- a/groups/bluetooth/btusb/BoardConfig.mk
+++ b/groups/bluetooth/btusb/BoardConfig.mk
@@ -1,5 +1,4 @@
-BOARD_HAVE_BLUETOOTH := true
-BOARD_HAVE_BLUETOOTH_LINUX := true
+BOARD_HAVE_BLUETOOTH_LINUX_PRI := true
 DEVICE_PACKAGE_OVERLAYS += device/intel/common/bluetooth/overlay-bt-pan
 BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/bluetooth/common \
                        device/intel/project-celadon/sepolicy/bluetooth/intel

--- a/groups/bluetooth/btusb/product.mk
+++ b/groups/bluetooth/btusb/product.mk
@@ -2,13 +2,12 @@ PRODUCT_PACKAGES += \
     audio.a2dp.default \
     ath3k-1.fw
 
-PRODUCT_COPY_FILES += frameworks/native/data/etc/android.hardware.bluetooth.xml:system/etc/permissions/android.hardware.bluetooth.xml \
-		frameworks/native/data/etc/android.hardware.bluetooth_le.xml:system/etc/permissions/android.hardware.bluetooth_le.xml
+PRODUCT_COPY_FILES += frameworks/native/data/etc/android.hardware.bluetooth.xml:vendor/etc/permissions/android.hardware.bluetooth.xml \
+		frameworks/native/data/etc/android.hardware.bluetooth_le.xml:vendor/etc/permissions/android.hardware.bluetooth_le.xml
 
 # Bluetooth HAL
 PRODUCT_PACKAGES += \
-  android.hardware.bluetooth@1.0-impl \
-  android.hardware.bluetooth@1.0-service \
+  android.hardware.bluetooth@1.0-service.vbt \
   libbt-vendor
 
 {{#ivi}}

--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -9,18 +9,11 @@ on post-fs-data
     wait /oem_config/wlan/iwl_nvm.bin
 {{/gpp}}
 
-
-
-
 on zygote-start
     # Create the directories used by the Wireless subsystem
-    mkdir /data/misc/wifi 0770 wifi wifi
-    mkdir /data/misc/wifi/wpa_supplicant 0770 wifi wifi
     mkdir /data/vendor/wifi 0771 wifi wifi
     mkdir /data/vendor/wifi/wpa 0770 wifi wifi
     mkdir /data/vendor/wifi/wpa/sockets 0770 wifi wifi
-    mkdir /data/misc/dhcp 0770 dhcp dhcp
-    chown dhcp dhcp /data/misc/dhcp
 
 service wpa_supplicant /vendor/bin/hw/wpa_supplicant \
     -O/data/vendor/wifi/wpa/sockets -puse_p2p_group_interface=1 \
@@ -44,18 +37,6 @@ service dhcpcd_wlan0 /system/bin/dhcpcd -ABDKL
 
 service iprenew_wlan0 /system/bin/dhcpcd -n
     class main
-    disabled
-    oneshot
-
-service p2p_supplicant /vendor/bin/hw/wpa_supplicant \
-   -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf \
-   -I/system/etc/wifi/wpa_supplicant_overlay.conf \
-   -m/data/misc/wifi/p2p_supplicant.conf \
-   -O/data/misc/wifi/sockets \
-   -e/data/misc/wifi/entropy.bin \
-   -dt -g@android:wpa_wlan0
-    class main
-    socket wpa_wlan0 dgram 660 wifi wifi
     disabled
     oneshot
 

--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -18,14 +18,14 @@ PRODUCT_PACKAGES += \
 
 #copy iwlwifi wpa config files
 PRODUCT_COPY_FILES += \
-        device/intel/common/wlan/wpa_supplicant-common.conf:system/etc/wifi/wpa_supplicant.conf \
+        device/intel/common/wlan/wpa_supplicant-common.conf:vendor/etc/wifi/wpa_supplicant.conf \
 {{#tdls_auto}}
-        device/intel/common/wlan/iwlwifi/wpa_supplicant_overlay.conf:system/etc/wifi/wpa_supplicant_overlay.conf \
+        device/intel/common/wlan/iwlwifi/wpa_supplicant_overlay.conf:vendor/etc/wifi/wpa_supplicant_overlay.conf \
 {{/tdls_auto}}
 {{^tdls_auto}}
-        device/intel/common/wlan/iwlwifi/wpa_supplicant_overlay_no_tdls.conf:system/etc/wifi/wpa_supplicant_overlay.conf \
+        device/intel/common/wlan/iwlwifi/wpa_supplicant_overlay_no_tdls.conf:vendor/etc/wifi/wpa_supplicant_overlay.conf \
 {{/tdls_auto}}
-        frameworks/native/data/etc/android.hardware.wifi.xml:system/etc/permissions/android.hardware.wifi.xml 
+        frameworks/native/data/etc/android.hardware.wifi.xml:vendor/etc/permissions/android.hardware.wifi.xml
 
 {{#gpp}}
 # Add Manufacturing tool


### PR DESCRIPTION
Remove setting of BOARD_HAVE_BLUETOOTH and
BOARD_HAVE_BLUETOOTH_LINUX to true.

Set BOARD_HAVE_BLUETOOTH_LINUX_PRI to true to make use
of bluetooth vendor adaptation.

Tracked-On: OAM-73759
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>