### PR TITLE
Add the treble support for boot system.

### DIFF
--- a/groups/boot-arch/mixinfo.spec
+++ b/groups/boot-arch/mixinfo.spec
@@ -1,2 +1,2 @@
 [mixinfo]
-deps = variants slot-ab avb storage config-partition vendor-partition factory-partition
+deps = variants slot-ab avb storage config-partition vendor-partition factory-partition treble

--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -81,3 +81,13 @@ PRODUCT_PROPERTY_OVERRIDES += \
 {{#self_usb_device_mode_protocol}}
 KERNELFLINGER_SUPPORT_SELF_USB_DEVICE_MODE_PROTOCOL := {{self_usb_device_mode_protocol}}
 {{/self_usb_device_mode_protocol}}
+
+
+{{#treble}}
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/fstab:$(TARGET_COPY_OUT_VENDOR)/etc/fstab.$(TARGET_PRODUCT)
+{{/treble}}
+{{^treble}}
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/fstab:root/fstab.$(TARGET_PRODUCT)
+{{/treble}}

--- a/groups/disk-bus/auto/product.mk
+++ b/groups/disk-bus/auto/product.mk
@@ -1,2 +1,5 @@
 # create primary storage symlink dynamically
 PRODUCT_PACKAGES += set_storage
+{{#treble}}
+PRODUCT_PACKAGES += set_storage.vendor
+{{/treble}}

--- a/groups/disk-bus/mixinfo.spec
+++ b/groups/disk-bus/mixinfo.spec
@@ -1,0 +1,2 @@
+[mixinfo]
+deps = treble

--- a/groups/project-celadon/default/init.rc
+++ b/groups/project-celadon/default/init.rc
@@ -5,7 +5,12 @@ on init
     # can be associated with the correct disk. Create a shortcut to
     # /dev/block/by-name so that we can use the same fstabs everywhere.
     mkdir /dev/block 0755 root root
+{{^treble}}
     exec u:r:set_storage:s0 root root -- /sbin/set_storage
+{{/treble}}
+{{#treble}}
+    exec u:r:set_storage:s0 root root -- /vendor/bin/set_storage.vendor
+{{/treble}}
     # The following line maybe replaced by scripts in SKL.
     # symlink /dev/block/pci/pci0000:00/0000:00:1c.0/by-name /dev/block/by-name
 
@@ -31,7 +36,12 @@ on verity-logging
 on mount-all-fs
     mkdir /dev/pstore 0755 root system
     mount pstore pstore /dev/pstore
+{{^treble}}
     mount_all /fstab.${ro.hardware}
+{{/treble}}
+{{#treble}}
+    mount_all /vendor/etc/fstab.${ro.hardware}
+{{/treble}}
 
 on restart-ueventd
     rm /dev/.coldboot_done

--- a/groups/project-celadon/default/product.mk
+++ b/groups/project-celadon/default/product.mk
@@ -41,11 +41,16 @@ $(call inherit-product-if-exists,vendor/vendor.mk)
 
 #Product Characteristics
 PRODUCT_COPY_FILES += \
-    $(if $(wildcard $(PRODUCT_DIR)fstab.$(TARGET_PRODUCT)),$(PRODUCT_DIR)fstab.$(TARGET_PRODUCT),$(LOCAL_PATH)/fstab):root/fstab.$(TARGET_PRODUCT) \
-    $(if $(wildcard $(PRODUCT_DIR)init.$(TARGET_PRODUCT).rc),$(PRODUCT_DIR)init.$(TARGET_PRODUCT).rc,$(LOCAL_PATH)/init.rc):root/init.$(TARGET_PRODUCT).rc \
-    $(if $(wildcard $(PRODUCT_DIR)ueventd.$(TARGET_PRODUCT).rc),$(PRODUCT_DIR)ueventd.$(TARGET_PRODUCT).rc,$(LOCAL_PATH)/ueventd.rc):root/ueventd.$(TARGET_PRODUCT).rc \
     $(LOCAL_PATH)/gpt.ini:root/gpt.$(TARGET_PRODUCT).ini \
     $(LOCAL_PATH)/init.recovery.rc:root/init.recovery.$(TARGET_PRODUCT).rc \
+{{#treble}}
+    $(LOCAL_PATH)/init.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw//init.$(TARGET_PRODUCT).rc \
+    $(LOCAL_PATH)/ueventd.rc:$(TARGET_COPY_OUT_VENDOR)/ueventd.rc
+{{/treble}}
+{{^treble}}
+    $(LOCAL_PATH)/init.rc:root/init.$(TARGET_PRODUCT).rc \
+    $(LOCAL_PATH)/ueventd.rc:root/ueventd.$(TARGET_PRODUCT).rc
+{{/treble}}
 
 # Voip
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
After enable the treble, then use /vendor/etc/fstab.${ro.hardware}
and /vendor/bin/set_storage.vendor.
The boot-arch and project-celadon will depend on treble.

Tracked-On: OAM-74931
Signed-off-by: Ming Tan <ming.tan@intel.com>