### PR TITLE
factory-partition: move the mount point to /vendor/factory.

### DIFF
--- a/groups/factory-partition/true/AndroidBoard.mk
+++ b/groups/factory-partition/true/AndroidBoard.mk
@@ -22,7 +22,7 @@ factoryimage: $(INSTALLED_FACTORYIMAGE_TARGET)
 
 {{#slot-ab}}
 make_dir_ab_factory:
-	@mkdir -p $(PRODUCT_OUT)/root/factory
+	@mkdir -p $(PRODUCT_OUT)/vendor/factory
 
 $(PRODUCT_OUT)/ramdisk.img: make_dir_ab_factory
 {{/slot-ab}}

--- a/groups/factory-partition/true/fstab
+++ b/groups/factory-partition/true/fstab
@@ -1,1 +1,1 @@
-/dev/block/by-name/factory      /factory        ext4    rw,noatime                                                  wait
+/dev/block/by-name/factory      /vendor/factory ext4    rw,noatime                                                  wait

--- a/groups/factory-partition/true/init.rc
+++ b/groups/factory-partition/true/init.rc
@@ -1,10 +1,12 @@
-# init.rc for telephony services specific to flashless platforms using /factory partition
+# init.rc for telephony services specific to flashless platforms using /vendor/factory partition
 
+{{^slot-ab}}
 on init
 # Used as mounting point for factory partition.
 # Calibration files configuring IMEI and RF calibration will also be stored on this partition.
-    mkdir /factory 0770 system system
+    mkdir /vendor/factory 0770 system system
+{{/slot-ab}}
 
 on post-fs
-    restorecon_recursive /factory
+    restorecon_recursive /vendor/factory
     trigger post-fs-factory


### PR DESCRIPTION
If enable treble, the GSI has not /factory mount point.

Tracked-On: OAM-75157
Signed-off-by: Ming Tan <ming.tan@intel.com>