### PR TITLE
vendor-partition: Should not add to fstab if enable firststage-mount.

### DIFF
--- a/groups/firststage-mount/mixinfo.spec
+++ b/groups/firststage-mount/mixinfo.spec
@@ -1,2 +1,2 @@
 [mixinfo]
-deps = boot-arch disk-bus trusty
+deps = disk-bus avb slot-ab

--- a/groups/slot-ab/true/option.spec
+++ b/groups/slot-ab/true/option.spec
@@ -1,3 +1,3 @@
 [defaults]
-system_fs = squashfs
+system_fs = ext4
 nb_slot = 2

--- a/groups/trusty/mixinfo.spec
+++ b/groups/trusty/mixinfo.spec
@@ -1,2 +1,2 @@
 [mixinfo]
-deps = sepolicy boot-arch avb slot-ab
+deps = sepolicy boot-arch avb slot-ab firststage-mount

--- a/groups/vendor-partition/mixinfo.spec
+++ b/groups/vendor-partition/mixinfo.spec
@@ -1,2 +1,2 @@
 [mixinfo]
-deps = slot-ab avb
+deps = slot-ab avb firststage-mount

--- a/groups/vendor-partition/true/fstab
+++ b/groups/vendor-partition/true/fstab
@@ -1,4 +1,16 @@
 # Following line is required if you use a vendor image.
 # If the vendor image is not used,
 # following line should be commented with the related ones in BoardConfig.mk
-/dev/block/by-name/vendor	    /vendor         ext4    ro                                                          wait{{#slot-ab}},slotselect{{/slot-ab}}{{#avb}},avb{{/avb}}
+{{^avb}}
+{{^firststage-mount}}
+/dev/block/by-name/{{partition_name}}       /vendor         {{system_fs}}    ro                                         wait{{#verity_mode}},verify{{^slot-ab}}{{#verity_warning}}=/dev/block/by-name/metadata{{/verity_warning}}{{/slot-ab}}{{/verity_mode}}{{#slot-ab}},slotselect{{/slot-ab}}
+{{/firststage-mount}}
+{{/avb}}
+{{#avb}}
+{{^firststage-mount}}
+/dev/block/by-name/{{partition_name}}       /vendor         {{system_fs}}    ro                                         wait{{#slot-ab}},slotselect{{/slot-ab}},avb
+{{/firststage-mount}}
+{{#firststage-mount}}
+#First-Stage Mount is enabled, the mount of vendor partition is moved to the configure in ACPI SSDT table.
+{{/firststage-mount}}
+{{/avb}}

--- a/groups/vendor-partition/true/fstab.recovery
+++ b/groups/vendor-partition/true/fstab.recovery
@@ -1,4 +1,10 @@
 # Following line is required if you use a vendor image.
 # If the vendor image is not used,
 # following line should be commented with the related ones in BoardConfig.mk
-/dev/block/by-name/vendor	    /vendor         ext4    ro                                                          wait{{#slot-ab}},slotselect{{/slot-ab}}
+{{^avb}}
+/dev/block/by-name/{{partition_name}}       /vendor         {{system_fs}}    ro                                         wait{{#verity_mode}},verify{{^slot-ab}}{{#verity_warning}}=/dev/block/by-name/metadata{{/verity_warning}}{{/slot-ab}}{{/verity_mode}}{{#slot-ab}},slotselect{{/slot-ab}}
+{{/avb}}
+
+{{#avb}}
+/dev/block/by-name/{{partition_name}}       /vendor         {{system_fs}}    ro                                         wait{{#slot-ab}},slotselect{{/slot-ab}}
+{{/avb}}


### PR DESCRIPTION
    After enable the firststage-mount, the mount porint of vendor partition
    is defined by ACPI first stage mount SSDT, not in fstab.
    Also adjust some depends of groups to support this change.

    Tracked-On: OAM-75272


Signed-off-by: Ming Tan <ming.tan@intel.com>