### PR TITLE
watchdog: Create init.rc to define watchdogd service

### DIFF
--- a/groups/boot-arch/project-celadon/init.rc
+++ b/groups/boot-arch/project-celadon/init.rc
@@ -1,4 +1,4 @@
-service watchdogd /sbin/watchdogd{{#watchdog_parameters}} {{{watchdog_parameters}}}{{/watchdog_par    ameters}}
+service watchdogd /sbin/watchdogd{{#watchdog_parameters}} {{{watchdog_parameters}}}{{/watchdog_parameters}}
     user root
     class core
     oneshot

--- a/groups/boot-arch/project-celadon/init.rc
+++ b/groups/boot-arch/project-celadon/init.rc
@@ -1,0 +1,8 @@
+service watchdogd /sbin/watchdogd{{#watchdog_parameters}} {{{watchdog_parameters}}}{{/watchdog_par    ameters}}
+    user root
+    class core
+    oneshot
+    seclabel u:r:watchdogd:s0
+    
+on charger
+    start watchdogd


### PR DESCRIPTION
Add a new file named init.rc to define watchdogd service.

Tracked-on: https://jira.devtools.intel.com/browse/OAM-72641
Signed-off-by: Tian, Baofeng <baofeng.tian@intel.com>
Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>