### PR TITLE
boot-arch: define watchdogd service

### DIFF
--- a/groups/boot-arch/project-celadon/init.rc
+++ b/groups/boot-arch/project-celadon/init.rc
@@ -1,0 +1,8 @@
+service watchdogd /sbin/watchdogd{{#watchdog_parameters}} {{{watchdog_parameters}}}{{/watchdog_parameters}}
+    user root
+    class core
+    oneshot
+    seclabel u:r:watchdogd:s0
+
+on charger
+    start watchdogd


### PR DESCRIPTION
Define a watchdogd service in a new init.rc file. 

Tracked-on: https://jira.devtools.intel.com/browse/OAM-72641
Signed-off-by: Tian, Baofeng baofeng.tian@intel.com
Signed-off-by: Duan, YayongX yayongx.duan@intel.com