### PR TITLE
boot-arch: define watchdog parameters

### DIFF
--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -16,3 +16,4 @@ tos_partition = false
 usb_storage = false
 self_usb_device_mode_protocol = false
 data_use_f2fs = false
+watchdog_parameters = false


### PR DESCRIPTION
define watchdog parameters to false as default in option spec file.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-72641
Signed-off-by: Tian, Baofeng baofeng.tian@intel.com
Signed-off-by: Duan, YayongX yayongx.duan@intel.com