### PR TITLE
Fix CtsVerifier Bugreport collection fail

### DIFF
--- a/groups/project-celadon/default/init.rc
+++ b/groups/project-celadon/default/init.rc
@@ -118,7 +118,7 @@ on charger
     start watchdogd
 
 # bugreport is triggered by holding down volume down, volume up and power
-service bugreport /system/bin/dumpstate -d -p -B \
+service bugreport /system/bin/dumpstate -d -p -B -z \
 	-o /data/user_de/0/com.android.shell/files/bugreports/bugreport
     class main
     disabled


### PR DESCRIPTION
Add -z option to bugreport service. New version of bugreport(dumpstate)
requires -z CLI option. The dumpstate will exit before doing actual dump
if lack of -z option. That will cause bugreport collection fail.

Tracked-On: OAM-75535
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>