### PR TITLE
Have GenCopy as default GC for celadon.

### DIFF
--- a/groups/device-type/car/product.mk
+++ b/groups/device-type/car/product.mk
@@ -29,3 +29,6 @@ VEHICLE_HAL_PROTO_TYPE := {{vhal-proto-type}}
 # IOC is enabled, add slcan or cbc proto in VHAL
 VEHICLE_HAL_PROTO_TYPE += {{ioc}}
 {{/ioc}}
+
+#We want to use default GC as GENCOPYING
+ART_DEFAULT_GC_TYPE?=GENCOPYING


### PR DESCRIPTION
Also default the bps size to 128m for IVI and to 48m for tablet, if GenCopy is used.

Tracked-On: OAM-75577
Signed-off-by: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>