### PR TITLE
btusb: Disable new AVRCP in IVI

### DIFF
--- a/groups/bluetooth/btusb/init.rc
+++ b/groups/bluetooth/btusb/init.rc
@@ -1,7 +1,9 @@
 on post-fs-data
     # To store BT paired info
     mkdir /data/misc/hcid 0770 bluetooth bluetooth
+{{#ivi}}
     setprop persist.bluetooth.enablenewavrcp false
+{{/ivi}}
 
 on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits


### PR DESCRIPTION
As new AVRCP is having issues with IVI package, enable it
only for tablet package.

Tracked-On: OAM-75947
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>