### PR TITLE
iwlwifi: Add changes for treble complaint

### DIFF
--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -1,7 +1,7 @@
 on post-fs-data
-    chmod 0660 /data/misc/wifi/p2p_supplicant.conf
-	setprop wifi.interface wlan0
-	setprop wifi.direct.interface p2p0
+    setprop wifi.interface wlan0
+    setprop wifi.direct.interface p2p-dev-wlan0
+
     # create config WiFi NVM folder
     mkdir /oem_config/wlan 0770 wifi system
 {{#gpp}}
@@ -57,9 +57,8 @@ service wlan_rest_nvm /system/bin/wlan_intel_restore.sh
     oneshot
 {{/gpp}}
 
-on post-fs
+on boot
     insmod /vendor/lib/modules/kernel/net/wireless/cfg80211.ko
     insmod /vendor/lib/modules/kernel/net/mac80211/mac80211.ko
     insmod /vendor/lib/modules/kernel/drivers/net/wireless/intel/iwlwifi/iwlwifi.ko
     insmod /vendor/lib/modules/kernel/drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.ko
-

--- a/groups/wlan/iwlwifi/option.spec
+++ b/groups/wlan/iwlwifi/option.spec
@@ -1,5 +1,4 @@
 [defaults]
-tdls_auto = false
 iwl_pnvm_hw = DEFAULT
 gpp = false
 softap_dualband_allow = false

--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -1,7 +1,7 @@
 PRODUCT_PACKAGES += \
     hostapd \
     hostapd_cli \
-	wificond \
+    wificond \
     wifilogd \
     wpa_supplicant \
     wpa_cli \
@@ -19,13 +19,10 @@ PRODUCT_PACKAGES += \
 #copy iwlwifi wpa config files
 PRODUCT_COPY_FILES += \
         device/intel/common/wlan/wpa_supplicant-common.conf:vendor/etc/wifi/wpa_supplicant.conf \
-{{#tdls_auto}}
         device/intel/common/wlan/iwlwifi/wpa_supplicant_overlay.conf:vendor/etc/wifi/wpa_supplicant_overlay.conf \
-{{/tdls_auto}}
-{{^tdls_auto}}
-        device/intel/common/wlan/iwlwifi/wpa_supplicant_overlay_no_tdls.conf:vendor/etc/wifi/wpa_supplicant_overlay.conf \
-{{/tdls_auto}}
-        frameworks/native/data/etc/android.hardware.wifi.xml:vendor/etc/permissions/android.hardware.wifi.xml
+        device/intel/common/wlan/iwlwifi/p2p_supplicant_overlay.conf:vendor/etc/wifi/p2p_supplicant_overlay.conf \
+        frameworks/native/data/etc/android.hardware.wifi.xml:vendor/etc/permissions/android.hardware.wifi.xml \
+        frameworks/native/data/etc/android.hardware.wifi.direct.xml:vendor/etc/permissions/android.hardware.wifi.direct.xml
 
 {{#gpp}}
 # Add Manufacturing tool


### PR DESCRIPTION
IWifi VTS test cases are not getting executed
due to p2p interface is not set properly.

Following changes are done to fix the issue:
- Set wifi.direct.interface to correct value
- Add p2p configuration file
- Remove not needed configuration file

Tracked-On: OAM-75990
Signed-off-by: Amrita Raju <amrita.raju@intel.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>