### PR TITLE
Crashlogd: add "vendor" prefix for crashlogd property

### DIFF
--- a/groups/debug-crashlogd/true/product.mk
+++ b/groups/debug-crashlogd/true/product.mk
@@ -8,7 +8,7 @@ PRODUCT_PACKAGES += crashlogd \
 endif
 
 ifeq ($(MIXIN_DEBUG_LOGS),true)
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += persist.crashlogd.data_quota=50
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += persist.vendor.crashlogd.data_quota=50
 BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/crashlogd
 
 CRASHLOGD_LOGS_PATH := "/data/logs"


### PR DESCRIPTION
Due to treble enabling, we need add "vendor" prefix
in front of vendor property to avoid violate selinux
rule.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-76202
Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>