### PR TITLE
boot-arch: add the Android feature of FEATURE_VERIFIED_BOOT.

### DIFF
--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -91,3 +91,7 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/fstab:root/fstab.$(TARGET_PRODUCT)
 {{/treble}}
+
+# Add the feature of FEATURE_VERIFIED_BOOT
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.verified_boot.xml:vendor/etc/permissions/android.software.verified_boot.xml


### PR DESCRIPTION
This patch also fix the issue of can't pass the CTS test of
android.security.cts.VerifiedBootTest#testVerifiedBootSupport.

Tracked-On: OAM-76274
Signed-off-by: Ming Tan <ming.tan@intel.com>