### PR TITLE
Set persist.bluetooth.enablenewavrcp to false

### DIFF
--- a/groups/device-specific/cel_apl/system.prop
+++ b/groups/device-specific/cel_apl/system.prop
@@ -3,4 +3,4 @@
 #
 
 audio.safemedia.bypass=true
-
+persist.bluetooth.enablenewavrcp=false

--- a/groups/device-specific/cel_kbl/system.prop
+++ b/groups/device-specific/cel_kbl/system.prop
@@ -3,4 +3,4 @@
 #
 
 audio.safemedia.bypass=true
-
+persist.bluetooth.enablenewavrcp=false


### PR DESCRIPTION
it's not supported by Intel BT HAL

Tracked-On: OAM-76215
Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>