### PR TITLE
Remove unused property related to pfw hal

### DIFF
--- a/groups/media/project-celadon/init.rc
+++ b/groups/media/project-celadon/init.rc
@@ -13,9 +13,6 @@ on post-fs-data
     mkdir /data/media 0770 media_rw media_rw
     chown media_rw media_rw /data/media
 
-on boot
-    setprop persist.media.pfw.verbose true
-
 on post-fs
     insmod /vendor/lib/modules/kernel/drivers/media/v4l2-core/videobuf2-core.ko
     insmod /vendor/lib/modules/kernel/drivers/media/v4l2-core/videobuf2-v4l2.ko


### PR DESCRIPTION
"persist.media.pfw.verbose" is only used in audio_pfw hal,
which itself is not being used in celadon targets

Removing this property inclusion as currently its not being used,
once audio_pfw hal is ported correctly we will modify the hal code
to use property "persist.vendor.media.verbose" instead of above and
update init.rc respective to audio.

Signed-off-by: Karan Patidar <karan.patidar@intel.com>