### PR TITLE
Remove unused gfx config

### DIFF
--- a/groups/graphics/mesa/init.rc.1
+++ b/groups/graphics/mesa/init.rc.1
@@ -43,15 +43,3 @@ on boot
     chown media media /sys/kernel/debug/tracing/events/i915/i915_ring_wait_end/enable
     chown media media /sys/devices/pci0000:00/0000:00:02.0/drm/card0/gt_max_freq_mhz
     chown media media /sys/devices/pci0000:00/0000:00:02.0/drm/card0/gt_min_freq_mhz
-
-on property:persist.vendor.gen_gfxd.enable=1
-    start gfxd
-
-on property:persist.vendor.gen_gfxd.enable=0
-    stop gfxd
-
-service gfxd /system/vendor/bin/gfxd
-    class main
-    user root
-    group graphics
-    disabled


### PR DESCRIPTION
gfxd is ufo config, we don't use ufo any more on Celadon, so we
remove related config.
S3TC is always supported on mesa, we don't need related config
anymore.

Tracked-On: OAM-76506
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>