### PR TITLE
[CELADON] Add app_launch_boost as part of boardconfig

### DIFF
--- a/groups/power/true/BoardConfig.mk
+++ b/groups/power/true/BoardConfig.mk
@@ -1,2 +1,5 @@
 BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/power
 
+{{#app_launch_boost}}
+APP_LAUNCH_BOOST := true
+{{/app_launch_boost}}

--- a/groups/power/true/option.spec
+++ b/groups/power/true/option.spec
@@ -1,0 +1,2 @@
+[defaults]
+app_launch_boost=false


### PR DESCRIPTION
This flag allows to enable/disable
app launch boost with true/false values.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-76682
Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>