### PR TITLE
debug-logs: add the vendor to vendor_default_ prop

### DIFF
--- a/groups/debug-logs/true/init.logs.rc
+++ b/groups/debug-logs/true/init.logs.rc
@@ -6,18 +6,18 @@
 on post-fs-data
     mkdir /data/logs 0770 system log
 
-on property:persist.service.aplogfs.enable=0
+on property:persist.vendor.service.aplogfs.enable=0
     stop vendor.ap_logfs
 
-on property:persist.service.aplogfs.enable=1
-    setprop persist.service.apklogfs.enable 0
+on property:persist.vendor.service.aplogfs.enable=1
+    setprop persist.vendor.service.apklogfs.enable 0
     restart vendor.ap_log_srv
 
-on property:persist.service.apklogfs.enable=0
+on property:persist.vendor.service.apklogfs.enable=0
     stop vendor.apk_logfs
 
-on property:persist.service.apklogfs.enable=1
-    setprop persist.service.aplogfs.enable 0
+on property:persist.vendor.service.apklogfs.enable=1
+    setprop persist.vendor.service.aplogfs.enable 0
     restart vendor.ap_log_srv
 
 service vendor.apk_logfs /vendor/bin/logcat_ep.sh auto \
@@ -55,10 +55,10 @@ on nonencrypted
 on property:vold.decrypt=trigger_restart_framework
     stop vendor.earlylogs
 
-on property:persist.service.elogs.enable=1
+on property:persist.vendor.service.elogs.enable=1
     mkdir /cache/elogs 0770 system log
     restorecon /cache/elogs
 
-on property:persist.service.elogs.enable=0
+on property:persist.vendor.service.elogs.enable=0
     exec -- /system/bin/rm -rf /cache/elogs
 # ------------------ END MIX-IN DEFINITIONS ------------------

--- a/groups/debug-logs/true/product.mk
+++ b/groups/debug-logs/true/product.mk
@@ -31,11 +31,11 @@ PRODUCT_PACKAGES += \
 endif
 
 ifeq ($(MIXIN_DEBUG_LOGS),true)
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.service.default_logfs=apklogfs
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.intel.logger={{logger}}
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += logd.kernel.raw_message={{klogd_raw_message}}
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += persist.intel.logger.rot_cnt={{logger_rot_cnt}}
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += persist.intel.logger.rot_size={{logger_rot_size}}
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.vendor.service.default_logfs=apklogfs
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.vendor.intel.logger={{logger}}
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += vendor.logd.kernel.raw_message={{klogd_raw_message}}
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += persist.vendor.intel.logger.rot_cnt={{logger_rot_cnt}}
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += persist.vendor.intel.logger.rot_size={{logger_rot_size}}
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/debug-logs
 BOARD_SEPOLICY_M4DEFS += module_debug_logs=true
 endif


### PR DESCRIPTION
the property under /vendor should be marked as vendor_default_prop
for vendor components to access
so add the vendor for the property

Tracked-On: OAM-77013
Signed-off-by: chenxia1 <xiao.x.chen@intel.com>