### PR TITLE
Tune the code of vendor-partition group about kernel module.

### DIFF
--- a/groups/kernel/project-celadon/AndroidBoard.mk
+++ b/groups/kernel/project-celadon/AndroidBoard.mk
@@ -55,6 +55,10 @@ $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kern
 	@echo Building additional kernel module $*
 	$(build_kernel) M=$(abspath $@) modules
 
+# This is to ensure that kernel modules are installed before
+# vendor.img is generated.
+$(PRODUCT_OUT)/vendor.img : $(KERNEL_MODULES_INSTALL)
+
 # Copy modules in directory pointed by $(KERNEL_MODULES_ROOT)
 # First copy modules keeping directory hierarchy lib/modules/`uname-r`for libkmod
 # Second, create flat hierarchy for insmod linking to previous hierarchy

--- a/groups/vendor-partition/true/AndroidBoard.mk
+++ b/groups/vendor-partition/true/AndroidBoard.mk
@@ -3,10 +3,6 @@ LOCAL_MODULE := vendor-partition
 LOCAL_REQUIRED_MODULES := toybox_static
 include $(BUILD_PHONY_PACKAGE)
 
-# This is to ensure that kernel modules are installed before
-# vendor.img is generated.
-$(PRODUCT_OUT)/vendor.img : $(KERNEL_MODULES_INSTALL)
-
 {{#slot-ab}}
 make_dir_ab_vendor:
 	@mkdir -p $(PRODUCT_OUT)/root/vendor


### PR DESCRIPTION
Move the $(PRODUCT_OUT)/vendor.img : $(KERNEL_MODULES_INSTALL) from
vendor-partition group to kernel group.

Tracked-On: OAM-76563
Signed-off-by: Ming Tan <ming.tan@intel.com>