### PR TITLE
Revert "Add HDMI audio module for celadon"

### DIFF
--- a/groups/audio/project-celadon/product.mk
+++ b/groups/audio/project-celadon/product.mk
@@ -8,7 +8,6 @@ PRODUCT_PACKAGES_DEBUG += \
 PRODUCT_PACKAGES += \
     audio.r_submix.default \
     audio.usb.default \
-    audio.hdmi.$(TARGET_BOARD_PLATFORM) \
     audio_policy.default.so \
     audio_configuration_files
 


### PR DESCRIPTION
Reverts projectceladon/device-androidia-mixins#244