### PR TITLE
project-celadon/default: Does not restart ueventd if enable treble.

### DIFF
--- a/groups/project-celadon/default/init.rc
+++ b/groups/project-celadon/default/init.rc
@@ -13,9 +13,11 @@ on init
     # otherwise the warning page maybe can't be shown.
     trigger mount-all-fs
 
+{{^treble}}
     # Since the modules are stored in /vendor, not in ram disk,
     # so need to restart ueventd after mount_all.
     trigger restart-ueventd
+{{/treble}}
 
 
 on verity-logging


### PR DESCRIPTION
If enabled treble, then after the kernel load some drive from the vendor
partition, and find some new devices(special some USB devices), but the
ueventd just restarting, then the device dev node will not be created.

Tracked-On: OAM-76170
Signed-off-by: Ming Tan <ming.tan@intel.com>