### PR TITLE
Device : : Intel : Mixin : adding android property

### DIFF
--- a/groups/project-celadon/default/init.rc
+++ b/groups/project-celadon/default/init.rc
@@ -97,7 +97,7 @@ on boot
     write /sys/kernel/debug/pstate_snb/setpoint 75
 
     # adb over ethernet
-    setprop service.adb.tcp.port 5555
+    # setprop service.adb.tcp.port 5555
 
 service watchdogd /sbin/watchdogd 10 30
     user root
@@ -120,3 +120,17 @@ on fs
    # Update dm-verity persistent state and set partition.*.verified
    # properties
    verity_update_state
+
+# switch adb over dwc
+on property:persist.vendor.sys.usb.adbover=dwc
+#    write /sys/bus/pci/devices/0000:00:14.0/dbc disable
+    stop adbd
+    start adbd
+
+# switch adb over dbc
+on property:persist.vendor.sys.usb.adbover=dbc
+    write /sys/bus/pci/devices/0000:00:14.0/dbc enable
+    write /sys/bus/pci/devices/0000:00:15.0/dbc enable
+    write /sys/bus/pci/devices/0000:39:00.0/dbc enable
+    stop adbd
+    start adbd

--- a/groups/project-celadon/default/product.mk
+++ b/groups/project-celadon/default/product.mk
@@ -102,6 +102,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.input.noresample=1
 
+# set default DBC configuration
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.vendor.sys.usb.adbover=dwc
+
 # AOSP Packages
 PRODUCT_PACKAGES += \
     Launcher3 \

--- a/groups/project-celadon/default/ueventd.rc
+++ b/groups/project-celadon/default/ueventd.rc
@@ -25,5 +25,5 @@
 /dev/ttyUSB*              0660   radio      radio
 /dev/iio:device*          0660   system     system
 /dev/radio0               0660   bluetooth  audio
-
+/dev/dbc_raw*		  0777	 system	    system
 /sys/devices/pci0000:00/0000:00:02.0/drm/card*/card*/intel_backlight brightness 0644 system system

--- a/groups/usb-gadget/g_ffs/BoardConfig.mk
+++ b/groups/usb-gadget/g_ffs/BoardConfig.mk
@@ -1,2 +1,2 @@
 BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/usb
-
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/usb-gadget


### PR DESCRIPTION
Changes to add android property persist.vendor.sys.usb.adbover, it can
have value dbc or dwc.
Default it will have value "dwc".
To enable adb over DbC set it to "dbc".

Tracked-On: OAM-79899
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>