### PR TITLE
adb: wifi: setprop the adb tcp port

### DIFF
--- a/groups/project-celadon/default/init.rc
+++ b/groups/project-celadon/default/init.rc
@@ -97,7 +97,7 @@ on boot
     write /sys/kernel/debug/pstate_snb/setpoint 75
 
     # adb over ethernet
-    # setprop service.adb.tcp.port 5555
+    setprop service.adb.tcp.port 5555
 
 service watchdogd /sbin/watchdogd 10 30
     user root


### PR DESCRIPTION
setprop adb tcp port

Tracked-On: OAM-79948
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>