### PR TITLE
serialport: use SERIAL_PARAMETER to set the serial port parameter.

### DIFF
--- a/groups/kernel/mixinfo.spec
+++ b/groups/kernel/mixinfo.spec
@@ -1,2 +1,2 @@
 [mixinfo]
-deps = slot-ab
+deps = slot-ab serialport

--- a/groups/kernel/project-celadon/BoardConfig.mk
+++ b/groups/kernel/project-celadon/BoardConfig.mk
@@ -14,7 +14,6 @@ TARGET_PRELINK_MODULE := false
 TARGET_NO_KERNEL ?= false
 
 KERNEL_LOGLEVEL ?= {{{loglevel}}}
-SERIAL_PARAMETER ?= console=tty0
 
 {{^slot-ab}}
 # If enable A/B, then the root should be system partition at last.
@@ -25,7 +24,7 @@ BOARD_KERNEL_CMDLINE += androidboot.hardware=$(TARGET_PRODUCT) firmware_class.pa
 
 ifneq ($(TARGET_BUILD_VARIANT),user)
 ifeq ($(SPARSE_IMG),true)
-BOARD_KERNEL_CMDLINE += $(SERIAL_PARAMETER)
+BOARD_KERNEL_CMDLINE += console=tty0 $(SERIAL_PARAMETER)
 endif
 endif
 

--- a/groups/serialport/ttyMAX0/BoardConfig.mk
+++ b/groups/serialport/ttyMAX0/BoardConfig.mk
@@ -1,3 +1,1 @@
-ifneq ($(TARGET_BUILD_VARIANT),user)
-BOARD_KERNEL_CMDLINE += console=ttyMAX0,230400n8
-endif
+SERIAL_PARAMETER ?= console=ttyMAX0,230400n8

--- a/groups/serialport/ttyS0/BoardConfig.mk
+++ b/groups/serialport/ttyS0/BoardConfig.mk
@@ -1,3 +1,1 @@
-ifneq ($(TARGET_BUILD_VARIANT),user)
-BOARD_KERNEL_CMDLINE += console=ttyS0,115200n8
-endif
+SERIAL_PARAMETER ?= console=ttyS0,115200n8

--- a/groups/serialport/ttyS1/BoardConfig.mk
+++ b/groups/serialport/ttyS1/BoardConfig.mk
@@ -1,3 +1,1 @@
-ifneq ($(TARGET_BUILD_VARIANT),user)
-BOARD_KERNEL_CMDLINE += console=ttyS1,115200n8
-endif
+SERIAL_PARAMETER ?= console=ttyS1,115200n8

--- a/groups/serialport/ttyS2/BoardConfig.mk
+++ b/groups/serialport/ttyS2/BoardConfig.mk
@@ -1,3 +1,1 @@
-ifneq ($(TARGET_BUILD_VARIANT),user)
-BOARD_KERNEL_CMDLINE += console=ttyS2,115200n8
-endif
+SERIAL_PARAMETER ?= console=ttyS2,115200n8

--- a/groups/serialport/ttyUSB0/BoardConfig.mk
+++ b/groups/serialport/ttyUSB0/BoardConfig.mk
@@ -1,3 +1,1 @@
-ifneq ($(TARGET_BUILD_VARIANT),user)
-BOARD_KERNEL_CMDLINE += console=ttyUSB0,115200n8
-endif
+SERIAL_PARAMETER ?= console=ttyUSB0,115200n8


### PR DESCRIPTION
Does not add it to kernel command line directly.
This patch also fix the issue of GRUB menu serial debug.

Tracked-On: OAM-80067
Signed-off-by: Ming Tan <ming.tan@intel.com>