### PR TITLE
Add keybox_provision parameter in mixins groups

### DIFF
--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -125,3 +125,7 @@ KERNELFLINGER_SUPPORT_SELF_USB_DEVICE_MODE_PROTOCOL := {{self_usb_device_mode_pr
 {{/self_usb_device_mode_protocol}}
 
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.frp.pst=/dev/block/by-name/persistent
+
+{{#keybox_provision}}
+KERNELFLINGER_SUPPORT_KEYBOX_PROVISION := true
+{{/keybox_provision}}


### PR DESCRIPTION
if keybox_provision is true, we can support trusty keybox
provision using fastboot command, default value is false.

Signed-off-by: gli41 genshen.li@intel.com
Tracked-On: OAM-83317