### PR TITLE
Add keybox_provision parameter for efi boot-arch

### DIFF
--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -20,6 +20,7 @@ hung_task_timeout_secs = 120
 ifwi_debug = false
 ignore_not_applicable_reset = false
 ignore_rsci = false
+keybox_provision = false
 magic_key_timeout = false
 os_secure_boot = false
 rpmb = false

--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -125,3 +125,7 @@ KERNELFLINGER_SUPPORT_SELF_USB_DEVICE_MODE_PROTOCOL := {{self_usb_device_mode_pr
 {{/self_usb_device_mode_protocol}}
 
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.frp.pst=/dev/block/by-name/persistent
+
+{{#keybox_provision}}
+KERNELFLINGER_SUPPORT_KEYBOX_PROVISION := true
+{{/keybox_provision}}


### PR DESCRIPTION
if keybox_provision is true, we can support trusty keybox
provision using fastboot command, default value is false.

Tracked-On: OAM-83317
Signed-off-by: gli41 genshen.li@intel.com