### PR TITLE
Adding entry for custom usb-audio hal

### DIFF
--- a/groups/audio/project-celadon/product.mk
+++ b/groups/audio/project-celadon/product.mk
@@ -8,6 +8,7 @@ PRODUCT_PACKAGES_DEBUG += \
 PRODUCT_PACKAGES += \
     audio.r_submix.default \
     audio.usb.default \
+    audio.usb.$(TARGET_BOARD_PLATFORM) \
     audio.hdmi.$(TARGET_BOARD_PLATFORM) \
     audio_policy.default.so \
     audio_configuration_files


### PR DESCRIPTION
Adding entry to build Intel's usb-audio hal, that is used to
add customization specific to Intel products.

Tracked-On: OAM-83587
Signed-off-by: Karan Patidar <karan.patidar@intel.com>