### PR TITLE
Change the flash timeout to 2 hours

### DIFF
--- a/groups/flashfiles/ini/flashfiles.ini
+++ b/groups/flashfiles/ini/flashfiles.ini
@@ -102,6 +102,7 @@ skipOnFailure = false
 [command.unlock.unlock]
 tool = fastboot
 args = flashing unlock
+timeout = 7200000
 description = Set device state to unlocked
 
 [command.erase.misc]
@@ -264,6 +265,7 @@ default = true
 [command.lock.lock]
 tool = fastboot
 args = flashing lock
+timeout = 7200000
 group = lock-device
 description = Set device state to locked
 


### PR DESCRIPTION
Currently the timeout is 20 minutes, and timeout in some platform.
Now need to change to 2 hours for whole flash.

Tracked-On: OAM-84058
Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>