### PR TITLE
Audio parameter update for project-celadon targets

### DIFF
--- a/groups/device-specific/cel_apl/audio/default/mixer_paths_0.xml
+++ b/groups/device-specific/cel_apl/audio/default/mixer_paths_0.xml
@@ -5,9 +5,6 @@
   <ctl name="Headphone Playback Switch" value="1 1" />
   <ctl name="Speaker Playback Switch" value="0 0" />
   <ctl name="Capture Switch" value="0 0" />
-  <ctl name="Auto-Mute Mode" value="0" />
-  <ctl name="Capture Source" value="Mic" />
-
 
   <path name="speaker">
     <ctl name="Master Playback Switch" value="1" />

--- a/groups/device-specific/cel_kbl/audio/default/mixer_paths_0.xml
+++ b/groups/device-specific/cel_kbl/audio/default/mixer_paths_0.xml
@@ -5,9 +5,6 @@
   <ctl name="Headphone Playback Switch" value="1 1" />
   <ctl name="Speaker Playback Switch" value="0 0" />
   <ctl name="Capture Switch" value="0 0" />
-  <ctl name="Auto-Mute Mode" value="0" />
-  <ctl name="Capture Source" value="Mic" />
-
 
   <path name="speaker">
     <ctl name="Master Playback Switch" value="1" />

--- a/groups/device-specific/celadon/audio/default/mixer_paths_0.xml
+++ b/groups/device-specific/celadon/audio/default/mixer_paths_0.xml
@@ -5,9 +5,6 @@
   <ctl name="Headphone Playback Switch" value="1 1" />
   <ctl name="Speaker Playback Switch" value="0 0" />
   <ctl name="Capture Switch" value="0 0" />
-  <ctl name="Auto-Mute Mode" value="0" />
-  <ctl name="Capture Source" value="Mic" />
-
 
   <path name="speaker">
     <ctl name="Master Playback Switch" value="1" />

--- a/groups/device-specific/clk/audio/default/policy/default_volume_tables.xml
+++ b/groups/device-specific/clk/audio/default/policy/default_volume_tables.xml
@@ -34,9 +34,9 @@
     </reference>
     <reference name="DEFAULT_MEDIA_VOLUME_CURVE">
     <!-- Default Media reference Volume Curve -->
-        <point>1,-5800</point>
-        <point>20,-4000</point>
-        <point>60,-1700</point>
+        <point>1,-3300</point>
+        <point>20,-2710</point>
+        <point>60,-1020</point>
         <point>100,0</point>
     </reference>
     <reference name="DEFAULT_DEVICE_CATEGORY_HEADSET_VOLUME_CURVE">
@@ -48,9 +48,9 @@
     </reference>
     <reference name="DEFAULT_DEVICE_CATEGORY_SPEAKER_VOLUME_CURVE">
     <!-- Default is Speaker Media Volume Curve -->
-        <point>1,-5800</point>
-        <point>20,-4000</point>
-        <point>60,-1700</point>
+        <point>1,-3500</point>
+        <point>33,-2850</point>
+        <point>66,-1700</point>
         <point>100,0</point>
     </reference>
     <reference name="DEFAULT_DEVICE_CATEGORY_EARPIECE_VOLUME_CURVE">


### PR DESCRIPTION
Update default_volume_tables.xml for CLK target to get volume at
lower levels (less than 50%). Additionally, clean up extra mixer
controls that are not specific to target(for cel_apl,cel_kbl,
celadon).

Tracked-On: OAM-83385
Signed-off-by: Karan Patidar <karan.patidar@intel.com>