### PR TITLE
[mixins] Add PFT configuration to keep device unlocked

### DIFF
--- a/groups/flashfiles/ini/flashfiles.ini
+++ b/groups/flashfiles/ini/flashfiles.ini
@@ -34,7 +34,7 @@ additional-files += provdatazip:firmware-info.txt
 fastboot-command-options += timeout={{timeout}} retry={{retry}} mandatory=true
 enable = true
 version = {{version}}
-configurations += update blank
+configurations += update blank update_without_lock blank_without_lock
 
 [output.installer.cmd]
 sets = unlock partition bootloader erase format flash configure{{#slot-ab}} slot-ab{{/slot-ab}} lock reboot
@@ -54,6 +54,19 @@ startState = pos
 sets = unlock partition bootloader reboot-bootloader erase format flash configure{{#slot-ab}} slot-ab{{/slot-ab}} lock reboot
 description = erase and flash all partitions, all data will be lost.
 brief = blank
+
+[configuration.update_without_lock]
+startState = pos
+sets = unlock bootloader flash capsule{{#slot-ab}} slot-ab{{/slot-ab}} reboot
+description = update device to new release
+brief = update_without_lock
+
+[configuration.blank_without_lock]
+startState = pos
+#sets = fw_update bootstrap unlock partition bootloader erase format flash capsule configure{{#slot-ab}} slot-ab{{/slot-ab}} reboot
+sets = unlock partition bootloader reboot-bootloader erase format flash configure{{#slot-ab}} slot-ab{{/slot-ab}} reboot
+description = erase and flash all partitions, all data will be lost.
+brief = blank_without_lock
 
 {{#capsule}}
 [group.delete-capsule]


### PR DESCRIPTION
On efi platform, Add 'blank_without_lock' and 'update_without_lock' to
keep device unlocked at the end of PFT flash.

Tracked-On: OAM-84217
Signed-off-by: sunxunou <xunoux.sun@intel.com>