### PR TITLE
Mixin: Health HAL supports multi-platform

### DIFF
--- a/groups/health/mixinfo.spec
+++ b/groups/health/mixinfo.spec
@@ -1,0 +1,2 @@
+[mixinfo]
+deps = device-specific

--- a/groups/health/true/product.mk
+++ b/groups/health/true/product.mk
@@ -1,3 +1,2 @@
 PRODUCT_PACKAGES += health
-PRODUCT_PACKAGES += health.$(TARGET_BOARD_PLATFORM) \
-					android.hardware.health@2.0-service.celadon
+PRODUCT_PACKAGES += android.hardware.health@2.0-service.{{target}}


### PR DESCRIPTION
Health HAL needs to support multi-platform because each platform has
its own configuration. To support this feature, health HAL uses
service according to the specific platform name.
This patch addes the function to support this feature and
will automatically copy the service with the specific platform name.