### PR TITLE
Add super image if dynamic partitions is enabled

### DIFF
--- a/groups/gptbuild/mixinfo.spec
+++ b/groups/gptbuild/mixinfo.spec
@@ -1,2 +1,2 @@
 [mixinfo]
-deps = trusty vendor-partition product-partition odm-partition acpi-partition acpio-partition
+deps = trusty vendor-partition product-partition odm-partition acpi-partition acpio-partition dynamic-partitions

--- a/groups/gptbuild/true/AndroidBoard.mk
+++ b/groups/gptbuild/true/AndroidBoard.mk
@@ -72,16 +72,21 @@ $(GPTIMAGE_BIN): \
 	recoveryimage \
 	cacheimage \
 	{{/slot-ab}}
-	systemimage \
 	{{#avb}}
 	vbmetaimage \
 	{{/avb}}
-    {{#vendor-partition}}
+	{{^dynamic-partitions}}
+	systemimage \
+  {{#vendor-partition}}
 	vendorimage \
-    {{/vendor-partition}}
-    {{#product-partition}}
+	{{/vendor-partition}}
+	{{#product-partition}}
 	productimage \
-    {{/product-partition}}
+	{{/product-partition}}
+	{{/dynamic-partitions}}
+	{{#dynamic-partitions}}
+	superimage \
+	{{/dynamic-partitions}}
 	$(SIMG2IMG) \
 	$(raw_config) \
 	$(raw_factory)
@@ -92,16 +97,21 @@ $(GPTIMAGE_BIN): \
 	$(hide) rm -f $(INSTALLED_CACHEIMAGE_TARGET).raw
 	{{/slot-ab}}
 
-	$(SIMG2IMG) $(INSTALLED_SYSTEMIMAGE) $(INSTALLED_SYSTEMIMAGE).raw
 	{{^slot-ab}}
 	$(SIMG2IMG) $(INSTALLED_CACHEIMAGE_TARGET) $(INSTALLED_CACHEIMAGE_TARGET).raw
 	{{/slot-ab}}
-    {{#vendor-partition}}
+	{{^dynamic-partitions}}
+	$(SIMG2IMG) $(INSTALLED_SYSTEMIMAGE) $(INSTALLED_SYSTEMIMAGE).raw
+	{{#vendor-partition}}
 	$(SIMG2IMG) $(INSTALLED_VENDORIMAGE_TARGET) $(INSTALLED_VENDORIMAGE_TARGET).raw
-    {{/vendor-partition}}
-    {{#product-partition}}
+	{{/vendor-partition}}
+	{{#product-partition}}
 	$(SIMG2IMG) $(INSTALLED_PRODUCTIMAGE_TARGET) $(INSTALLED_PRODUCTIMAGE_TARGET).raw
-    {{/product-partition}}
+	{{/product-partition}}
+	{{/dynamic-partitions}}
+	{{#dynamic-partitions}}
+	$(SIMG2IMG) $(INSTALLED_SUPERIMAGE_TARGET) $(INSTALLED_SUPERIMAGE_TARGET).raw
+	{{/dynamic-partitions}}
 
 	$(INTEL_PATH_BUILD)/create_gpt_image.py \
 		--create $@ \
@@ -122,25 +132,29 @@ $(GPTIMAGE_BIN): \
 		{{#avb}}
 		--vbmeta $(INSTALLED_VBMETAIMAGE_TARGET) \
 		{{/avb}}
+	{{^dynamic-partitions}}
 		--system $(INSTALLED_SYSTEMIMAGE).raw \
-        {{#vendor-partition}}
+	{{#vendor-partition}}
 		--vendor $(INSTALLED_VENDORIMAGE_TARGET).raw \
-        {{/vendor-partition}}
-        {{#product-partition}}
+	{{/vendor-partition}}
+	{{#product-partition}}
 		--product $(raw_product) \
-        {{/product-partition}}
-        {{#odm-partition}}
+	{{/product-partition}}
+	{{#odm-partition}}
 		--odm $(raw_odm) \
-        {{/odm-partition}}
-        {{#acpi-partition}}
+	{{/odm-partition}}
+	{{/dynamic-partitions}}
+	{{#dynamic-partitions}}
+		--super $(INSTALLED_SUPERIMAGE_TARGET).raw \
+	{{/dynamic-partitions}}
+	{{#acpi-partition}}
 		--acpi $(raw_acpi) \
-        {{/acpi-partition}}
-        {{#acpio-partition}}
+	{{/acpi-partition}}
+	{{#acpio-partition}}
 		--acpio $(raw_acpio) \
-        {{/acpio-partition}}
+	{{/acpio-partition}}
 		--config $(raw_config) \
 		--factory $(raw_factory)
-
 
 .PHONY: gptimage
 gptimage: $(GPTIMAGE_BIN)

--- a/groups/gptbuild/true/BoardConfig.mk
+++ b/groups/gptbuild/true/BoardConfig.mk
@@ -1,10 +1,12 @@
 # can't use := here, as PRODUCT_OUT is not defined yet
+{{#dynamic-partitions}}
+BOARD_BUILD_SUPER_IMAGE_BY_DEFAULT := true
+{{/dynamic-partitions}}
 GPTIMAGE_BIN = $(PRODUCT_OUT)/$(TARGET_PRODUCT).img
 {{#generate_craff}}
 CRAFFIMAGE_BIN = $(PRODUCT_OUT)/$(TARGET_PRODUCT).craff
 {{/generate_craff}}
 BOARD_FLASHFILES += $(GPTIMAGE_BIN):$(TARGET_PRODUCT).img
-
 ifeq ($(TARGET_USE_TRUSTY),true)
 TRUSTY_ENV_VAR += ENABLE_TRUSTY_SIMICS=true
 endif


### PR DESCRIPTION
After dynamic partitions enalbed, must add super image into gptbuild,
and remove system/vendor/product/odm out.

Tracked-On: OAM-84316
Signed-off-by: Tang, Haoyu <haoyu.tang@intel.com>
Signed-off-by: Yang, Kai <kaix.yang@intel.com>