### PR TITLE
Add keybox_provision parameter for efi boot-arch

### DIFF
--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -20,6 +20,7 @@ hung_task_timeout_secs = 120
 ifwi_debug = false
 ignore_not_applicable_reset = false
 ignore_rsci = false
+keybox_provision = true
 mountfstab-flag = true
 nvme_rpmb_scan = false
 os_secure_boot = false

--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -129,3 +129,7 @@ PRODUCT_COPY_FILES += $(LOCAL_PATH)/{{_extra_dir}}/update_ifwi_ab.sh:recovery/ro
 {{#avb}}
 $(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)
 {{/avb}}
+
+{{#keybox_provision}}
+KERNELFLINGER_SUPPORT_KEYBOX_PROVISION := true
+{{/keybox_provision}}


### PR DESCRIPTION
if keybox_provision is true, we can support trusty keybox
provision using fastboot command, default value is false.

Signed-off-by: zhang,xuepeng <xuepeng.zhang@intel.com>