### PR TITLE
Enable storageproxyd and cp_ss service from /vendor/bin

### DIFF
--- a/groups/trusty/true/init.rc
+++ b/groups/trusty/true/init.rc
@@ -16,12 +16,12 @@ on property:ro.vendor.copy.ss=1
     copy /data/misc/securestorage/0 /data/vendor/securestorage/0
     restart storageproxyd
 
-service cp_securestorage /system/vendor/bin/cp_ss
+service cp_securestorage /vendor/bin/cp_ss
     user system
     group system
     oneshot
 
-service storageproxyd /system/vendor/bin/intelstorageproxyd -d /dev/trusty-ipc-dev0 -p /data/vendor/securestorage -r /dev/rpmb0
+service storageproxyd /vendor/bin/storageproxyd -d /dev/trusty-ipc-dev0 -p /data/vendor/securestorage -r /dev/rpmb0
     user system
     group system
 {{/enable_storage_proxyd}}

--- a/groups/trusty/true/product.mk
+++ b/groups/trusty/true/product.mk
@@ -16,7 +16,7 @@ endif
 
 PRODUCT_PACKAGES += \
 	libtrusty \
-	intelstorageproxyd \
+	storageproxyd \
 	cp_ss \
 	libinteltrustystorage \
 	libinteltrustystorageinterface \


### PR DESCRIPTION
Use simulation RPMB as secure storage.

Change-Id: Ie612abb774f1f4eac40ec1627c7789faf16ec177
Tracked-On: OAM-84475
Signed-off-by: sheng wei <w.sheng@intel.com>