### PR TITLE
[Do Not Merge][Fix] : Added Ignore cpuid check

### DIFF
--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -1,4 +1,4 @@
-service thermal-daemon /system/vendor/bin/thermal-daemon --config-file /system/vendor/etc/thermal-daemon/thermal-conf.xml
+service thermal-daemon /system/vendor/bin/thermal-daemon --config-file /system/vendor/etc/thermal-daemon/thermal-conf.xml --ignore-cpuid-check
     class main
     user system
     group system


### PR DESCRIPTION
        - This change will allow thermal daemon to run on all platform.
	- Currently in celadon, Specific models of KBL & APL are supported
	  in thermal-conf.xml file.
        - This is not a work around
                * This is a feature supported by thermal daemon tool.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-84501
Signed-off-by: ashish18590 <ashish18590@gmail.com>