### PR TITLE
[WHL] Modify volume curve points

### DIFF
--- a/groups/device-specific/clk/audio/default/policy/default_volume_tables.xml
+++ b/groups/device-specific/clk/audio/default/policy/default_volume_tables.xml
@@ -34,8 +34,9 @@
     </reference>
     <reference name="DEFAULT_MEDIA_VOLUME_CURVE">
     <!-- Default Media reference Volume Curve -->
-        <point>1,-3300</point>
-        <point>20,-2710</point>
+        <point>1,-4000</point>
+        <point>10,-3800</point>
+        <point>20,-3550</point>
         <point>60,-1020</point>
         <point>100,0</point>
     </reference>
@@ -48,9 +49,9 @@
     </reference>
     <reference name="DEFAULT_DEVICE_CATEGORY_SPEAKER_VOLUME_CURVE">
     <!-- Default is Speaker Media Volume Curve -->
-        <point>1,-3500</point>
-        <point>33,-2850</point>
-        <point>66,-1700</point>
+        <point>1,-5800</point>
+        <point>20,-4000</point>
+        <point>60,-1700</point>
         <point>100,0</point>
     </reference>
     <reference name="DEFAULT_DEVICE_CATEGORY_EARPIECE_VOLUME_CURVE">


### PR DESCRIPTION
Safe media volume index for USB_HEADSET was coming as 0,
to improve user experience, modifying volume curve to get
safe media volume index for USB_HEADSET as 2.

Tracked-On: OAM-84941
Signed-off-by: Karan Patidar <karan.patidar@intel.com>