### PR TITLE
pstore-clean: Remove user level privilege

### DIFF
--- a/groups/pstore/init.rc
+++ b/groups/pstore/init.rc
@@ -1,13 +1,15 @@
 on fs
     mkdir /dev/pstore 0700 5001 root
     mount pstore pstore /dev/pstore
+    chown 5001 root /dev/pstore
+    chmod 0700 /dev/pstore
 
 on post-fs-data
    mkdir /data/dontpanic 0770 root log
 
 service pstore-clean /system/vendor/bin/pstore-clean
     user 5001
-    group root log
+    group log
     class late_start
     oneshot
 


### PR DESCRIPTION
`Remove` pstore-clean service from "root" group.
Mount will change rwx mode from 0700 to 0740, use chmod to change it back.
Mount will also change /dev/pstore user from 5001 to root, change it back.
Then we can remove group root for pstore clean.

Tracked-On: OAM-85378
Signed-off-by: chenxia1 <xiao.x.chen@intel.com>