### PR TITLE
Pstore: change pstore's user and group back to origin.

### DIFF
--- a/groups/pstore/init.rc
+++ b/groups/pstore/init.rc
@@ -1,8 +1,8 @@
 on fs
-    mkdir /dev/pstore 0700 5001 root
+    mkdir /dev/pstore 0550 system log
     mount pstore pstore /dev/pstore
-    chown 5001 root /dev/pstore
-    chmod 0700 /dev/pstore
+    chown system log /dev/pstore
+    chmod 0550 /dev/pstore
 
 on post-fs-data
    mkdir /data/dontpanic 0770 root log


### PR DESCRIPTION
Google original expected difination:
  pstore log user is system;
  pstore log group is log;
  pstore log mode is 0550;
These are used to make some dumpstatez service can collect
pstore log.

Tracked-On: OAM-85576
Signed-off-by: Tian, Baofeng <baofeng.tian@intel.com>
Signed-off-by: Duan, YayongX <yayongx.duan@intel.com>