### PR TITLE
Enabling vendor specific wpa_supplicant library

### DIFF
--- a/groups/wlan/iwlwifi/BoardConfig.mk
+++ b/groups/wlan/iwlwifi/BoardConfig.mk
@@ -7,6 +7,8 @@ WPA_SUPPLICANT_VERSION := VER_2_1_DEVEL
 BOARD_WLAN_DEVICE := iwlwifi
 {{/libwifi-hal}}
 
+BOARD_WPA_SUPPLICANT_PRIVATE_LIB ?= lib_driver_cmd_intc
+
 # Enabling iwlwifi
 BOARD_USING_INTEL_IWL := true
 INTEL_IWL_MODULE_SUB_FOLDER := {{{iwl_sub_folder}}}


### PR DESCRIPTION
Setting BOARD_WPA_SUPPLICANT_PRIVATE_LIB to enable wpa_supplicant
private library support.

Change-Id: I8ce413c80a3cbf4efdcbea39dbdc1fd9c70cbc57
Tracked-On: OAM-85130
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Amrita Raju <amrita.raju@intel.com>