### PR TITLE
boot-arch: add live_boot option.

### DIFF
--- a/groups/boot-arch/doc.spec
+++ b/groups/boot-arch/doc.spec
@@ -46,6 +46,8 @@ this option will select UEFI as bootloader.
         - flash_block_size: set for BOARD_FLASH_BLOCK_SIZE
         - loader_efi_to_flash: set for fastboot boot command
         - userdata_checkpoint: userdata checkpoint (UDC) feature for ota rollback in case of failure
+        - usb_storage: set for KERNELFLINGER_SUPPORT_USB_STORAGE
+        - live_boot: set for KERNELFLINGER_SUPPORT_LIVE_BOOT
 
     --- extra files
         - oemvars.txt:  "magic key detection timeout"

--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -154,5 +154,9 @@ AB_OTA_PARTITIONS += bootloader
 {{/slot-ab}}
 
 {{#usb_storage}}
-KERNELFLINGER_SUPPORT_USB_STORAGE := true
+KERNELFLINGER_SUPPORT_USB_STORAGE ?= true
 {{/usb_storage}}
+
+{{#live_boot}}
+KERNELFLINGER_SUPPORT_LIVE_BOOT ?= true
+{{/live_boot}}

--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -21,6 +21,7 @@ ifwi_debug = false
 ignore_not_applicable_reset = false
 ignore_rsci = false
 keybox_provision = true
+live_boot = false
 mountfstab-flag = true
 nvme_rpmb_scan = false
 os_secure_boot = false


### PR DESCRIPTION
Default setting is disabled.
Set live_boot = true will set KERNELFLINGER_SUPPORT_LIVE_BOOT ?= true.
Set both of usb_storage and live_boot option to true to enable USB live boot.
Set usb_storage = true and live_boot = false to only support USB storage
as an internal storage and does not support USB live boot.
Also change to set KERNELFLINGER_SUPPORT_USB_STORAGE ?= true if enable
usb_storage.

Tracked-On: OAM-85337
Signed-off-by: Ming Tan <ming.tan@intel.com>