### PR TITLE
Add an option for enable GRUB installer

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -160,3 +160,7 @@ KERNELFLINGER_SUPPORT_USB_STORAGE ?= true
 {{#live_boot}}
 KERNELFLINGER_SUPPORT_LIVE_BOOT ?= true
 {{/live_boot}}
+
+{{#grub_installer}}
+ENABLE_GRUB_INSTALLER ?= true
+{{/grub_installer}}

--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -16,6 +16,7 @@ disk_encryption = true
 esp_partition_size = 30
 file_encryption = false
 flash_block_size = 512
+grub_installer = false
 hung_task_timeout_secs = 120
 ifwi_debug = false
 ignore_not_applicable_reset = false


### PR DESCRIPTION
Disabled by default.
To build the grub image, try to enable this option or
set ENBALE_GRUB_INSTALLER=true in make command line.
Grub image only built in eng and userdebug build.

Tracked-On: OAM-85443
Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>