### PR TITLE
Enable HDMI audio on Q dessert

### DIFF
--- a/groups/audio/project-celadon/default/policy/audio_policy_configuration.xml
+++ b/groups/audio/project-celadon/default/policy/audio_policy_configuration.xml
@@ -111,6 +111,9 @@
         <!-- Usb Audio HAL -->
         <xi:include href="usb_audio_policy_configuration.xml"/>
 
+        <!-- HDMI Audio HAL -->
+        <xi:include href="hdmi_audio_policy_configuration.xml"/>
+
         <!-- Remote Submix Audio HAL -->
         <xi:include href="r_submix_audio_policy_configuration.xml"/>
 

--- a/groups/audio/project-celadon/default/policy/hdmi_audio_policy_configuration.xml
+++ b/groups/audio/project-celadon/default/policy/hdmi_audio_policy_configuration.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2015 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<!-- HDMI Audio HAL Audio Policy Configuration file -->
+
+<module name="hdmi" halVersion="2.0">
+    <mixPorts>
+        <mixPort name="hdmi_stereo" role="source">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="48000" />
+        </mixPort>
+        <mixPort name="hdmi_multi" role="source" flags="AUDIO_OUTPUT_FLAG_DIRECT">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="48000" />
+        </mixPort>
+    </mixPorts>
+    <devicePorts>
+        <devicePort tagName="HDMI" type="AUDIO_DEVICE_OUT_LINE" role="sink">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="32000,44100,48000"/>
+        </devicePort>
+        <devicePort tagName="HDMI_2" type="AUDIO_DEVICE_OUT_HDMI" role="sink">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="32000,44100,48000"/>
+        </devicePort>
+ 
+    </devicePorts>
+    <routes>
+        <route type="mix" sink="HDMI"
+               sources="hdmi_stereo,hdmi_multi"/>
+     <route type="mix" sink="HDMI_2"
+               sources="hdmi_stereo,hdmi_multi"/>
+    </routes>
+</module>

--- a/groups/audio/project-celadon/product.mk
+++ b/groups/audio/project-celadon/product.mk
@@ -24,6 +24,7 @@ PRODUCT_PACKAGES += \
     audio.r_submix.default \
     audio.usb.default \
     audio.usb.$(TARGET_BOARD_PLATFORM) \
+    audio.hdmi.$(TARGET_BOARD_PLATFORM) \
     audio_policy.default.so \
     audio_configuration_files
 
@@ -47,6 +48,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/default/policy/a2dp_audio_policy_configuration.xml:vendor/etc/a2dp_audio_policy_configuration.xml \
     $(LOCAL_PATH)/audio/default/policy/r_submix_audio_policy_configuration.xml:vendor/etc/r_submix_audio_policy_configuration.xml \
     $(LOCAL_PATH)/audio/default/policy/usb_audio_policy_configuration.xml:vendor/etc/usb_audio_policy_configuration.xml \
+    $(LOCAL_PATH)/audio/default/policy/hdmi_audio_policy_configuration.xml:vendor/etc/hdmi_audio_policy_configuration.xml \
     $(LOCAL_PATH)/audio/default/policy/audio_policy_volumes.xml:vendor/etc/audio_policy_volumes.xml \
     $(LOCAL_PATH)/audio/default/policy/default_volume_tables.xml:vendor/etc/default_volume_tables.xml \
     $(LOCAL_PATH)/audio/default/effect/audio_effects.xml:vendor/etc/audio_effects.xml \

--- a/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_accessibility.pfw
+++ b/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_accessibility.pfw
@@ -293,43 +293,6 @@ supDomain: DeviceForStrategy
 					usb_headset = 0 
 					hdmi = 0
 
-			conf: Line
-				ANY
-					#
-					# accessibility falls through Phone strategy if in call
-					# but Line has a lower priority than WiredHeadset in this case.
-					#
-					ALL
-						ANY
-							TelephonyMode Is InCall
-							TelephonyMode Is InCommunication
-						ForceUseForCommunication IsNot ForceSpeaker
-						AvailableOutputDevices Excludes WiredHeadset
-					#
-					# accessibility follows Media strategy if not in call
-					#
-				AvailableOutputDevices Includes Line
-
-				component: /Policy/policy/strategies/accessibility/selected_output_devices/mask
-					remote_submix = 0
-					earpiece = 0
-					bluetooth_a2dp = 0
-					bluetooth_a2dp_headphones = 0
-					bluetooth_a2dp_speaker = 0
-					bluetooth_sco_headset = 0
-					bluetooth_sco_carkit = 0
-					bluetooth_sco = 0
-					speaker = 0
-					wired_headset = 0
-					wired_headphone = 0
-					line = 1
-					angl_dock_headset = 0
-					dgtl_dock_headset = 0
-					usb_accessory = 0
-					usb_device = 0
-					usb_headset = 0 
-					hdmi = 0
-
 			conf: WiredHeadset
 				ANY
 					#
@@ -577,6 +540,7 @@ supDomain: DeviceForStrategy
 					usb_headset = 0 
 					hdmi = 0
 
+
 			conf: Earpiece
 				#
 				# accessibility falls through Phone strategy if in call
@@ -628,6 +592,43 @@ supDomain: DeviceForStrategy
 					usb_accessory = 0
 					usb_device = 0
 					usb_headset = 0
+					hdmi = 0
+
+			conf: Line
+				ANY
+					#
+					# accessibility falls through Phone strategy if in call
+					# but Line has a lower priority than WiredHeadset in this case.
+					#
+					ALL
+						ANY
+							TelephonyMode Is InCall
+							TelephonyMode Is InCommunication
+						ForceUseForCommunication IsNot ForceSpeaker
+						AvailableOutputDevices Excludes WiredHeadset
+					#
+					# accessibility follows Media strategy if not in call
+					#
+				AvailableOutputDevices Includes Line
+
+				component: /Policy/policy/strategies/accessibility/selected_output_devices/mask
+					remote_submix = 0
+					earpiece = 0
+					bluetooth_a2dp = 0
+					bluetooth_a2dp_headphones = 0
+					bluetooth_a2dp_speaker = 0
+					bluetooth_sco_headset = 0
+					bluetooth_sco_carkit = 0
+					bluetooth_sco = 0
+					speaker = 0
+					wired_headset = 0
+					wired_headphone = 0
+					line = 1
+					angl_dock_headset = 0
+					dgtl_dock_headset = 0
+					usb_accessory = 0
+					usb_device = 0
+					usb_headset = 0 
 					hdmi = 0
 
 			conf: Default

--- a/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_enforced_audible.pfw
+++ b/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_enforced_audible.pfw
@@ -178,30 +178,6 @@ supDomain: DeviceForStrategy
 					telephony_tx = 0
 					line = 0
 
-			conf: Line
-				ForceUseForMedia IsNot ForceSpeaker
-				AvailableOutputDevices Includes Line
-
-				component: /Policy/policy/strategies/enforced_audible/selected_output_devices/mask
-					remote_submix = 0
-					earpiece = 0
-					wired_headset = 0
-					wired_headphone = 0
-					bluetooth_sco = 0
-					bluetooth_sco_headset = 0
-					bluetooth_sco_carkit = 0
-					bluetooth_a2dp = 0
-					bluetooth_a2dp_headphones = 0
-					bluetooth_a2dp_speaker = 0
-					hdmi = 0
-					angl_dock_headset = 0
-					dgtl_dock_headset = 0
-					usb_accessory = 0
-					usb_device = 0
-					usb_headset = 0
-					telephony_tx = 0
-					line = 1
-
 			conf: WiredHeadset
 				ForceUseForMedia IsNot ForceSpeaker
 				AvailableOutputDevices Includes WiredHeadset
@@ -370,6 +346,29 @@ supDomain: DeviceForStrategy
 					usb_headset = 0 
 					telephony_tx = 0
 					line = 0
+
+			conf: Line
+				AvailableOutputDevices Includes Line
+
+				component: /Policy/policy/strategies/enforced_audible/selected_output_devices/mask
+					remote_submix = 0
+					earpiece = 0
+					wired_headset = 0
+					wired_headphone = 0
+					bluetooth_sco = 0
+					bluetooth_sco_headset = 0
+					bluetooth_sco_carkit = 0
+					bluetooth_a2dp = 0
+					bluetooth_a2dp_headphones = 0
+					bluetooth_a2dp_speaker = 0
+					hdmi = 0
+					angl_dock_headset = 0
+					dgtl_dock_headset = 0
+					usb_accessory = 0
+					usb_device = 0
+					usb_headset = 0
+					telephony_tx = 0
+					line = 1
 
 			conf: NoDevice
 				component: /Policy/policy/strategies/enforced_audible/selected_output_devices/mask

--- a/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_media.pfw
+++ b/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_media.pfw
@@ -142,25 +142,6 @@ domainGroup: DeviceForStrategy
 					remote_submix = 0
 					line = 0
 
-			conf: Line
-				AvailableOutputDevices Includes Line
-
-				component: /Policy/policy/strategies/media/selected_output_devices/mask
-					speaker = 0
-					hdmi = 0
-					dgtl_dock_headset = 0
-					angl_dock_headset = 0
-					usb_device = 0 
-					usb_headset = 0
-					usb_accessory = 0
-					wired_headset = 0
-					wired_headphone = 0
-					bluetooth_a2dp_speaker = 0
-					bluetooth_a2dp_headphones = 0
-					bluetooth_a2dp = 0
-					remote_submix = 0
-					line = 1
-
 			conf: WiredHeadset
 				AvailableOutputDevices Includes WiredHeadset
 
@@ -274,6 +255,25 @@ domainGroup: DeviceForStrategy
 					bluetooth_a2dp = 0
 					remote_submix = 0
 					line = 0
+
+			conf: Line
+				AvailableOutputDevices Includes Line
+
+				component: /Policy/policy/strategies/media/selected_output_devices/mask
+					speaker = 0
+					hdmi = 0
+					dgtl_dock_headset = 0
+					angl_dock_headset = 0
+					usb_device = 0 
+					usb_headset = 0
+					usb_accessory = 0
+					wired_headset = 0
+					wired_headphone = 0
+					bluetooth_a2dp_speaker = 0
+					bluetooth_a2dp_headphones = 0
+					bluetooth_a2dp = 0
+					remote_submix = 0
+					line = 1
 
 			conf: AnlgDockHeadset
 				AvailableOutputDevices Includes AnlgDockHeadset

--- a/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_phone.pfw
+++ b/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_phone.pfw
@@ -238,30 +238,6 @@ supDomain: DeviceForStrategy
 					line = 0
 					speaker = 0
 
-			conf: Line
-				AvailableOutputDevices Includes Line
-				ForceUseForCommunication IsNot ForceSpeaker
-
-				component: /Policy/policy/strategies/phone/selected_output_devices/mask
-					earpiece = 0
-					wired_headset = 0
-					wired_headphone = 0
-					bluetooth_sco = 0
-					bluetooth_sco_headset = 0
-					bluetooth_sco_carkit = 0
-					bluetooth_a2dp = 0
-					bluetooth_a2dp_headphones = 0
-					bluetooth_a2dp_speaker = 0
-					hdmi = 0
-					angl_dock_headset = 0
-					dgtl_dock_headset = 0
-					usb_accessory = 0
-					usb_device = 0
-					usb_headset = 0
-					telephony_tx = 0
-					line = 1
-					speaker = 0
-
 			conf: UsbDevice
 				#
 				# Fallback BT Sco devices in case of FORCE_BT_SCO
@@ -512,6 +488,30 @@ supDomain: DeviceForStrategy
 					line = 0
 					speaker = 1
 
+			conf: Line
+				AvailableOutputDevices Includes Line
+				ForceUseForCommunication IsNot ForceSpeaker
+
+				component: /Policy/policy/strategies/phone/selected_output_devices/mask
+					earpiece = 0
+					wired_headset = 0
+					wired_headphone = 0
+					bluetooth_sco = 0
+					bluetooth_sco_headset = 0
+					bluetooth_sco_carkit = 0
+					bluetooth_a2dp = 0
+					bluetooth_a2dp_headphones = 0
+					bluetooth_a2dp_speaker = 0
+					hdmi = 0
+					angl_dock_headset = 0
+					dgtl_dock_headset = 0
+					usb_accessory = 0
+					usb_device = 0
+					usb_headset = 0
+					telephony_tx = 0
+					line = 1
+					speaker = 0
+                    
 			conf: Default
 				#
 				# Fallback on default output device which can be speaker for example

--- a/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_rerouting.pfw
+++ b/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_rerouting.pfw
@@ -140,25 +140,6 @@ domainGroup: DeviceForStrategy
 					usb_headset = 0 
 					hdmi = 0
 
-			conf: Line
-				AvailableOutputDevices Includes Line
-
-				component: /Policy/policy/strategies/rerouting/selected_output_devices/mask
-					remote_submix = 0
-					bluetooth_a2dp = 0
-					bluetooth_a2dp_headphones = 0
-					bluetooth_a2dp_speaker = 0
-					speaker = 0
-					wired_headset = 0
-					wired_headphone = 0
-					line = 1
-					angl_dock_headset = 0
-					dgtl_dock_headset = 0
-					usb_accessory = 0
-					usb_device = 0
-					usb_headset = 0 
-					hdmi = 0
-
 			conf: WiredHeadset
 				AvailableOutputDevices Includes WiredHeadset
 
@@ -308,6 +289,25 @@ domainGroup: DeviceForStrategy
 					wired_headset = 0
 					wired_headphone = 0
 					line = 0
+					angl_dock_headset = 0
+					dgtl_dock_headset = 0
+					usb_accessory = 0
+					usb_device = 0
+					usb_headset = 0 
+					hdmi = 0
+
+			conf: Line
+				AvailableOutputDevices Includes Line
+
+				component: /Policy/policy/strategies/rerouting/selected_output_devices/mask
+					remote_submix = 0
+					bluetooth_a2dp = 0
+					bluetooth_a2dp_headphones = 0
+					bluetooth_a2dp_speaker = 0
+					speaker = 0
+					wired_headset = 0
+					wired_headphone = 0
+					line = 1
 					angl_dock_headset = 0
 					dgtl_dock_headset = 0
 					usb_accessory = 0

--- a/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_sonification.pfw
+++ b/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_sonification.pfw
@@ -252,45 +252,6 @@ supDomain: DeviceForStrategy
 					telephony_tx = 0
 					line = 0
 
-			conf: Line
-				AvailableOutputDevices Includes Line
-				ANY
-					#
-					# Sonification follows Phone strategy if in call (widely speaking)
-					# but Line has a lower priority than WiredHeadset in this case.
-					#
-					ALL
-						ANY
-							TelephonyMode Is InCall
-							TelephonyMode Is InCommunication
-						ForceUseForCommunication IsNot ForceSpeaker
-						AvailableOutputDevices Excludes WiredHeadset
-					#
-					# Sonification falls through media strategy if not in call (widely speaking)
-					#
-					ALL
-						TelephonyMode IsNot InCall
-						TelephonyMode IsNot InCommunication
-						ForceUseForMedia IsNot ForceSpeaker
-
-				component: /Policy/policy/strategies/sonification/selected_output_devices/mask
-					earpiece = 0
-					wired_headset = 0
-					wired_headphone = 0
-					bluetooth_sco = 0
-					bluetooth_sco_headset = 0
-					bluetooth_sco_carkit = 0
-					bluetooth_a2dp = 0
-					bluetooth_a2dp_headphones = 0
-					bluetooth_a2dp_speaker = 0
-					angl_dock_headset = 0
-					dgtl_dock_headset = 0
-					usb_accessory = 0
-					usb_device = 0 
-					usb_headset = 0
-					telephony_tx = 0
-					line = 1
-
 			conf: WiredHeadset
 				AvailableOutputDevices Includes WiredHeadset
 				ANY
@@ -494,6 +455,44 @@ supDomain: DeviceForStrategy
 					usb_headset = 0
 					telephony_tx = 0
 					line = 0
+
+			conf: Line
+				AvailableOutputDevices Includes Line
+				ANY
+					#
+					# Sonification follows Phone strategy if in call (widely speaking)
+					# but Line has a lower priority than WiredHeadset in this case.
+					#
+					ALL
+						ANY
+							TelephonyMode Is InCall
+							TelephonyMode Is InCommunication
+						ForceUseForCommunication IsNot ForceSpeaker
+						AvailableOutputDevices Excludes WiredHeadset
+					#
+					# Sonification falls through media strategy if not in call (widely speaking)
+					#
+					ALL
+						TelephonyMode IsNot InCall
+						TelephonyMode IsNot InCommunication
+						
+				component: /Policy/policy/strategies/sonification/selected_output_devices/mask
+					earpiece = 0
+					wired_headset = 0
+					wired_headphone = 0
+					bluetooth_sco = 0
+					bluetooth_sco_headset = 0
+					bluetooth_sco_carkit = 0
+					bluetooth_a2dp = 0
+					bluetooth_a2dp_headphones = 0
+					bluetooth_a2dp_speaker = 0
+					angl_dock_headset = 0
+					dgtl_dock_headset = 0
+					usb_accessory = 0
+					usb_device = 0 
+					usb_headset = 0
+					telephony_tx = 0
+					line = 1
 
 			conf: Earpiece
 				#

--- a/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_sonification_respectful.pfw
+++ b/groups/audio/project-celadon/reference_configurable_audio_policy/Settings/device_for_strategy_sonification_respectful.pfw
@@ -277,48 +277,6 @@ domainGroup: DeviceForStrategy
 					usb_headset = 0
 					hdmi = 0
 
-			conf: Line
-				ANY
-					#
-					# SonificationRespectful Follows Phone strategy if in call
-					# but Line has a lower priority than WiredHeadset in this case.
-					#
-					#
-					ALL
-						ANY
-							TelephonyMode Is InCall
-							TelephonyMode Is InCommunication
-						ForceUseForCommunication IsNot ForceSpeaker
-						AvailableOutputDevices Excludes WiredHeadset
-					#
-					# SonificationRespectful Follows Sonification that falls through Media strategy if not in call
-					# SonificationRespectful follows media if music stream is active
-					#
-					ALL
-						TelephonyMode IsNot InCall
-						TelephonyMode IsNot InCommunication
-						AvailableOutputDevices Includes WiredHeadphone
-						ForceUseForMedia IsNot ForceSpeaker
-				AvailableOutputDevices Includes Line
-
-				component: /Policy/policy/strategies/sonification_respectful/selected_output_devices/mask
-					earpiece = 0
-					bluetooth_sco = 0
-					bluetooth_sco_headset = 0
-					bluetooth_sco_carkit = 0
-					bluetooth_a2dp_headphones = 0
-					bluetooth_a2dp_speaker = 0
-					bluetooth_a2dp = 0
-					wired_headset = 0
-					wired_headphone = 0
-					line = 1
-					angl_dock_headset = 0
-					dgtl_dock_headset = 0
-					usb_accessory = 0
-					usb_device = 0
-					usb_headset = 0 
-					hdmi = 0
-
 			conf: WiredHeadset
 				ANY
 					ALL
@@ -559,6 +517,47 @@ domainGroup: DeviceForStrategy
 					usb_accessory = 0
 					usb_device = 0
 					usb_headset = 0
+					hdmi = 0
+
+			conf: Line
+				ANY
+					#
+					# SonificationRespectful Follows Phone strategy if in call
+					# but Line has a lower priority than WiredHeadset in this case.
+					#
+					#
+					ALL
+						ANY
+							TelephonyMode Is InCall
+							TelephonyMode Is InCommunication
+						ForceUseForCommunication IsNot ForceSpeaker
+						AvailableOutputDevices Excludes WiredHeadset
+					#
+					# SonificationRespectful Follows Sonification that falls through Media strategy if not in call
+					# SonificationRespectful follows media if music stream is active
+					#
+					ALL
+						TelephonyMode IsNot InCall
+						TelephonyMode IsNot InCommunication
+						AvailableOutputDevices Includes WiredHeadphone
+				AvailableOutputDevices Includes Line
+
+				component: /Policy/policy/strategies/sonification_respectful/selected_output_devices/mask
+					earpiece = 0
+					bluetooth_sco = 0
+					bluetooth_sco_headset = 0
+					bluetooth_sco_carkit = 0
+					bluetooth_a2dp_headphones = 0
+					bluetooth_a2dp_speaker = 0
+					bluetooth_a2dp = 0
+					wired_headset = 0
+					wired_headphone = 0
+					line = 1
+					angl_dock_headset = 0
+					dgtl_dock_headset = 0
+					usb_accessory = 0
+					usb_device = 0
+					usb_headset = 0 
 					hdmi = 0
 
 			conf: Earpiece


### PR DESCRIPTION
Enable HDMI audio on Q dessert

Add HDMI audio related changes in audio config

Change-Id: I80ab1bdc9ab0e7ce3ed214ce5ad6734174f967fd
Tracked-On: OAM-84728
Signed-off-by: M, Kumar K <kumar.k.m@intel.com>