### PR TITLE
Remove inclusion of incorrect camera service, impl and module

### DIFF
--- a/groups/device-specific/celadon_ivi/product.mk
+++ b/groups/device-specific/celadon_ivi/product.mk
@@ -19,9 +19,6 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     android.hardware.usb@1.0-service \
                     android.hardware.dumpstate@1.0-impl \
                     android.hardware.dumpstate@1.0-service \
-                    camera.device@1.0-impl \
-                    android.hardware.camera.provider@2.4-impl \
-                    android.hardware.camera.provider@2.4-service \
                     android.hardware.graphics.mapper@2.0-impl \
                     android.hardware.graphics.allocator@2.0-impl \
                     android.hardware.graphics.allocator@2.0-service \

--- a/groups/device-specific/celadon_tablet/product.mk
+++ b/groups/device-specific/celadon_tablet/product.mk
@@ -19,9 +19,6 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     android.hardware.usb@1.0-service \
                     android.hardware.dumpstate@1.0-impl \
                     android.hardware.dumpstate@1.0-service \
-                    camera.device@1.0-impl \
-                    android.hardware.camera.provider@2.4-impl \
-                    android.hardware.camera.provider@2.4-service \
                     android.hardware.graphics.mapper@2.0-impl \
                     android.hardware.graphics.allocator@2.0-impl \
                     android.hardware.graphics.allocator@2.0-service \


### PR DESCRIPTION
Due to inclusion of incorrect camera service and libraries,
error "Could not load camera HAL module" seen while running
CtsMediaTestCases.

Tracked-On: OAM-86606
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>