### PR TITLE
Dont set the value of "media.settings.xml"

### DIFF
--- a/groups/codecs/configurable/product.mk
+++ b/groups/codecs/configurable/product.mk
@@ -4,7 +4,7 @@ PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:vendor/etc/media_codecs_google_video.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs.xml:vendor/etc/media_codecs.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/mfx_omxil_core.conf:vendor/etc/mfx_omxil_core.conf \
-    $(LOCAL_PATH)/{{_extra_dir}}/{{profile_file}}:vendor/etc/media_profiles.xml
+    $(LOCAL_PATH)/{{_extra_dir}}/{{profile_file}}:vendor/etc/media_profiles_V1_0.xml
 
 {{^codec_perf_xen}}
 PRODUCT_COPY_FILES += \

--- a/groups/device-specific/caas/system.prop
+++ b/groups/device-specific/caas/system.prop
@@ -10,4 +10,3 @@ ro.board.platform=broxton
 audio.safemedia.bypass=true
 debug.nn.cpuonly=0
 camera.disable_treble=false
-media.settings.xml=/vendor/etc/media_profiles.xml

--- a/groups/device-specific/celadon_ivi/system.prop
+++ b/groups/device-specific/celadon_ivi/system.prop
@@ -10,4 +10,3 @@ ro.board.platform=broxton
 audio.safemedia.bypass=true
 debug.nn.cpuonly=0
 camera.disable_treble=false
-media.settings.xml=/vendor/etc/media_profiles.xml

--- a/groups/device-specific/celadon_tablet/system.prop
+++ b/groups/device-specific/celadon_tablet/system.prop
@@ -10,4 +10,3 @@ ro.board.platform=broxton
 audio.safemedia.bypass=true
 debug.nn.cpuonly=0
 camera.disable_treble=false
-media.settings.xml=/vendor/etc/media_profiles.xml


### PR DESCRIPTION
Currently, this property is system non-exported. So, can't be set
neither in vendor partition nor in system.prop as
VtsValidateMediaProfiles with GSI(Generic System Image) will
fail.

Copy media_profiles file as media_profiles_V1_0.xml to
vendor/etc folder and clean setting of the property from
system.prop.

Tracked-On: OAM-85140
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Tong Bo <bo.tong@intel.com>