### PR TITLE
Dont set the value of "media.settings.xml"

### DIFF
--- a/groups/device-specific/cel_apl/system.prop
+++ b/groups/device-specific/cel_apl/system.prop
@@ -4,5 +4,4 @@
 
 audio.safemedia.bypass=true
 persist.bluetooth.enablenewavrcp=false
-media.settings.xml=/vendor/etc/media_profiles.xml
 ro.crypto.volume.filenames_mode=aes-256-cts

--- a/groups/device-specific/cel_kbl/system.prop
+++ b/groups/device-specific/cel_kbl/system.prop
@@ -4,5 +4,4 @@
 
 audio.safemedia.bypass=true
 persist.bluetooth.enablenewavrcp=false
-media.settings.xml=/vendor/etc/media_profiles.xml
 ro.crypto.volume.filenames_mode=aes-256-cts

--- a/groups/media/project-celadon/init.rc
+++ b/groups/media/project-celadon/init.rc
@@ -20,5 +20,3 @@ on post-fs
     insmod /vendor/lib/modules/kernel/drivers/media/v4l2-core/videobuf2-dma-contig.ko
     insmod /vendor/lib/modules/kernel/drivers/media/v4l2-core/videobuf2-vmalloc.ko
     insmod /vendor/lib/modules/kernel/drivers/media/usb/uvc/uvcvideo.ko
-
-    setprop media.settings.xml /vendor/etc/media_profiles.xml

--- a/groups/media/project-celadon/product.mk
+++ b/groups/media/project-celadon/product.mk
@@ -10,7 +10,7 @@ PRODUCT_PACKAGES += libpciaccess
 PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:vendor/etc/media_codecs_google_audio.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:vendor/etc/media_codecs_google_video.xml \
-    device/intel/project-celadon/common/media/{{profile_file}}:vendor/etc/media_profiles.xml \
+    device/intel/project-celadon/common/media/{{profile_file}}:vendor/etc/media_profiles_V1_0.xml \
     device/intel/project-celadon/common/media/media_codecs.xml:vendor/etc/media_codecs.xml \
     device/intel/project-celadon/common/media/media_codecs_performance.xml:vendor/etc/media_codecs_performance.xml
 


### PR DESCRIPTION
Currently, this property is system non-exported. So, can't be set
neither in vendor partition nor in system.prop as
VtsValidateMediaProfiles with GSI(Generic System Image) will
fail.

Copy media_profiles file as media_profiles_V1_0.xml to
vendor/etc folder and clean setting of the property from
system.prop.

Tracked-On: OAM-86732
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Tong Bo <bo.tong@intel.com>