### PR TITLE
Mixins: define the macro to control the log.

### DIFF
--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -26,6 +26,7 @@ live_boot = false
 mountfstab-flag = true
 nvme_rpmb_scan = false
 os_secure_boot = false
+output_log_file = false
 rpmb = false
 rpmb_simulate = false
 run_tco_on_shutdown = false

--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -136,6 +136,11 @@ PRODUCT_COPY_FILES += system/extras/checkpoint_gc/checkpoint_gc.sh:recovery/root
 $(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)
 {{/avb}}
 
+{{#output_log_file}}
+OUTPUT_INSTALLERLOG_FILE := true
+OUTPUT_KERNELFLINGERLOG_FILE := true
+{{/output_log_file}}
+
 {{#keybox_provision}}
 KERNELFLINGER_SUPPORT_KEYBOX_PROVISION := true
 {{/keybox_provision}}


### PR DESCRIPTION
The macro is disable in default state.
if set the parameter "output_log_file = true", the macro is enable,
and the log of installer was written into the installer.log.

Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
Tracked-On: OAM-80876