### PR TITLE
Remove cp_ss

### DIFF
--- a/groups/trusty/true/init.rc
+++ b/groups/trusty/true/init.rc
@@ -5,21 +5,7 @@ on post-fs-data
 
 {{#enable_storage_proxyd}}
 on early-boot
-{{#ota-upgrade}}
-{{#ota_pre_o_version}}
-    start cp_securestorage
-{{/ota_pre_o_version}}
-{{/ota-upgrade}}
     start storageproxyd
-
-on property:ro.vendor.copy.ss=1
-    copy /data/misc/securestorage/0 /data/vendor/securestorage/0
-    restart storageproxyd
-
-service cp_securestorage /vendor/bin/cp_ss
-    user system
-    group system
-    oneshot
 
 service storageproxyd /vendor/bin/storageproxyd -d /dev/trusty-ipc-dev0 -p /data/vendor/securestorage -r /dev/rpmb0
     user system

--- a/groups/trusty/true/product.mk
+++ b/groups/trusty/true/product.mk
@@ -17,7 +17,6 @@ endif
 PRODUCT_PACKAGES += \
 	libtrusty \
 	storageproxyd \
-	cp_ss \
 	libinteltrustystorage \
 	libinteltrustystorageinterface \
 	gatekeeper.trusty \


### PR DESCRIPTION
This module is only required for the OTA across pre-P to P or successors.
No requirement of O->Q now.
And it will cause to ATS failure due to sepolicy.

Change-Id: Ib5f29078274ed5285887ee667c236c8e2da9d37f
Signed-off-by: Huang Yang <yang.huang@intel.com>
Tracked-On: OAM-86820