### PR TITLE
[postinstall] Fix "fails to run postinstall" issue

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -105,8 +105,8 @@ BOARD_KERNEL_CMDLINE += iTCO_wdt.stop_on_shutdown=0
 
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/boot-arch/generic
 {{#slot-ab}}
-BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/boot-arch/slotab_ota/generic
-BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/boot-arch/slotab_ota/efi
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/abota/generic
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/abota/efi
 {{/slot-ab}}
 
 {{#rpmb}}

--- a/groups/boot-arch/project-celadon/update_ifwi_ab.sh
+++ b/groups/boot-arch/project-celadon/update_ifwi_ab.sh
@@ -1,4 +1,4 @@
-#!/vendor/bin/sh
+#!/system/bin/sh
 
 # userdata checkpoint cleanup at postinstall step
 USERDATA_CHECKPOINT_GC=vendor/bin/checkpoint_gc


### PR DESCRIPTION
1. Sepolicy path of postinstall was changed,
modify BOARD_SEPOLICY_DIRS to point to right path.

2. Use system/bin/sh to replace vendor/bin/sh

EB 4570 test pass

Tracked-On: OAM-86848
Signed-off-by: Heng Luo <heng.luo@intel.com>