### PR TITLE
Set overlay for disabling keepalive offload to address CTS issue 

### DIFF
--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -50,3 +50,5 @@ PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     ro.wifi.softap_dualband_allow=false
 {{/softap_dualband_allow}}
+
+PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-disable_keepalive_offload


### PR DESCRIPTION
Keepalive packet offloading is enabled by default. CTS test cases
are failing as the keepalive offloading event is not received.

As keepalive offloading is not supported, override the configs
to disable it to address CTS failures.

Change-Id: I02f6ef654efc5707833edc0900f1f69db631d49c
Tracked-On: OAM-86930
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>