### PR TITLE
Rename build result file as CI convention.

### DIFF
--- a/groups/device-specific/cic/AndroidBoard.mk
+++ b/groups/device-specific/cic/AndroidBoard.mk
@@ -16,7 +16,7 @@ multidroid: droid
 	$(hide) cp -r $(PRODUCT_OUT)/system/etc $(PRODUCT_OUT)/docker/android/root
 	$(hide) chmod -R g-w $(PRODUCT_OUT)/docker/android/root
 
-TARGET_AIC_FILE_NAME := $(TARGET_PRODUCT)-aic-$(BUILD_NUMBER_FROM_FILE).tar.gz
+TARGET_AIC_FILE_NAME := $(TARGET_PRODUCT)-$(BUILD_NUMBER_FROM_FILE).tar.gz
 
 .PHONY: aic
 aic: .KATI_NINJA_POOL := console


### PR DESCRIPTION
We have certain logic in our CI process that depends
on this naming convention for the build result:
  lunchtargetname-buildnumber

Otherwise, it will break the CI process.

Signed-off-by: zhongjie <zhongjie.shi@intel.com>