### PR TITLE
Set control_privapp_permissions to enforce

### DIFF
--- a/groups/device-specific/celadon_ivi/product.mk
+++ b/groups/device-specific/celadon_ivi/product.mk
@@ -27,3 +27,5 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     libbt-vendor
 
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/manifest.xml:vendor/manifest.xml
+
+PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce


### PR DESCRIPTION
New cts cases of Q require control_privapp_permissions must be enforce.
Test: run cts -m CtsPermission2TestCases -t android.permission2.cts.PrivappPermissionsTest#privappPermissionsMustBeEnforced

Tracked-On: OAM-86934
Signed-off-by: Xie, Shellyx <shellyx.xie@intel.com>