### PR TITLE
Donot load VM when host kernel version lower than V5.0.0

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -82,8 +82,8 @@ if [[ "$vno" > "5.0.0" ]]; then
 		launch_swrender
 	fi
 else
-	echo "W: Detected linux version $vno, fall to software rendering"
-	echo "W: Please upgrade kernel version newer than 5.0.0 for smoother experience!"
-	launch_swrender
+	echo "E: Detected linux version $vno"
+	echo "E: Please upgrade kernel version newer than 5.0.0!"
+	exit -1
 fi
 


### PR DESCRIPTION
Caas VM is working on host kernel newer than V5.0.0 with trusty enabled.

Tracked-On: OAM-88232
Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>