### PR TITLE
media_profiles.xml: Make changes to pass CTS

### DIFF
--- a/groups/codecs/configurable/media_profiles_1080p.xml
+++ b/groups/codecs/configurable/media_profiles_1080p.xml
@@ -246,6 +246,19 @@
                    channels="1" />
         </EncoderProfile>
 
+        <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="60">
+            <Video codec="h264"
+                   bitRate="15000000"
+                   width="1920"
+                   height="1080"
+                   frameRate="30" />
+
+            <Audio codec="aac"
+                   bitRate="192000"
+                   sampleRate="48000"
+                   channels="1" />
+        </EncoderProfile>
+
         <EncoderProfile quality="timelapsehigh" fileFormat="mp4" duration="60">
             <Video codec="h264"
                    bitRate="15000000"
@@ -269,14 +282,14 @@
 
         <EncoderProfile quality="high" fileFormat="mp4" duration="60">
             <Video codec="h264"
-                   bitRate="3000000"
-                   width="1280"
-                   height="720"
+                   bitRate="15000000"
+                   width="1920"
+                   height="1080"
                    frameRate="30" />
 
             <Audio codec="aac"
-                   bitRate="12200"
-                   sampleRate="8000"
+                   bitRate="192000"
+                   sampleRate="48000"
                    channels="1" />
         </EncoderProfile>
 
@@ -359,16 +372,39 @@
                    channels="1" />
         </EncoderProfile>
 
+        <EncoderProfile quality="1080p" fileFormat="mp4" duration="30">
+            <Video codec="h264"
+                   bitRate="15000000"
+                   width="1920"
+                   height="1080"
+                   frameRate="30" />
+            <Audio codec="aac"
+                   bitRate="192000"
+                   sampleRate="48000"
+                   channels="1" />
+        </EncoderProfile>
+
         <EncoderProfile quality="timelapsehigh" fileFormat="mp4" duration="60">
             <Video codec="h264"
-                   bitRate="3000000"
-                   width="1280"
-                   height="720"
+                   bitRate="15000000"
+                   width="1920"
+                   height="1080"
                    frameRate="30" />
-
             <Audio codec="aac"
-                   bitRate="12200"
-                   sampleRate="8000"
+                   bitRate="192000"
+                   sampleRate="48000"
+                   channels="1" />
+        </EncoderProfile>
+
+        <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="60">
+            <Video codec="h264"
+                   bitRate="15000000"
+                   width="1920"
+                   height="1080"
+                   frameRate="30" />
+            <Audio codec="aac"
+                   bitRate="192000"
+                   sampleRate="48000"
                    channels="1" />
         </EncoderProfile>
 


### PR DESCRIPTION
CamcorderProfileTest expects "high" profile to match
with max profile in each category. This patch adds
changes for that. This was tested with Logitech
1080p camera which is POR for camera team.

Tracked-On: OAM-86962
Signed-off-by: saranya <saranya.gopal@intel.com>