### PR TITLE
CIV: Enable virtual VT-d(vIOMMU)

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -37,6 +37,7 @@ function launch_hwrender(){
 	  -device virtio-blk-pci,drive=disk1,bootindex=1 \
 	  -device e1000,netdev=net0 \
 	  -netdev user,id=net0,hostfwd=tcp::5555-:5555 \
+	  -device intel-iommu,device-iotlb=off \
 	  -nodefaults
 }
 


### PR DESCRIPTION
Add options in start_android_qcow2.sh:
	-device intel-iommu,device-iotlb=off \

The "device-iotlb" must off due to a QEMU issue:
	https://patchew.org/QEMU/20190927045838.2968-1-qi1.zhang@intel.com/

Tracked-On: OAM-88511
Signed-off-by: Qi Yadong <yadong.qi@intel.com>