### PR TITLE
Remove inclusion of firmware files for wlan and bluetooth

### DIFF
--- a/groups/bluetooth/btusb/option.spec
+++ b/groups/bluetooth/btusb/option.spec
@@ -1,3 +1,2 @@
 [defaults]
-firmware =
 ivi =

--- a/groups/bluetooth/btusb/product.mk
+++ b/groups/bluetooth/btusb/product.mk
@@ -11,15 +11,6 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.bluetooth_le.xml:vendor/etc/permissions/android.hardware.bluetooth_le.xml
 
 PRODUCT_COPY_FILES += \
-    vendor/linux/firmware/intel/ibt-18-16-1.ddc:$(TARGET_COPY_OUT_VENDOR)/firmware/intel/ibt-18-16-1.ddc \
-    vendor/linux/firmware/intel/ibt-18-16-1.sfi:$(TARGET_COPY_OUT_VENDOR)/firmware/intel/ibt-18-16-1.sfi \
-    vendor/linux/firmware/intel/ibt-18-2.ddc:$(TARGET_COPY_OUT_VENDOR)/firmware/intel/ibt-18-2.ddc \
-    vendor/linux/firmware/intel/ibt-18-2.sfi:$(TARGET_COPY_OUT_VENDOR)/firmware/intel/ibt-18-2.sfi \
-    vendor/linux/firmware/intel/ibt-12-16.ddc:$(TARGET_COPY_OUT_VENDOR)/firmware/intel/ibt-12-16.ddc \
-    vendor/linux/firmware/intel/ibt-12-16.sfi:$(TARGET_COPY_OUT_VENDOR)/firmware/intel/ibt-12-16.sfi \
-    vendor/linux/firmware/intel/ibt-hw-37.8.10-fw-22.50.19.14.f.bseq:$(TARGET_COPY_OUT_VENDOR)/firmware/intel/ibt-hw-37.8.10-fw-22.50.19.14.f.bseq
-
-PRODUCT_COPY_FILES += \
 	$(LOCAL_PATH)/{{_extra_dir}}/bluetooth_auto_detection.sh:vendor/bin/bluetooth_auto_detection.sh
 
 PRODUCT_PROPERTY_OVERRIDES += bluetooth.rfkill=1
@@ -27,9 +18,6 @@ PRODUCT_PROPERTY_OVERRIDES += bluetooth.rfkill=1
 PRODUCT_PACKAGES += \
     android.hardware.bluetooth@1.0-service.vbt \
     libbt-vendor \
-{{#firmware}}
-    {{firmware}}
-{{/firmware}}
 
 {{#ivi}}
 PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/bluetooth/overlay-car

--- a/groups/wlan/iwlwifi/option.spec
+++ b/groups/wlan/iwlwifi/option.spec
@@ -7,6 +7,5 @@ iwl_defconfig = kbl
 softap_dualband_allow = false
 iwl_sub_folder = dev
 libwifi-hal = false
-firmware =
 nvm = true
 iwl_upstream_drv = true

--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -12,9 +12,6 @@ PRODUCT_PACKAGES += \
 
 # FW and PNVM
 PRODUCT_PACKAGES += \
-{{#firmware}}
-    {{firmware}} \
-{{/firmware}}
 {{#nvm}}
     iwl-nvm
 {{/nvm}}
@@ -30,11 +27,6 @@ PRODUCT_COPY_FILES += \
         $(INTEL_PATH_COMMON)/wlan/iwlwifi/p2p_supplicant_overlay.conf:vendor/etc/wifi/p2p_supplicant_overlay.conf \
         frameworks/native/data/etc/android.hardware.wifi.xml:vendor/etc/permissions/android.hardware.wifi.xml \
         frameworks/native/data/etc/android.hardware.wifi.direct.xml:vendor/etc/permissions/android.hardware.wifi.direct.xml
-
-PRODUCT_COPY_FILES += \
-    vendor/linux/firmware/iwlwifi-9260-th-b0-jf-b0-43.ucode:$(TARGET_COPY_OUT_VENDOR)/firmware/iwlwifi-9260-th-b0-jf-b0-43.ucode \
-    vendor/linux/firmware/iwlwifi-3168-29.ucode:$(TARGET_COPY_OUT_VENDOR)/firmware/iwlwifi-3168-29.ucode \
-    vendor/linux/firmware/iwlwifi-8265-36.ucode:$(TARGET_COPY_OUT_VENDOR)/firmware/iwlwifi-8265-36.ucode
 
 {{#gpp}}
 # Add Manufacturing tool


### PR DESCRIPTION
Instead of adding specific firmware files, all firmware
files are added to the build so that wlan and bluetooth
functionalities are not broken due to missing firmware
files.

Tracked-On: OAM-88498
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>