### PR TITLE
CIV: Enable virtual VT-d(vIOMMU) for launch_swrender()

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -64,6 +64,7 @@ function launch_swrender(){
 	  -device virtio-blk-pci,drive=disk1,bootindex=1 \
 	  -device e1000,netdev=net0 \
 	  -netdev user,id=net0,hostfwd=tcp::5555-:5555 \
+	  -device intel-iommu,device-iotlb=off \
 	  -nodefaults
 }
 


### PR DESCRIPTION
The launch script may fall-back to launch_swrender(). When launch
with sw rendering, the vIOMMU is also required.

Tracked-On: OAM-88532
Signed-off-by: Qi Yadong <yadong.qi@intel.com>