### PR TITLE
Fix some treble violations

### DIFF
--- a/groups/aaf/true/init.rc
+++ b/groups/aaf/true/init.rc
@@ -5,4 +5,10 @@ on init
     start vendor.aafd
 
 on fs
-    exec u:r:init:s0 -- /system/bin/logwrapper /system/bin/sh /vendor/bin/auto_detection.sh
+    exec - root root -- /vendor/bin/logwrapper /vendor/bin/sh /vendor/bin/auto_detection.sh
+
+#   previously these properties are set in auto_detection.sh, however, these properties are
+#   of exported_default_prop which can only be set by init or vendor_init with treble
+#   enabled, so we have to hardcod these properties here.
+    setprop ro.hardware.hwcomposer intel
+    setprop ro.hardware.gralloc intel

--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -19,8 +19,9 @@ PRODUCT_PACKAGES += ufo_prebuilts
 # i915 firmwares
 $(foreach fw,$(I915_FW),$(eval PRODUCT_PACKAGES += $(notdir $(fw))))
 
+# move configure files provided by intel to vendor partition
 PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/{{_extra_dir}}/drirc:system/etc/drirc
+    $(LOCAL_PATH)/{{_extra_dir}}/drirc:vendor/etc/drirc
 
 {{#drmhwc}}
 # DRM HWComposer

--- a/groups/wlan/auto/product.mk
+++ b/groups/wlan/auto/product.mk
@@ -10,11 +10,12 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     android.hardware.wifi@1.0-service
 
+# move configure files provided by intel to vendor partition.
 PRODUCT_COPY_FILES += \
     $(INTEL_PATH_COMMON)/wlan/wpa_supplicant-common.conf:vendor/etc/wifi/wpa_supplicant.conf \
     $(INTEL_PATH_COMMON)/wlan/wpa_supplicant_overlay.conf:vendor/etc/wifi/wpa_supplicant_overlay.conf \
     $(INTEL_PATH_COMMON)/wlan/p2p_supplicant_overlay.conf:vendor/etc/wifi/p2p_supplicant_overlay.conf \
-    $(INTEL_PATH_COMMON)/wlan/wlan.conf:system/etc/modprobe.d/wlan.conf \
+    $(INTEL_PATH_COMMON)/wlan/wlan.conf:vendor/etc/modprobe.d/wlan.conf \
     frameworks/native/data/etc/android.hardware.wifi.xml:vendor/etc/permissions/android.hardware.wifi.xml \
     frameworks/native/data/etc/android.hardware.wifi.direct.xml:vendor/etc/permissions/android.hardware.wifi.direct.xml
 


### PR DESCRIPTION
There are some operations violate the treble requiements, and this
introduces some selinux avc errors that cannot be fixed. Fix these
violations so we can add proper sepolicy rules for this.

Tracked-On: OAM-88545
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>