### PR TITLE
Camera: Add support for 4k@30,HD/FHD@60 resolutions

### DIFF
--- a/groups/camera-ext/ext-camera-only/external_camera_config.xml
+++ b/groups/camera-ext/ext-camera-only/external_camera_config.xml
@@ -39,8 +39,10 @@
             <Limit width="640" height="480" fpsBound="60.0"/>
             <Limit width="720" height="480" fpsBound="60.0"/>
             <Limit width="960" height="560" fpsBound="60.0"/>
-            <Limit width="1280" height="720" fpsBound="30.0"/>
-            <Limit width="1920" height="1080" fpsBound="30.0"/>
+            <Limit width="1280" height="720" fpsBound="60.0"/>
+            <Limit width="1920" height="1080" fpsBound="60.0"/>
+            <Limit width="3840" height="2160" fpsBound="30.0"/>
+            <Limit width="4096" height="2160" fpsBound="30.0"/>
             <!-- image size larger than the last entry will not be supported-->
         </FpsList>
     </Device>


### PR DESCRIPTION
Adding support for 4k UHD@30, 4k DCI@30fps, 1080p@60,
720p@60 resolutions. All 4k@30 or FHD/HD@60 fps cameras
are supported through USB 3.x standard.

Tracked-On: OAM-88590
Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>