### PR TITLE
caas: Change order of usb host device pass through

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -27,13 +27,13 @@ function launch_hwrender(){
 	  -global PIIX4_PM.disable_s3=1 -global PIIX4_PM.disable_s4=1 \
 	  -cpu host \
 	  -device qemu-xhci,id=xhci,addr=0x8 \
+	  -device usb-host,vendorid=0x046d,productid=0x082d \
+	  -device usb-host,vendorid=0x046d,productid=0x085c \
 	  -device usb-host,vendorid=0x03eb,productid=0x8a6e \
 	  -device usb-host,vendorid=0x0eef,productid=0x7200 \
 	  -device usb-host,vendorid=0x222a,productid=0x0141 \
 	  -device usb-host,vendorid=0x222a,productid=0x0088 \
 	  -device usb-host,vendorid=0x8087,productid=0x0a2b \
-	  -device usb-host,vendorid=0x046d,productid=0x082d \
-	  -device usb-host,vendorid=0x046d,productid=0x085c \
 	  -device usb-mouse \
 	  -device usb-kbd \
 	  -drive file=$ovmf_file,format=raw,if=pflash \
@@ -61,12 +61,12 @@ function launch_swrender(){
 	  -global PIIX4_PM.disable_s3=1 -global PIIX4_PM.disable_s4=1 \
 	  -cpu host \
 	  -device qemu-xhci,id=xhci,addr=0x8 \
+	  -device usb-host,vendorid=0x046d,productid=0x082d \
+	  -device usb-host,vendorid=0x046d,productid=0x085c \
 	  -device usb-host,vendorid=0x03eb,productid=0x8a6e \
 	  -device usb-host,vendorid=0x0eef,productid=0x7200 \
 	  -device usb-host,vendorid=0x222a,productid=0x0141 \
 	  -device usb-host,vendorid=0x222a,productid=0x0088 \
-	  -device usb-host,vendorid=0x046d,productid=0x082d \
-	  -device usb-host,vendorid=0x046d,productid=0x085c \
 	  -device usb-mouse \
 	  -device usb-kbd \
 	  -drive file=$ovmf_file,format=raw,if=pflash \


### PR DESCRIPTION
Camera not working properly after touch screen devices are
passed to VM.

Fix the issue by moving the USB camera pass through to top
of the list.

Tracked-On: OAM-88637
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>