### PR TITLE
Revert "flashfiles: format data partition to f2fs filesystem"

### DIFF
--- a/groups/flashfiles/ini/flashfiles.ini
+++ b/groups/flashfiles/ini/flashfiles.ini
@@ -327,7 +327,7 @@ description = Set OEM variables
 
 [command.format.data]
 tool = fastboot
-args = format{{#data_use_f2fs}}:f2fs{{/data_use_f2fs}} {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}}
+args = format {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}}
 description = Format {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}} partition
 {{/mfgos}}
 

--- a/groups/flashfiles/mixinfo.spec
+++ b/groups/flashfiles/mixinfo.spec
@@ -1,2 +1,2 @@
 [mixinfo]
-deps = variants slot-ab dynamic-partitions boot-arch
+deps = variants slot-ab dynamic-partitions


### PR DESCRIPTION
This reverts commit 2786ca9cf496d31743674c4273dda9d5ce9958ca.
"fastboot format:f2fs userdata" is not supported in uefi, hence revert
this patch.

Tracked-On: OAM-88669
Signed-off-by: Zhiwei Li <zhiwei.li@intel.com>