### PR TITLE
Enable "full-screen" in launching QEMU

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -45,6 +45,7 @@ function launch_hwrender(){
 	  -device e1000,netdev=net0 \
 	  -netdev user,id=net0,hostfwd=tcp::5555-:5555 \
 	  -device intel-iommu,device-iotlb=off \
+	  -full-screen \
 	  -nodefaults
 }
 
@@ -78,6 +79,7 @@ function launch_swrender(){
 	  -device e1000,netdev=net0 \
 	  -netdev user,id=net0,hostfwd=tcp::5555-:5555 \
 	  -device intel-iommu,device-iotlb=off \
+	  -full-screen \
 	  -nodefaults
 }
 


### PR DESCRIPTION
For Android UI is booting with Full Screen, add an option in
QEMU launching. For switching back to host from Androud Full
screen, "Ctrl-Alt-F" can be used.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-88724
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>