### PR TITLE
Upgrade QEMU to 4.2.0 and enable ramfb  to support boot display.

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 reboot_required=0
+QEMU_REL=qemu-4.2.0
 
 function ubu_changes_require(){
 	echo "Please make sure your apt is working"
@@ -17,17 +18,9 @@ function ubu_install_qemu(){
 	apt autoremove -y
 	apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl1.2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc libsdl1.2-dev uuid-runtime uuid uml-utilities bridge-utils python-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0.0-dev libgtk-3-dev bison
 
-	wget https://download.qemu.org/qemu-3.0.0.tar.xz
-	tar -xf qemu-3.0.0.tar.xz
-	cd qemu-3.0.0/
-	wget https://patchwork.kernel.org/patch/10678791/raw/ -O Audio_fix.patch &&  patch -p1 < Audio_fix.patch
-	if [ $? != "0" ]; then
-		echo "Patch didn't apply"
-		echo "Please check ..."
-		exit 1
-	else
-		echo "Patch applied"
-	fi
+	wget https://download.qemu.org/$QEMU_REL.tar.xz
+	tar -xf $QEMU_REL.tar.xz
+	cd $QEMU_REL/
 	./configure --prefix=/usr \
 	    --enable-kvm \
 	    --disable-xen \
@@ -41,7 +34,7 @@ function ubu_install_qemu(){
 	    --enable-opengl \
 	    --enable-gtk \
 	    --target-list=x86_64-softmmu \
-	    --audio-drv-list=pa
+	    --audio-drv-list=alsa
 	make -j24
 	make install
 	cd ../

--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -40,6 +40,16 @@ function ubu_install_qemu(){
 	cd ../
 }
 
+function ubu_build_ovmf(){
+	sudo apt install -y uuid-dev nasm acpidump iasl
+	cd $QEMU_REL/roms/edk2
+	source ./edksetup.sh
+	make -C BaseTools/
+	build -b DEBUG -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc -D NETWORK_IP4_ENABLE -D NETWORK_ENABLE  -D SECURE_BOOT_ENABLE
+	cp Build/OvmfX64/DEBUG_GCC5/FV/OVMF.fd ../../../OVMF.fd
+	cd ../../../
+}
+
 function ubu_enable_host_gvtg(){
 	if [[ ! `cat /etc/default/grub` =~ "i915.enable_gvt=1 intel_iommu=on" ]]; then
 		read -p "The grub entry in '/etc/default/grub' will be updated for enabling GVT-g, do you want to continue? [Y/n]" res
@@ -118,6 +128,7 @@ if [[ $version =~ "Ubuntu" ]]; then
 	check_network
 	ubu_changes_require
 	ubu_install_qemu
+	ubu_build_ovmf
 	ubu_enable_host_gvtg
 	get_required_scripts
 	check_kernel

--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -46,14 +46,14 @@ common_options="\
  -device virtio-blk-pci,drive=disk1,bootindex=1 \
  -device e1000,netdev=net0 \
  -netdev user,id=net0,hostfwd=tcp::5555-:5555,hostfwd=tcp::5554-:5554 \
- -device intel-iommu,device-iotlb=off \
+ -device intel-iommu,device-iotlb=off,caching-mode=on \
  -full-screen \
  -nodefaults
 "
 
 function launch_hwrender(){
 	qemu-system-x86_64 \
-	  -device vfio-pci,sysfsdev=$GVTg_DEV_PATH/$GVTg_VGPU_UUID,display=on,x-igd-opregion=on \
+	  -device vfio-pci-nohotplug,ramfb=on,sysfsdev=$GVTg_DEV_PATH/$GVTg_VGPU_UUID,display=on,x-igd-opregion=on \
 	  $common_options
 }
 

--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -45,7 +45,7 @@ common_options="\
  -drive file=$caas_image,if=none,id=disk1 \
  -device virtio-blk-pci,drive=disk1,bootindex=1 \
  -device e1000,netdev=net0 \
- -netdev user,id=net0,hostfwd=tcp::5555-:5555 \
+ -netdev user,id=net0,hostfwd=tcp::5555-:5555,hostfwd=tcp::5554-:5554 \
  -device intel-iommu,device-iotlb=off \
  -full-screen \
  -nodefaults


### PR DESCRIPTION
ramfb is a very simple framebuffer display device.  It is intended to be configured by the firmware and used as boot framebuffer, until the guest  OS loads a real GPU driver.
ramfb is supported by qemu 4.2.0.
