### PR TITLE
reomve deprecated init copy from hwcomposer-intel

### DIFF
--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -37,15 +37,6 @@ PRODUCT_PACKAGES += \
 # PRODUCT_PROPERTY_OVERRIDES += \
 #   ro.hardware.hwcomposer=$(TARGET_GFX_INTEL)
 
-INTEL_HWC_CONFIG := $(INTEL_PATH_VENDOR)/external/hwcomposer-intel
-
-ifeq ($(findstring _acrn,$(TARGET_PRODUCT)),_acrn)
-PRODUCT_COPY_FILES += $(INTEL_HWC_CONFIG)/hwc_display_virt.ini:$(TARGET_COPY_OUT_VENDOR)/etc/hwc_display.ini
-else
-PRODUCT_COPY_FILES += $(INTEL_HWC_CONFIG)/hwc_display.ini:$(TARGET_COPY_OUT_VENDOR)/etc/hwc_display.ini
-PRODUCT_COPY_FILES += $(INTEL_HWC_CONFIG)/hwc_display.kvm.ini:$(TARGET_COPY_OUT_VENDOR)/etc/hwc_display.kvm.ini
-endif
-
 {{#minigbm}}
 # Mini gbm
 # PRODUCT_PROPERTY_OVERRIDES += \

--- a/groups/graphics/mesa/product.mk
+++ b/groups/graphics/mesa/product.mk
@@ -34,14 +34,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
    ro.hardware.hwcomposer=$(TARGET_BOARD_PLATFORM)
 
-INTEL_HWC_CONFIG := $(INTEL_PATH_VENDOR)/external/hwcomposer-intel
-
-ifeq ($(findstring _acrn,$(TARGET_PRODUCT)),_acrn)
-PRODUCT_COPY_FILES += $(INTEL_HWC_CONFIG)/hwc_display_virt.ini:$(TARGET_COPY_OUT_VENDOR)/etc/hwc_display.ini
-else
-PRODUCT_COPY_FILES += $(INTEL_HWC_CONFIG)/hwc_display.ini:$(TARGET_COPY_OUT_VENDOR)/etc/hwc_display.ini
-endif
-
 {{/drmhwc}}
 
 {{#minigbm}}


### PR DESCRIPTION
Deprecated ini files from hwcomposer-intel have been removed, so
that no need to do init copies.

Tracked-On: OAM-88753
Signed-off-by: yifang ma <yifangx.ma@intel.com>