### PR TITLE
CIV: fix QEMU 4.2 build error

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -16,7 +16,7 @@ function ubu_changes_require(){
 function ubu_install_qemu(){
 	apt purge -y "qemu*"
 	apt autoremove -y
-	apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl1.2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc libsdl1.2-dev uuid-runtime uuid uml-utilities bridge-utils python-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0.0-dev libgtk-3-dev bison
+	apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0.0-dev libgtk-3-dev bison
 
 	wget https://download.qemu.org/$QEMU_REL.tar.xz
 	tar -xf $QEMU_REL.tar.xz


### PR DESCRIPTION
    QEMU 4.2 depends on libsdl2-dev.
    install libsdl2-dev before building QEMU 4.2