### PR TITLE
Use PulseAudio as Audio backend with config change

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -42,6 +42,7 @@ common_options="\
  -chardev socket,id=charserial0,path=./kernel-console,server,nowait \
  -device isa-serial,chardev=charserial0,id=serial0 \
  -device intel-hda -device hda-duplex \
+ -audiodev id=android_spk,timer-period=5000,driver=pa \
  -drive file=$caas_image,if=none,id=disk1 \
  -device virtio-blk-pci,drive=disk1,bootindex=1 \
  -device e1000,netdev=net0 \


### PR DESCRIPTION
QEMU has default audio driver timer-period set to 10 milliseconds. This is quite long for PulseAudio, which causes audio distortion. It is solved by reducing timer-period to 5 milliseconds.

Tested Audio playback/capture on Default and USB/3.5mm devices.

Tracked-On: OAM-89014
Signed-off-by: Prashanth M, Shakthi <shakthi.prashanth.m@intel.com>