### PR TITLE
Add PulseAudio backend to QEMU at build time

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -34,7 +34,7 @@ function ubu_install_qemu(){
 	    --enable-opengl \
 	    --enable-gtk \
 	    --target-list=x86_64-softmmu \
-	    --audio-drv-list=alsa
+	    --audio-drv-list=pa
 	make -j24
 	make install
 	cd ../


### PR DESCRIPTION
QEMU audio backend needs to be configured at build time.
This commit adds PulseAudio as backend at build time.

Tracked-On: OAM-89307
Signed-off-by: Prashanth M, Shakthi <shakthi.prashanth.m@intel.com>