### PR TITLE
[Revert] [BT] Add BT usb vendor ID and product ID

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -35,7 +35,6 @@ common_options="\
  -device usb-host,vendorid=0x0eef,productid=0x7200 \
  -device usb-host,vendorid=0x222a,productid=0x0141 \
  -device usb-host,vendorid=0x222a,productid=0x0088 \
- -device usb-host,vendorid=0x8087,productid=0x0a2b \
  -device usb-mouse \
  -device usb-kbd \
  -drive file=$ovmf_file,format=raw,if=pflash \


### PR DESCRIPTION
Reverting the change which makes CIV bluetooth to operate
in USB port forwarding. This change will remove the BT control
in the VM. BT operations can only be done in Host.

Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>