### PR TITLE
Launch kvmgt module before start QEMU

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -80,6 +80,9 @@ vno=$(echo $version | \
 	}'
 )
 if [[ "$vno" > "5.0.0" ]]; then
+	if [[ "$vno" > "5.3.0" ]]; then
+		modprobe kvmgt
+	fi
 	check_nested_vt
 	setup_vgpu
 	if [[ $? == 0 ]]; then


### PR DESCRIPTION
on host linux kernel higher than 5.3.0, kvmgt not launched by default.
need to launch kvmgt module before start QEMU.
otherwise, VGPU can't be created and android UI will not be shown.

Tracked-On:OAM-89705
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>