### PR TITLE
civ: load kvmgt/vfio modules when host startup

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -59,6 +59,10 @@ function ubu_enable_host_gvtg(){
 		fi
 		sed -i "s/GRUB_CMDLINE_LINUX=\"/GRUB_CMDLINE_LINUX=\"i915.enable_gvt=1 intel_iommu=on /g" /etc/default/grub
 		update-grub
+
+		echo -e "\nkvmgt\nvfio-iommu-type1\nvfio-mdev\n" >> /etc/initramfs-tools/modules
+		update-initramfs -u -k all
+
 		reboot_required=1
 	fi
 }

--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -114,9 +114,6 @@ vno=$(echo $version | \
 	}'
 )
 if [[ "$vno" > "5.0.0" ]]; then
-	if [[ "$vno" > "5.3.0" ]]; then
-		modprobe kvmgt
-	fi
 	check_nested_vt
 	setup_vgpu
 	if [[ $? == 0 ]]; then


### PR DESCRIPTION
refine setup_host.sh to load kvmgt/vfio modules when host startup.
remove "modprobe kvmgt" from start_android_qcow2.sh

Tracked-On:OAM-89719
Signed-off-by: Qi Yadong <yadong.qi@intel.com>