### PR TITLE
Caas: Update script with an option to enable ADB

### DIFF
--- a/groups/device-specific/caas/adb.sh
+++ b/groups/device-specific/caas/adb.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+sleep 4
+echo "adb setup"
+adb kill-server
+adb wait-for-device devices
+adb wait-for-device root
+adb shell "echo dwc3.1.auto > /config/usb_gadget/g1/UDC"
+adb shell "setprop sys.usb.controller dwc3.1.auto"
+echo "done"

--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -77,6 +77,31 @@ function launch_hwrender(){
 		echo -n "Android started successfully and is running in background, pid of the process is:"
 		cat android_vm.pid
 		echo -ne '\n'
+	elif [[ ($1 == "--display-off") && ($2 == "--usb-adb") ]]
+	then
+		echo device > /sys/class/usb_role/intel_xhci_usb_sw-role-switch/role
+		echo 0000:00:14.1 > /sys/bus/pci/devices/0000\:00\:14.1/driver/unbind
+		modprobe vfio-pci
+		echo 8086 9d30 > /sys/bus/pci/drivers/vfio-pci/new_id
+		sh adb.sh &
+		qemu-system-x86_64 \
+                -device vfio-pci-nohotplug,ramfb=$ramfb_state,sysfsdev=$GVTg_DEV_PATH/$GVTg_VGPU_UUID,display=$display_state,x-igd-opregion=on \
+		-device vfio-pci,host=00:14.1,id=dwc3,addr=0x14,x-no-kvm-intx=on \
+                $common_options &
+                sleep 5
+                echo -n "Android started successfully and is running in background, pid of the process is:"
+                cat android_vm.pid
+	elif [[ $1 == "--usb-adb" ]]
+	then
+		echo device > /sys/class/usb_role/intel_xhci_usb_sw-role-switch/role
+		echo 0000:00:14.1 > /sys/bus/pci/devices/0000\:00\:14.1/driver/unbind
+		modprobe vfio-pci
+		echo 8086 9d30 > /sys/bus/pci/drivers/vfio-pci/new_id
+		sh adb.sh &
+		qemu-system-x86_64 \
+		-device vfio-pci-nohotplug,ramfb=$ramfb_state,sysfsdev=$GVTg_DEV_PATH/$GVTg_VGPU_UUID,display=$display_state,x-igd-opregion=on \
+		-device vfio-pci,host=00:14.1,id=dwc3,addr=0x14,x-no-kvm-intx=on \
+		$common_options
 	else
 		qemu-system-x86_64 \
 		-device vfio-pci-nohotplug,ramfb=$ramfb_state,sysfsdev=$GVTg_DEV_PATH/$GVTg_VGPU_UUID,display=$display_state,x-igd-opregion=on \


### PR DESCRIPTION
Add an option in Android VM launch script to enable
ADB over debugging.

Tracked-On: OAM-89728
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>