### PR TITLE
Disable Bluetooth profiles when BT is disabled

### DIFF
--- a/groups/bluetooth/false/product.mk
+++ b/groups/bluetooth/false/product.mk
@@ -1,1 +1,3 @@
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += config.disable_bluetooth=true
+DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/bluetooth/overlay-bt-disable
+

--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -49,7 +49,6 @@ common_options="\
  -device usb-host,vendorid=0x0eef,productid=0x7200 \
  -device usb-host,vendorid=0x222a,productid=0x0141 \
  -device usb-host,vendorid=0x222a,productid=0x0088 \
- -device usb-host,vendorid=0x8087,productid=0x0a2b \
  -device usb-mouse \
  -device usb-kbd \
  -drive file=$ovmf_file,format=raw,if=pflash \


### PR DESCRIPTION
Even if BT is disabled, OPP profile option will be
shown in the file share option. Remove the profile
when BT is disabled so that OPP file share option is not
listed

Tracked-On:
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>