### PR TITLE
boot-arch: using BoringSSL instead of OpenSSL

### DIFF
--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -2,7 +2,7 @@ TARGET_UEFI_ARCH := {{{uefi_arch}}}
 
 # Android Kernelflinger uses the OpenSSL library to support the
 # bootloader policy
-KERNELFLINGER_SSL_LIBRARY := openssl
+KERNELFLINGER_SSL_LIBRARY := boringssl
 
 {{^use_cic}}
 BIOS_VARIANT := {{{bios_variant}}}


### PR DESCRIPTION
Tracked-On: OAM-90303
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>