### PR TITLE
CIV: add -smbios parameter in launch script

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -11,7 +11,7 @@ function ubu_changes_require(){
 	if [ x$res = xn ]; then
 		exit 0
 	fi
-	apt install -y wget mtools ovmf
+	apt install -y wget mtools ovmf dmidecode
 }
 
 function ubu_install_qemu(){

--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -32,6 +32,8 @@ else
         display_state="on"
 fi
 
+smbios_serialno=$(dmidecode -t 2 | grep -i serial | awk '{print $3}')
+
 common_options="\
  -m 2048 -smp 2 -M q35 \
  -name caas-vm \
@@ -65,6 +67,7 @@ common_options="\
  -full-screen \
  -fsdev local,security_model=none,id=fsdev0,path=./share_folder \
  -device virtio-9p-pci,fsdev=fsdev0,mount_tag=hostshare \
+ -smbios "type=2,serial=$smbios_serialno"
  -nodefaults
 "
 function wifi_passthrough(){


### PR DESCRIPTION
This patch read mainboard serial no of host, append a random and pass
to guest machine by QEMU -smbios parameter

Tracked-On: OAM-90314
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>