### PR TITLE
graphics/media: Handle case when fb is set to i915drmfb

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -1,5 +1,18 @@
 auto_hal() {
 case "$(cat /proc/fb)" in
+        *i915drmfb)
+                echo "intel"
+                setprop ro.hardware.hwcomposer intel
+                setprop ro.hardware.gralloc intel
+                case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
+                        QEMU)
+                                setprop ro.graphics.hwcomposer.kvm true
+                                ;;
+                        *)
+                                setprop ro.graphics.hwcomposer.kvm false
+                                ;;
+                esac
+                ;;
         *inteldrmfb)
                 echo "intel"
                 setprop ro.hardware.hwcomposer intel

--- a/groups/media/auto/auto_hal.in
+++ b/groups/media/auto/auto_hal.in
@@ -1,10 +1,14 @@
 auto_hal() {
-case "$(cat /proc/fb | head -1)" in
-        0*inteldrmfb)
+case "$(cat /proc/fb)" in
+        *i915drmfb)
                 echo "intel"
                 setprop vendor.intel.video.codec hardware
                 ;;
-        0*)
+        *inteldrmfb)
+                echo "intel"
+                setprop vendor.intel.video.codec hardware
+                ;;
+        *)
                 echo "software codec"
                 setprop vendor.intel.video.codec software
                 ;;


### PR DESCRIPTION
When framebuffer is set to i915drmfb, graphics and media
properties are not set resulting in device not booting and
audio/video sync issues.

Fix the issue by setting hwcomposer, gralloc and codec
properties for frame buffer i915drmfb case.

Tracked-On: OAM-90359
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Yang, Dong <dong.yang@intel.com>