### PR TITLE
Porting Health Monitoring Service along with Storage HAL to

### DIFF
--- a/groups/device-specific/cic/cic.mk
+++ b/groups/device-specific/cic/cic.mk
@@ -45,6 +45,8 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/manifest.xml:$(TARGET_COPY_OUT_VENDOR)/manifest.xml \
     out/target/product/$(TARGET_PRODUCT)/system/bin/sdcard-fuse:system/bin/sdcard \
 
+PRODUCT_PACKAGES += android.hardware.health@2.0-service.intel
+
 PRODUCT_NAME := cic
 PRODUCT_DEVICE := cic
 PRODUCT_BRAND := Intel


### PR DESCRIPTION
enabling health service by adding package details in .mk file.

Changes done:
1.Storage Metrics enabled along with this permission.
2. Health Service package name is added.

Tracked-On: OAM-90485
Signed-off-by: tkaur <taranpreet.kaur@intel.com>