### PR TITLE
Added changes for dynamic BT passthrough switch

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -45,6 +45,28 @@ for each in $@
                 break
 	fi
 done
+BT_PT="true"
+
+for each in $@
+	do
+	if [[ $each == "--bt-host" ]]
+	then
+		BT_PT="false"
+		echo BT_PT: $BT_PT
+		break
+	fi
+done
+
+if [ $BT_PT = "true" ]
+then
+	bt_passthrough="-device usb-host,vendorid=0x8087,productid=0x0a2b \
+	-device usb-host,vendorid=0x8087,productid=0x0025 \
+	-device usb-host,vendorid=0x8087,productid=0x0026 \
+	-device usb-host,vendorid=0x8087,productid=0x0029 \
+	-device usb-host,vendorid=0x8087,productid=0x0aaa \
+	-device usb-host,vendorid=0x8087,productid=0x0aa7
+	"
+fi
 
 smbios_serialno=$(dmidecode -t 2 | grep -i serial | awk '{print $3}')
 
@@ -65,7 +87,7 @@ common_options="\
  -device usb-host,vendorid=0x0eef,productid=0x7200 \
  -device usb-host,vendorid=0x222a,productid=0x0141 \
  -device usb-host,vendorid=0x222a,productid=0x0088 \
- -device usb-host,vendorid=0x8087,productid=0x0a2b \
+ $bt_passthrough \
  -device usb-mouse \
  -device usb-kbd \
  -drive file=$ovmf_file,format=raw,if=pflash \


### PR DESCRIPTION
Added BT host controller command line argument, so that
user can choose b/w host controlled or VM controlled
functionality. If user does not choose any option BT will
be passthrough

Tracked-On: OAM-90571
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>