### PR TITLE
SELinux: set file label for health hwservice

### DIFF
--- a/groups/device-specific/cic/sepolicy/file_contexts
+++ b/groups/device-specific/cic/sepolicy/file_contexts
@@ -9,3 +9,5 @@
 # Docker will remove the /etc link and create a directory to override some files
 # such as /etc/hosts, /etc/hostname, etc.
 /etc(/.*)?                  u:object_r:system_file:s0
+
+/(vendor|system/vendor)/bin/hw/android\.hardware\.health@2\.0-service\.intel         u:object_r:hal_health_default_exec:s0


### PR DESCRIPTION
android.hardware.health@2.0-service.intel is added to CIC, but the relevant sepolicy is not added for it, this may introduce boot issue.

Tracked-On: OAM-90587
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>