### PR TITLE
CIC: Solve build issue for Android Verified Boot in mixins

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -1,3 +1,6 @@
+BOARD_BOOTIMAGE_PARTITION_SIZE ?= 31457280
+BOARD_TOSIMAGE_PARTITION_SIZE := 10485760
+
 {{^use_cic}}
 #
 # -- OTA RELATED DEFINES --
@@ -19,12 +22,10 @@ TARGET_RECOVERY_PIXEL_FORMAT := "BGRA_8888"
 #
 
 # NOTE: These values must be kept in sync with BOARD_GPT_INI
-BOARD_BOOTIMAGE_PARTITION_SIZE ?= 31457280
 SYSTEM_PARTITION_SIZE = $(shell echo {{system_partition_size}}*1024*1024 | bc)
 {{^dynamic-partitions}}
 BOARD_SYSTEMIMAGE_PARTITION_SIZE ?= $(SYSTEM_PARTITION_SIZE)
 {{/dynamic-partitions}}
-BOARD_TOSIMAGE_PARTITION_SIZE := 10485760
 BOARD_BOOTLOADER_PARTITION_SIZE ?= $$(({{bootloader_len}} * 1024 * 1024))
 BOARD_BOOTLOADER_BLOCK_SIZE := {{{bootloader_block_size}}}
 {{^slot-ab}}

--- a/groups/device-specific/cic/addon/pre-requisites/secure
+++ b/groups/device-specific/cic/addon/pre-requisites/secure
@@ -8,6 +8,10 @@ teedata=`sudo parted -l | grep -i teedata`
 trusty_host=`dmesg | grep trusty`
 tos_img=`dmesg | grep trusty | grep 'error -22'`
 trusty_init=`dmesg | grep trusty | grep 'initializ'`
+tos_dev=`sudo blkid | grep "\"tos\"" | awk '{print $1}' | tr -d ':'`
+vbmeta_dev=`sudo blkid | grep "\"vbmeta\"" | awk '{print $1}' | tr -d ':'`
+tos_dev_sec_num=`sudo fdisk -l | grep $tos_dev | awk '{print $4}'`
+vbmeta_dev_sec_num=`sudo fdisk -l | grep $vbmeta_dev | awk '{print $4}'`
 
 
 ### If trusty is enabled
@@ -24,6 +28,38 @@ if [[ $trusty_host == "" && $security == "true" ]]; then
     echo "Trusty not enabled in kernel"
     echo "Please install trusty drivers in host kernel"
     echo "security : $security"
+fi
+
+## flash tos and vbmeta to partitions
+if [[ $security == "true" ]]; then
+    if [[ -z $tos_dev || -z $vbmeta_dev ]]; then
+        echo "Partition /tos[10MB] and /vbmeta[1MB] should be present"
+        echo "Please create them"
+        exit -1
+    else
+        tos_img_size=`du -b $AIC_WORK_DIR/tos.img | awk '{print $1}'`
+        vbmeta_img_size=`du -b $AIC_WORK_DIR/vbmeta.img | awk '{print $1}'`
+
+        if [[ $tos_img_size -gt `expr $tos_dev_sec_num\*512` ]]; then
+            echo "error: tos image size is bigger than tos partition size"
+            exit -1
+        fi
+
+        if [[ $vbmeta_img_size -gt `expr $vbmeta_dev_sec_num\*512` ]]; then
+            echo "error: vbmeta image size is bigger than vbmeta partition size"
+            exit -1
+        fi
+
+        tos_blk_count=`expr ${tos_img_size} / 512`
+        vbmeta_blk_count=`expr $vbmeta_img_size / 512`
+
+        echo "flash tos and vbmeta to partitions"
+        sudo dd if=/dev/zero of=${vbmeta_dev} bs=512 count=$vbmeta_dev_sec_num
+        sudo dd if=/dev/zero of=${tos_dev} bs=512 count=$tos_dev_sec_num
+
+        sudo dd if=$AIC_WORK_DIR/vbmeta.img of=${vbmeta_dev} bs=512 count=$vbmeta_blk_count
+        sudo dd if=$AIC_WORK_DIR/tos.img of=${tos_dev} bs=512 count=$tos_blk_count
+    fi
 fi
 
 ## copy KF and tos to ubuntu

--- a/groups/device-specific/cic_dev/AndroidBoard.mk
+++ b/groups/device-specific/cic_dev/AndroidBoard.mk
@@ -44,6 +44,12 @@ else
 	@echo Nothing todo
 endif
 
+ifeq ($(BOARD_AVB_ENABLE),true)
+VBMETA_IMG := vbmeta.img
+else
+VBMETA_IMG :=
+endif
+
 .PHONY: aic
 aic: .KATI_NINJA_POOL := console
 aic: multidroid tosimage
@@ -54,7 +60,7 @@ else
 	BUILD_VARIANT=loop_mount $(HOST_OUT_EXECUTABLES)/aic-build -b $(BUILD_NUMBER)
 endif
 ifneq (,$(filter cic cic_dev,$(TARGET_PRODUCT)))
-	tar cvzf $(PRODUCT_OUT)/$(TARGET_AIC_FILE_NAME) -C $(PRODUCT_OUT) aic android.tar.gz aic-manager.tar.gz cfc ia_hwc pre-requisites sof_audio README-CIC INFO cic.sh setup-aic tos.img kf4cic.efi verity_metadata -C docker update
+	tar cvzf $(PRODUCT_OUT)/$(TARGET_AIC_FILE_NAME) -C $(PRODUCT_OUT) aic android.tar.gz aic-manager.tar.gz cfc ia_hwc pre-requisites sof_audio README-CIC INFO cic.sh setup-aic tos.img $(VBMETA_IMG) kf4cic.efi verity_metadata -C docker update
 	@echo Make debian binaries...
 	$(hide) (rm -rf $(PRODUCT_OUT)/cic && mkdir -p $(PRODUCT_OUT)/cic/opt/cic && mkdir -p $(PRODUCT_OUT)/cic/etc/profile.d)
 	$(hide) (cd $(PRODUCT_OUT)/cic/opt/cic && tar xvf ../../../$(TARGET_AIC_FILE_NAME) aic android.tar.gz aic-manager.tar.gz INFO cic.sh cfc update)


### PR DESCRIPTION
1. Solve build issue while enabling Android Verified Boot for CIC
2. Add vbmeta.image to cic build packages if AVB is enabled

Tracked-On: OAM-90660
Signed-off-by: Chen Gang G <gang.g.chen@intel.com>