### PR TITLE
Restart logcatd service with new parameters correctly

### DIFF
--- a/groups/debug-crashlogd/true/init.crashlogd.rc
+++ b/groups/debug-crashlogd/true/init.crashlogd.rc
@@ -18,13 +18,13 @@ on property:persist.vendor.service.aplogfs.enable=0 && property:persist.vendor.s
 
 on property:persist.vendor.service.aplogfs.enable=1
     setprop persist.vendor.service.apklogfs.enable 0
-    setprop persist.logd.logpersistd stop
+    setprop logd.logpersistd stop
     setprop persist.logd.logpersistd.buffer main,system,radio,events,crash
     setprop persist.logd.logpersistd logcatd
 
 on property:persist.vendor.service.apklogfs.enable=1
     setprop persist.vendor.service.aplogfs.enable 0
-    setprop persist.logd.logpersistd stop
+    setprop logd.logpersistd stop
     setprop persist.logd.logpersistd.buffer all
     setprop persist.logd.logpersistd logcatd
 


### PR DESCRIPTION
Setting persist.logd.logpersistd to stop will not trigger logcatd service restart with new parameters. So set logd.logpersistd to stop directly.

Tracked-On: OAM-90655
Signed-off-by: Jingdong Lu <jingdong.lu@intel.com>