### PR TITLE
Enable SOF Audio on CML Hardware

### DIFF
--- a/groups/device-specific/cic/addon/cic.sh
+++ b/groups/device-specific/cic/addon/cic.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-snd_load=`lsmod | grep -i snd_dummy`
-
-if [[ -z $snd_load ]]; then
-  /sbin/modprobe snd-dummy
-fi
-
 /bin/bash aic $1

--- a/groups/device-specific/cic/addon/setup-aic
+++ b/groups/device-specific/cic/addon/setup-aic
@@ -261,6 +261,7 @@ sudo systemctl enable cic
 #Run pactl
 if [[ $AUDIO_MT == "true" ]]; then
   ./pre-requisites/pactl_socket $(whoami)
+  ./sof_audio/configure_sof.sh "install" $AIC_WORK_DIR
 fi
 if [[ $AUDIO_PT == "true" ]]; then
   sudo rm -rf /etc/profile.d/create_pasocket.sh

--- a/groups/device-specific/cic/addon/sof_audio/blacklist-dsp.conf
+++ b/groups/device-specific/cic/addon/sof_audio/blacklist-dsp.conf
@@ -1,0 +1,10 @@
+blacklist snd\_soc\_sst\_acpi
+blacklist snd\_soc\_sst\_dsp
+blacklist snd\_soc\_sst\_firmware
+blacklist snd\_soc\_sst\_ipc
+blacklist snd\_soc\_sst\_match
+blacklist snd\_soc\_skl
+blacklist snd\_soc\_sst\_byt\_cht\_nocodec
+blacklist snd\_intel\_sst\_acpi
+blacklist snd\_intel\_sst\_core
+blacklist snd\_hda\_intel

--- a/groups/device-specific/cic/addon/sof_audio/configure_sof.sh
+++ b/groups/device-specific/cic/addon/sof_audio/configure_sof.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+SOFBIN_TPLGS="sof-bin/lib/firmware/intel/sof-tplg-v1.4.2/"
+SOFBIN_FWS="sof-bin/lib/firmware/intel/sof/v1.4.2/"
+LIB_TPLG="/lib/firmware/intel/sof-tplg/"
+LIB_FW="/lib/firmware/intel/sof/"
+BLACKLIST_HDA_CONF="/etc/modprobe.d/blacklist-dsp.conf"
+SOF_WORK_DIR="$2/sof_audio"
+USAGE="Usage : configure_sof.sh install/uninstall WorkingDir"
+
+function setupSof {
+    cd $SOF_WORK_DIR
+    if [ -d "$LIB_FW" ]; then
+        if [ ! -d "sof_bkp" ]; then
+            sudo mv $LIB_FW "sof_bkp"
+        fi
+    fi
+    if [ -d "$LIB_TPLG" ]; then
+        if [ ! -d "sof-tplg_bkp" ]; then
+            sudo mv $LIB_TPLG "sof-tplg_bkp"
+        fi
+    fi
+    if [ -f "$BLACKLIST_HDA_CONF" ]; then
+        if [ ! -f "blacklist_hda_bkp" ]; then
+            sudo mv $BLACKLIST_HDA_CONF "blacklist_hda_bkp"
+        fi
+    fi
+    sudo mkdir $LIB_FW
+    sudo mkdir $LIB_TPLG
+
+    rm -rf sof-bin
+    git clone https://github.com/thesofproject/sof-bin -b stable-v1.4.2
+    if [ ! -d "sof-bin" ]; then
+        echo "Failed to download https://github.com/thesofproject/sof-bin/tree/stable-v1.4.2"
+        exit -1
+    fi
+    sudo cp "${SOFBIN_TPLGS}sof-hda-generic-4ch.tplg" $LIB_TPLG
+    sudo cp "${SOFBIN_TPLGS}sof-hda-generic-2ch.tplg" $LIB_TPLG
+    sudo cp "${SOFBIN_TPLGS}sof-hda-generic.tplg" $LIB_TPLG
+    sudo cp "${SOFBIN_FWS}intel-signed/sof-cnl-v1.4.2.ri" "${LIB_FW}sof-cml.ri"
+    sudo cp "${SOFBIN_FWS}intel-signed/sof-cnl-v1.4.2.ri" "${LIB_FW}sof-cnl.ri"
+    sudo cp "blacklist-dsp.conf" $BLACKLIST_HDA_CONF
+}
+
+function restore {
+    cd $SOF_WORK_DIR
+    sudo rm -rf $LIB_FW
+    sudo rm -rf $LIB_TPLG
+    if [ -d "sof_bkp" ]; then
+        sudo mv "sof_bkp" $LIB_FW
+    fi
+    if [ -d "sof-tplg_bkp" ]; then
+        sudo mv "sof-tplg_bkp" $LIB_TPLG
+    fi
+    if [ -f "blacklist_hda_bkp" ]; then
+        sudo mv "blacklist_hda_bkp" $BLACKLIST_HDA_CONF
+    fi
+}
+
+if [[ ! -d $SOF_WORK_DIR ]]; then
+    echo "Error : $SOF_WORK_DIR does not exist"
+    echo $USAGE
+    exit -1
+fi
+
+echo "SOF_WORK_DIR=$SOF_WORK_DIR"
+
+if [[ $1 == "install" ]]; then
+    setupSof
+else
+    if [[ $1 == "uninstall" ]]; then
+        restore
+    else
+        echo $USAGE
+        exit -1
+    fi
+fi
+

--- a/groups/device-specific/cic_dev/AndroidBoard.mk
+++ b/groups/device-specific/cic_dev/AndroidBoard.mk
@@ -33,7 +33,7 @@ TARGET_AIC_FILE_NAME := $(TARGET_PRODUCT)-aic-$(BUILD_NUMBER).tar.gz
 addon:
 ifneq (,$(filter cic cic_dev,$(TARGET_PRODUCT)))
 	@echo Make additional release binaries/files...
-	$(hide) rm -rf $(PRODUCT_OUT)/cfc $(PRODUCT_OUT)/pre-requisites  $(PRODUCT_OUT)/README-CIC  $(PRODUCT_OUT)/ia_hwc $(PRODUCT_OUT)/setup-aic $(PRODUCT_OUT)/INFO
+	$(hide) rm -rf $(PRODUCT_OUT)/cfc $(PRODUCT_OUT)/pre-requisites $(PRODUCT_OUT)/sof_audio  $(PRODUCT_OUT)/README-CIC  $(PRODUCT_OUT)/ia_hwc $(PRODUCT_OUT)/setup-aic $(PRODUCT_OUT)/INFO
 	$(hide) cp -r $(TOP)/device/intel/project-celadon/$(TARGET_PRODUCT)/addon/* $(TOP)/vendor/intel/cic/host/cfc $(TOP)/vendor/intel/cic/target/graphics/ia_hwc $(PRODUCT_OUT)/.
 	$(hide) cp -r $(TOP)/vendor/intel/cic/README $(PRODUCT_OUT)/INFO
 	$(hide) cp $(TOP)/device/intel/project-celadon/$(TARGET_PRODUCT)/addon/cic.sh $(PRODUCT_OUT)
@@ -51,7 +51,7 @@ else
 	BUILD_VARIANT=loop_mount $(HOST_OUT_EXECUTABLES)/aic-build -b $(BUILD_NUMBER)
 endif
 ifneq (,$(filter cic cic_dev,$(TARGET_PRODUCT)))
-	tar cvzf $(PRODUCT_OUT)/$(TARGET_AIC_FILE_NAME) -C $(PRODUCT_OUT) aic android.tar.gz aic-manager.tar.gz cfc ia_hwc pre-requisites README-CIC INFO cic.sh setup-aic tos.img kf4cic.efi -C docker update
+	tar cvzf $(PRODUCT_OUT)/$(TARGET_AIC_FILE_NAME) -C $(PRODUCT_OUT) aic android.tar.gz aic-manager.tar.gz cfc ia_hwc pre-requisites sof_audio README-CIC INFO cic.sh setup-aic tos.img kf4cic.efi -C docker update
 	@echo Make debian binaries...
 	$(hide) (rm -rf $(PRODUCT_OUT)/cic && mkdir -p $(PRODUCT_OUT)/cic/opt/cic && mkdir -p $(PRODUCT_OUT)/cic/etc/profile.d)
 	$(hide) (cd $(PRODUCT_OUT)/cic/opt/cic && tar xvf ../../../$(TARGET_AIC_FILE_NAME) aic android.tar.gz aic-manager.tar.gz INFO cic.sh cfc update)


### PR DESCRIPTION
Copy the required firmware and topology files for SOF
into the device lib path for listing sof audio devices.
Disable snd-dummy module as it is only required for Commercial KBL.
Blacklist the legacy hda_intel driver to pick only sof.

Tracked-On: OAM-90683
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>