### PR TITLE
Enable SOF Audio on CML Hardware

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -182,6 +182,11 @@ function get_required_scripts(){
 	wget https://raw.githubusercontent.com/projectceladon/device-androidia-mixins/master/groups/device-specific/caas/start_android_qcow2.sh
 	wget https://raw.githubusercontent.com/projectceladon/device-androidia-mixins/master/groups/device-specific/caas/auto_switch_pt_usb_vms.sh
 	wget https://raw.githubusercontent.com/projectceladon/device-androidia-mixins/master/groups/device-specific/caas/findall.py
+	wget https://raw.githubusercontent.com/projectceladon/device-androidia-mixins/master/groups/device-specific/caas/sof_audio/configure_sof.sh
+	wget https://raw.githubusercontent.com/projectceladon/device-androidia-mixins/master/groups/device-specific/caas/sof_audio/blacklist-dsp.conf
+	chmod +x configure_sof.sh
+	mkdir $CIV_WORK_DIR/sof_audio
+	mv -t $CIV_WORK_DIR/sof_audio configure_sof.sh blacklist-dsp.conf
 	chmod +x auto_switch_pt_usb_vms.sh
 	chmod +x findall.py
 	chmod +x start_flash_usb.sh
@@ -231,7 +236,11 @@ if [[ $version =~ "Ubuntu" ]]; then
 		ubu_build_ovmf
 		ubu_enable_host_gvtg
 	fi
+	if [[ ! -d $CIV_WORK_DIR/sof_audio ]]; then
+		reboot_required=1
+	fi
 	get_required_scripts
+	./sof_audio/configure_sof.sh "install" $CIV_WORK_DIR
 	install_9p_module
 	ask_reboot
 

--- a/groups/device-specific/caas/sof_audio/blacklist-dsp.conf
+++ b/groups/device-specific/caas/sof_audio/blacklist-dsp.conf
@@ -1,0 +1,10 @@
+blacklist snd\_soc\_sst\_acpi
+blacklist snd\_soc\_sst\_dsp
+blacklist snd\_soc\_sst\_firmware
+blacklist snd\_soc\_sst\_ipc
+blacklist snd\_soc\_sst\_match
+blacklist snd\_soc\_skl
+blacklist snd\_soc\_sst\_byt\_cht\_nocodec
+blacklist snd\_intel\_sst\_acpi
+blacklist snd\_intel\_sst\_core
+blacklist snd\_hda\_intel

--- a/groups/device-specific/caas/sof_audio/configure_sof.sh
+++ b/groups/device-specific/caas/sof_audio/configure_sof.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+SOFBIN_TPLGS="sof-bin/lib/firmware/intel/sof-tplg-v1.4.2/"
+SOFBIN_FWS="sof-bin/lib/firmware/intel/sof/v1.4.2/"
+LIB_TPLG="/lib/firmware/intel/sof-tplg/"
+LIB_FW="/lib/firmware/intel/sof/"
+BLACKLIST_HDA_CONF="/etc/modprobe.d/blacklist-dsp.conf"
+SOF_WORK_DIR="$2/sof_audio"
+USAGE="Usage : configure_sof.sh install/uninstall WorkingDir"
+
+function setupSof {
+    cd $SOF_WORK_DIR
+    if [ -d "$LIB_FW" ]; then
+        if [ ! -d "sof_bkp" ]; then
+            sudo mv $LIB_FW "sof_bkp"
+        fi
+    fi
+    if [ -d "$LIB_TPLG" ]; then
+        if [ ! -d "sof-tplg_bkp" ]; then
+            sudo mv $LIB_TPLG "sof-tplg_bkp"
+        fi
+    fi
+    if [ -f "$BLACKLIST_HDA_CONF" ]; then
+        if [ ! -f "blacklist_hda_bkp" ]; then
+            sudo mv $BLACKLIST_HDA_CONF "blacklist_hda_bkp"
+        fi
+    fi
+    sudo mkdir $LIB_FW
+    sudo mkdir $LIB_TPLG
+
+    rm -rf sof-bin
+    git clone https://github.com/thesofproject/sof-bin -b stable-v1.4.2
+    if [ ! -d "sof-bin" ]; then
+        echo "Failed to download https://github.com/thesofproject/sof-bin/tree/stable-v1.4.2"
+        exit -1
+    fi
+    sudo cp "${SOFBIN_TPLGS}sof-hda-generic-4ch.tplg" $LIB_TPLG
+    sudo cp "${SOFBIN_TPLGS}sof-hda-generic-2ch.tplg" $LIB_TPLG
+    sudo cp "${SOFBIN_TPLGS}sof-hda-generic.tplg" $LIB_TPLG
+    sudo cp "${SOFBIN_FWS}intel-signed/sof-cnl-v1.4.2.ri" "${LIB_FW}sof-cml.ri"
+    sudo cp "${SOFBIN_FWS}intel-signed/sof-cnl-v1.4.2.ri" "${LIB_FW}sof-cnl.ri"
+    #sudo cp "blacklist-dsp.conf" $BLACKLIST_HDA_CONF
+}
+
+function restore {
+    cd $SOF_WORK_DIR
+    sudo rm -rf $LIB_FW
+    sudo rm -rf $LIB_TPLG
+    sudo rm $BLACKLIST_HDA_CONF
+    if [ -d "sof_bkp" ]; then
+        sudo mv "sof_bkp" $LIB_FW
+    fi
+    if [ -d "sof-tplg_bkp" ]; then
+        sudo mv "sof-tplg_bkp" $LIB_TPLG
+    fi
+    if [ -f "blacklist_hda_bkp" ]; then
+        sudo mv "blacklist_hda_bkp" $BLACKLIST_HDA_CONF
+    fi
+}
+
+if [[ ! -d $SOF_WORK_DIR ]]; then
+    echo "Error : $SOF_WORK_DIR does not exist"
+    echo $USAGE
+    exit -1
+fi
+
+echo "SOF_WORK_DIR=$SOF_WORK_DIR"
+
+if [[ $1 == "install" ]]; then
+    setupSof
+else
+    if [[ $1 == "uninstall" ]]; then
+        restore
+    else
+        echo $USAGE
+        exit -1
+    fi
+fi
+


### PR DESCRIPTION
Copy the required firmware and topology files for SOF
into the device lib path for listing sof audio devices.
Blacklist the legacy hda_intel driver to pick only sof.

Tracked-On: OAM-90701
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>