### PR TITLE
Specify HuC/GuC FW path

### DIFF
--- a/groups/codecs/configurable/media_codecs.xml
+++ b/groups/codecs/configurable/media_codecs.xml
@@ -211,7 +211,6 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
 {{/hw_ve_h265}}
     </Encoders>
-    <Include href="media_codecs_google_video.xml" />
     <Include href="media_codecs_google_audio.xml" />
     <Settings>
         <Setting name="max-video-encoder-input-buffers" value="9" />

--- a/groups/codecs/configurable/media_codecs_vp9.xml
+++ b/groups/codecs/configurable/media_codecs_vp9.xml
@@ -210,7 +210,6 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
 {{/hw_ve_h265}}
     </Encoders>
-    <Include href="media_codecs_google_video.xml" />
     <Include href="media_codecs_google_audio.xml" />
     <Settings>
         <Setting name="max-video-encoder-input-buffers" value="9" />

--- a/groups/codecs/configurable/product.mk
+++ b/groups/codecs/configurable/product.mk
@@ -1,7 +1,6 @@
 # Audio/video codec support.
 PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:vendor/etc/media_codecs_google_audio.xml \
-    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:vendor/etc/media_codecs_google_video.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/{{profile_file}}:vendor/etc/media_profiles_V1_0.xml
 
 ifeq ($(BASE_YOCTO_KERNEL),true)


### PR DESCRIPTION
This change is to specify huc/guc fw path in yocto kernel.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-83943
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>