### PR TITLE
add dm-verity support for cic

### DIFF
--- a/groups/device-specific/cic/addon/setup-aic
+++ b/groups/device-specific/cic/addon/setup-aic
@@ -211,9 +211,17 @@ echo "Installing CIC -- DONE"
 a=`grep GRUB_CMDLINE_LINUX /etc/default/grub | grep -i 'androidboot.selinux=permissive'`
 b=`grep GRUB_CMDLINE_LINUX /etc/default/grub | grep -i 'androidboot.selinux=enforcing'`
 
+VERITY_METADATA_IMG=$AIC_WORK_DIR/verity_metadata
+
 if [[ $SECURE == "true" ]]; then
   if [ ! -z "$a" ]; then
     sudo sed -i 's/androidboot.selinux=permissive//g' /etc/default/grub
+  fi
+
+  #Copying the verity metadata images
+  if [[ -f $VERITY_METADATA_IMG ]]; then
+    echo "copying the verity metadta to aic-manager"
+    sudo docker cp $VERITY_METADATA_IMG aic-manager:/images
   fi
 fi
 if [[ $SECURE == "false" ]]; then

--- a/groups/device-specific/cic/cic.mk
+++ b/groups/device-specific/cic/cic.mk
@@ -27,6 +27,11 @@ PRODUCT_CHARACTERISTICS := tablet
 PRODUCT_AAPT_CONFIG := normal large xlarge mdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := mdpi
 
+{{#dm_verity}}
+TARGET_LOOP_MOUNT_SYSTEM_IMAGES := true
+TARGET_DM_VERITY_SUPPORT := true
+{{/dm_verity}}
+
 INTEL_PATH_DEVICE_CIC := device/intel/project-celadon/$(TARGET_PRODUCT)
 INTEL_PATH_KERNEL_MODULES_CIC := kernel/modules/cic
 INTEL_PATH_VENDOR_CIC := vendor/intel/cic

--- a/groups/device-specific/cic_dev/AndroidBoard.mk
+++ b/groups/device-specific/cic_dev/AndroidBoard.mk
@@ -24,6 +24,11 @@ else
 	$(hide) cp -r $(PRODUCT_OUT)/system/etc $(PRODUCT_OUT)/docker/android/root
 	$(hide) rm -rf $(PRODUCT_OUT)/docker/aic-manager/images
 	$(hide) mkdir -p $(PRODUCT_OUT)/docker/aic-manager/images
+ifeq ($(TARGET_DM_VERITY_SUPPORT), true)
+	$(hide) cp $(PRODUCT_OUT)/cic_veritysetup $(PRODUCT_OUT)/docker/aic-manager/images
+	$(hide) rm -rf $(INSTALLED_VERITY_METADATA_IMG)
+	$(hide) python $(HOST_OUT_EXECUTABLES)/build_verity_img.py $(PRODUCT_OUT)/system.img $(PRODUCT_OUT)/verity_metadata
+endif
 	$(hide) ln -t $(PRODUCT_OUT)/docker/aic-manager/images $(PRODUCT_OUT)/system.img
 endif
 
@@ -51,7 +56,7 @@ else
 	BUILD_VARIANT=loop_mount $(HOST_OUT_EXECUTABLES)/aic-build -b $(BUILD_NUMBER)
 endif
 ifneq (,$(filter cic cic_dev,$(TARGET_PRODUCT)))
-	tar cvzf $(PRODUCT_OUT)/$(TARGET_AIC_FILE_NAME) -C $(PRODUCT_OUT) aic android.tar.gz aic-manager.tar.gz cfc ia_hwc pre-requisites sof_audio README-CIC INFO cic.sh setup-aic tos.img kf4cic.efi -C docker update
+	tar cvzf $(PRODUCT_OUT)/$(TARGET_AIC_FILE_NAME) -C $(PRODUCT_OUT) aic android.tar.gz aic-manager.tar.gz cfc ia_hwc pre-requisites sof_audio README-CIC INFO cic.sh setup-aic tos.img kf4cic.efi verity_metadata -C docker update
 	@echo Make debian binaries...
 	$(hide) (rm -rf $(PRODUCT_OUT)/cic && mkdir -p $(PRODUCT_OUT)/cic/opt/cic && mkdir -p $(PRODUCT_OUT)/cic/etc/profile.d)
 	$(hide) (cd $(PRODUCT_OUT)/cic/opt/cic && tar xvf ../../../$(TARGET_AIC_FILE_NAME) aic android.tar.gz aic-manager.tar.gz INFO cic.sh cfc update)

--- a/groups/device-specific/cic_dev/option.spec
+++ b/groups/device-specific/cic_dev/option.spec
@@ -1,3 +1,4 @@
 [defaults]
 file_encryption = false
 gk_force_passthrough = false
+dm_verity = false

--- a/groups/device-specific/cic_dev/product.mk
+++ b/groups/device-specific/cic_dev/product.mk
@@ -16,5 +16,13 @@ PRODUCT_PACKAGES += \
     android.hardware.keymaster@3.0-impl \
     android.hardware.keymaster@3.0-service \
 
+ifeq ($(TARGET_DM_VERITY_SUPPORT), true)
+PRODUCT_PACKAGES += \
+    build_verity_img.py \
+    cic_veritysetup
+
+PRODUCT_COPY_FILES += out/host/linux-x86/bin/cic_veritysetup:cic_veritysetup
+endif
+
 PRODUCT_PROPERTY_OVERRIDES += \
     service.adb.tcp.port=5555


### PR DESCRIPTION
1. verity_metadata is the metadata images of the verity infomations of the system.img
2. the cic_veritysetup is a customer wrapper tool for veritysetup which is used to parse
the verity_metadata image in aic-manager when mount the system.img for android container

Tracked-On: OAM-89713
Signed-off-by: Yan, Shaopu <shaopu.yan@intel.com>