### PR TITLE
Fix android.qcow2 issue in GVT-d ENV

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -45,7 +45,7 @@ function ubu_install_qemu(){
 function ubu_install_qemu_gvtd(){
 	apt purge -y "qemu*"
 	apt autoremove -y
-	apt install -y git python-dev libfdt-dev libpixman-1-dev libssl-dev socat autoconf libtool uml-utilities bridge-utils liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0.0-dev bison flex gcc g++ flex pkg-config python-pip libpulse-dev uuid-runtime uuid 
+	apt install -y git python-dev libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool uml-utilities xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0.0-dev libgtk-3-dev bison libcap-dev libattr1-dev flex gcc g++ flex pkg-config python-pip libpulse-dev uuid-runtime uuid
 	wget https://download.qemu.org/$QEMU_REL.tar.xz
 	tar -xf $QEMU_REL.tar.xz
 	cd $QEMU_REL/
@@ -57,8 +57,13 @@ function ubu_install_qemu_gvtd(){
 		--enable-libusb \
 		--enable-debug-info \
 		--enable-debug \
+		--enable-sdl \
 		--enable-vhost-net \
+		--enable-spice \
 		--disable-debug-tcg \
+		--enable-opengl \
+		--enable-gtk \
+		--enable-virtfs \
 		--target-list=x86_64-softmmu \
 		--audio-drv-list=pa
 	make -j24

--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -84,6 +84,8 @@ then
 	-device usb-host,vendorid=0x8087,productid=0x0026 \
 	-device usb-host,vendorid=0x8087,productid=0x0029 \
 	-device usb-host,vendorid=0x8087,productid=0x0aaa \
+	-device usb-host,vendorid=0x413c,productid=0x301a \
+	-device usb-host,vendorid=0x046d,productid=0x0a38 \
 	-device usb-host,vendorid=0x8087,productid=0x0aa7
 	"
 fi
@@ -186,6 +188,7 @@ function launch_hwrender(){
 
 function launch_hwrender_gvtd(){
 	common_options=${common_options/-display $display_type /}
+	common_options=${common_options/-vga none /-vga none -nographic}
 	qemu-system-x86_64 \
 	-device vfio-pci,host=00:02.0,x-igd-gms=2,id=hostdev0,bus=pcie.0,addr=0x2,x-igd-opregion=on \
 	${common_options/-device virtio-9p-pci,fsdev=fsdev0,mount_tag=hostshare /}


### PR DESCRIPTION
Current image android.qcow2 can not be generated successfully in GVT-d ENV.
This patch fix the issue.

Tracked-On: OAM-90732
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>