### PR TITLE
use dedicate virtio disk as persistent partition

### DIFF
--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -122,7 +122,12 @@ KERNELFLINGER_OS_SECURE_BOOT := true
 KERNELFLINGER_SUPPORT_SELF_USB_DEVICE_MODE_PROTOCOL := {{self_usb_device_mode_protocol}}
 {{/self_usb_device_mode_protocol}}
 
+{{#high_security}}
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.frp.pst=/dev/block/vdc
+{{/high_security}}
+{{^high_security}}
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.frp.pst=/dev/block/by-name/persistent
+{{/high_security}}
 
 {{#slot-ab}}
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/{{_extra_dir}}/update_ifwi_ab.sh:vendor/bin/update_ifwi_ab


### PR DESCRIPTION
if high_security set to true,  mount /dev/block/vdc as persistent partition

Tracked-On:  OAM-91579
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>