### PR TITLE
caas: Update TARGET_BOARD_PLATFORM to celadon

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -1,4 +1,4 @@
-TARGET_BOARD_PLATFORM := broxton
+TARGET_BOARD_PLATFORM := celadon
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.rc:root/init.recovery.$(TARGET_PRODUCT).rc \

--- a/groups/device-specific/celadon_ivi/product.mk
+++ b/groups/device-specific/celadon_ivi/product.mk
@@ -1,4 +1,4 @@
-TARGET_BOARD_PLATFORM := broxton
+TARGET_BOARD_PLATFORM := celadon
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.rc:root/init.recovery.$(TARGET_PRODUCT).rc \

--- a/groups/device-specific/celadon_tablet/product.mk
+++ b/groups/device-specific/celadon_tablet/product.mk
@@ -1,4 +1,4 @@
-TARGET_BOARD_PLATFORM := broxton
+TARGET_BOARD_PLATFORM := celadon
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.rc:root/init.recovery.$(TARGET_PRODUCT).rc \


### PR DESCRIPTION
As celadon supports multiple platforms change the
TARGET_BOARD_PLATFORM to celadon instead of setting it to
specific platform.

Tracked-On: OAM-90597
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>