### PR TITLE
caas: Add xHCI passthrough feature in GVT-d launch

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -258,11 +258,13 @@ function launch_hwrender(){
 }
 
 function launch_hwrender_gvtd(){
+	setup_usb_vfio_passthrough setup
 	common_options=${common_options/-display $display_type /}
 	common_options=${common_options/-vga none /-vga none -nographic}
 	qemu-system-x86_64 \
 	-device vfio-pci,host=00:02.0,x-igd-gms=2,id=hostdev0,bus=pcie.0,addr=0x2,x-igd-opregion=on \
 	${common_options/-device virtio-9p-pci,fsdev=fsdev0,mount_tag=hostshare /} > $qmp_log <<< "{ \"execute\": \"qmp_capabilities\" }"
+	setup_usb_vfio_passthrough remove
 }
 
 function launch_swrender(){


### PR DESCRIPTION
Currently, the xHCI passthrough feature was enabled for
hwrender. Enable the same for GVT-d hwrender also.

Tracked-On: OAM-90851
Signed-off-by: saranya <saranya.gopal@intel.com>