### PR TITLE
mixins: Add thermal HAL to caas manifest

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -23,6 +23,16 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.thermal</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <version>2.0</version>
+        <interface>
+            <name>IThermal</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
         <name>android.hardware.health</name>
         <transport>hwbinder</transport>
         <version>2.0</version>


### PR DESCRIPTION
Thermal HAL needs to be added to caas target
manifest file. It is needed for CIV target and
is also relevant for native Android platform.

Tracked-On: OAM-90879
Signed-off-by: saranya <saranya.gopal@intel.com>