### PR TITLE
Update CIV_WORK_DIR for usage within the script

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -3,6 +3,7 @@
 reboot_required=0
 QEMU_REL=qemu-4.2.0
 a=`grep -rn CIV_WORK_DIR /etc/environment`
+CIV_WORK_DIR=$(pwd)
 
 function ubu_changes_require(){
 	echo "Please make sure your apt is working"


### PR DESCRIPTION
The value for CIV_WORK_DIR is being exported from the setup_host script.
But, this value will be available only after the script execution.
CIV_WORK_DIR has to be assigned the value to be used within the script too.

Tracked-On: OAM-90892
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>