### PR TITLE
UVC-gadget: Enable UVC-gadget for CIC target

### DIFF
--- a/groups/usb-gadget/cic-configfs/init.rc
+++ b/groups/usb-gadget/cic-configfs/init.rc
@@ -20,6 +20,33 @@ on boot
     mkdir /config/usb_gadget/g1/functions/rndis.gs4
     write /config/usb_gadget/g1/functions/rndis.gs4/wceis 1
     mkdir /config/usb_gadget/g1/functions/midi.gs5
+    mkdir /config/usb_gadget/g1/functions/ncm.gs6
+    mkdir /config/usb_gadget/g1/functions/acm.gs7
+
+
+    #UVC gadget function creation
+    mkdir /config/usb_gadget/g1/functions/uvc.usb0
+    mkdir /config/usb_gadget/g1/functions/uvc.usb0/control/header/h
+    symlink /config/usb_gadget/g1/functions/uvc.usb0/control/header/h /config/usb_gadget/g1/functions/uvc.usb0/control/class/fs/h
+    symlink /config/usb_gadget/g1/functions/uvc.usb0/control/header/h /config/usb_gadget/g1/functions/uvc.usb0/control/class/ss/h
+    #1080p MJPEG
+    mkdir /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m
+    mkdir /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/1080p
+    write /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth 1920
+    write /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/1080p/wHeight 1080
+    copy /vendor/etc/1080p.txt /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
+    #write /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwDefaultFrameInterval 1000000
+    write /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxVideoFrameBufferSize 4147200
+    write /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxBitRate 995328000
+    write /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMinBitRate 165888000
+    write /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m/bBitsPerPixel 16
+    mkdir /config/usb_gadget/g1/functions/uvc.usb0/streaming/header/h
+    symlink /config/usb_gadget/g1/functions/uvc.usb0/streaming/mjpeg/m /config/usb_gadget/g1/functions/uvc.usb0/streaming/header/h/u
+    symlink /config/usb_gadget/g1/functions/uvc.usb0/streaming/header/h /config/usb_gadget/g1/functions/uvc.usb0/streaming/class/fs/h
+    symlink /config/usb_gadget/g1/functions/uvc.usb0/streaming/header/h /config/usb_gadget/g1/functions/uvc.usb0/streaming/class/hs/h
+    symlink /config/usb_gadget/g1/functions/uvc.usb0/streaming/header/h /config/usb_gadget/g1/functions/uvc.usb0/streaming/class/ss/h
+    write /config/usb_gadget/g1/functions/uvc.usb0/streaming_maxpacket 3072
+
     mkdir /config/usb_gadget/g1/configs/b.1 0770 shell shell
     mkdir /config/usb_gadget/g1/configs/b.1/strings/0x409 0770 shell shell
     write /config/usb_gadget/g1/os_desc/b_vendor_code 0x1
@@ -63,6 +90,12 @@ on property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/os_desc/use 1
     write /config/usb_gadget/g1/idProduct 0x5207
 
+on property:sys.usb.config=uvc && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "uvc_adb"
+    symlink /config/usb_gadget/g1/functions/uvc.usb0 /config/usb_gadget/g1/configs/b.1/f2
+    chmod 666 /dev/video0
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+
 on property:sys.usb.config=adb && property:sys.usb.configfs=1
     symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
     mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000
@@ -95,3 +128,22 @@ on property:sys.usb.config=accessory,audio_source && property:sys.usb.configfs=1
 
 on property:sys.usb.config=accessory,audio_source,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/idProduct 0x2d05
+
+on property:sys.usb.config=ncm && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ncm"
+    symlink /config/usb_gadget/g1/functions/ncm.gs6 /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+
+on property:sys.usb.config=acm && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "acm"
+    symlink /config/usb_gadget/g1/functions/acm.gs7 /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+
+on property:sys.usb.config=ncm,acm && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ncm_acm"
+    symlink /config/usb_gadget/g1/functions/ncm.gs6 /config/usb_gadget/g1/configs/b.1/f1
+    symlink /config/usb_gadget/g1/functions/acm.gs7 /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}

--- a/groups/usb-gadget/cic-configfs/product.mk
+++ b/groups/usb-gadget/cic-configfs/product.mk
@@ -1,0 +1,3 @@
+PRODUCT_COPY_FILES += \
+    $(INTEL_PATH_COMMON)/usb-gadget/uvc-gadget:system/vendor/bin/uvc-gadget \
+    $(INTEL_PATH_COMMON)/usb-gadget/1080p.txt:system/vendor/etc/1080p.txt


### PR DESCRIPTION
This patch adds UVC-gadget app in Makefile and
configFS changes in init.rc to add support for CIC
to act as a camera streaming device. Also, the changes
for ACM/NCM which were there for cic_dev target were
not ported to mixins. This patch adds those changes too.

Tracked-On: OAM-89993
Signed-off-by: saranya <saranya.gopal@intel.com>