### PR TITLE
Fix video recording not working for all resolutions with Camera2

### DIFF
--- a/groups/camera-ext/ext-camera-only/product.mk
+++ b/groups/camera-ext/ext-camera-only/product.mk
@@ -1,7 +1,7 @@
 # Camera: Device-specific configuration files. Supports only External USB camera, no CSI support
 PRODUCT_COPY_FILES += \
-    frameworks/native/data/etc/android.hardware.camera.external.xml:vendor/etc/permissions/android.hardware.camera.external.xml \
-    $(LOCAL_PATH)/{{_extra_dir}}/external_camera_config.xml:vendor/etc/external_camera_config.xml
+    frameworks/native/data/etc/android.hardware.camera.external.xml:system/vendor/etc/permissions/android.hardware.camera.external.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/external_camera_config.xml:system/vendor/etc/external_camera_config.xml
 
 # External camera service
 PRODUCT_PACKAGES += android.hardware.camera.provider@2.4-external-service \


### PR DESCRIPTION
Video recording with resolutions 720p and 1080p are not
working with Camera2 app as camera config files are not
copied to correct etc folder.

Fix the issue by copying external camera and external camera
feature config files to system/vendor/etc folder.

Tracked-On: OAM-90937
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>