### PR TITLE
Change VGPU type to 4 for GVT-g

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -18,7 +18,7 @@ function ubu_changes_require(){
 function ubu_install_qemu(){
 	apt purge -y "qemu*"
 	apt autoremove -y
-	apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0.0-dev libgtk-3-dev bison libcap-dev libattr1-dev
+	apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0.0-dev libgtk-3-dev bison libcap-dev libattr1-dev flex
 
 	wget https://download.qemu.org/$QEMU_REL.tar.xz
 	tar -xf $QEMU_REL.tar.xz

--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -12,6 +12,7 @@ ovmf_file="./OVMF.fd"
 
 GVTg_DEV_PATH="/sys/bus/pci/devices/0000:00:02.0"
 GVTg_VGPU_UUID="4ec1ff92-81d7-11e9-aed4-5bf6a9a2bb0a"
+GVTg_VGPU_TYPE="i915-GVTg_V5_4"
 
 function network_setup(){
 	#setup unprivileged ICMP on the host for ping to work on guest side.
@@ -22,7 +23,7 @@ function setup_vgpu(){
 	res=0
 	if [ ! -d $GVTg_DEV_PATH/$GVTg_VGPU_UUID ]; then
 		echo "Creating VGPU..."
-		sudo sh -c "echo $GVTg_VGPU_UUID > $GVTg_DEV_PATH/mdev_supported_types/i915-GVTg_V5_8/create"
+		sudo sh -c "echo $GVTg_VGPU_UUID > $GVTg_DEV_PATH/mdev_supported_types/$GVTg_VGPU_TYPE/create"
 		res=$?
 	fi
 	return $res


### PR DESCRIPTION
In order to change GVTg Android default resolution to 1080P,
modify VGPU type to 4.

Tracked-On: OAM-90927
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>