### PR TITLE
battery: Disabling fake battery disable so that proper battery value …

### DIFF
--- a/groups/wlan/mac80211_hwsim/init.rc
+++ b/groups/wlan/mac80211_hwsim/init.rc
@@ -1,7 +1,7 @@
 on boot
     setprop wifi.interface wlan0
     # enable fake battery state, details in system/core/healthd/BatteryMonitor.cpp
-    setprop ro.boot.fake_battery 1
+    # setprop ro.boot.fake_battery 1
 
     # Disable rild
     setprop ro.radio.noril yes


### PR DESCRIPTION
…is taken

This patch disables the fake battery state so that real battery values can be seen.

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>