### PR TITLE
Reduce CPU load during shutdown and reboot scenario

### DIFF
--- a/groups/device-specific/caas/guest_pm_control
+++ b/groups/device-specific/caas/guest_pm_control
@@ -57,7 +57,7 @@ def main():
     while True:
         try:
             # Pull the VM shutdown and reboot event from QEMU QMP Server
-            resp = qemu.pull_event()
+            resp = qemu.pull_event(wait=True)
             if resp != None:
                 for val in resp.values():
                     if val == "SHUTDOWN" or val == "RESET":


### PR DESCRIPTION
Currently the CPU load is very high when the CIV is run with --guest-pm option.

Improvement for this can be done by making the qemu event a blocking call
so that CPU will wait until it gets the event, hence reducing the CPU utilazation.

Tracked-On: OAM-90975
Signed-off-by: Kaushlendra Kumar <kaushlendra.kumar@intel.com>
Signed-off-by: Shwetha B <shwetha.b@intel.com>