### PR TITLE
Battery: Patch to show correct battery percentage on the android screen

### DIFF
--- a/groups/wlan/mac80211_hwsim/init.rc
+++ b/groups/wlan/mac80211_hwsim/init.rc
@@ -1,7 +1,5 @@
 on boot
     setprop wifi.interface wlan0
-    # enable fake battery state, details in system/core/healthd/BatteryMonitor.cpp
-    setprop ro.boot.fake_battery 1
 
     # Disable rild
     setprop ro.radio.noril yes


### PR DESCRIPTION
This patch enables to show correct battery percentage on the android screen.

Tracked-On: OAM-90977
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>