### PR TITLE
Fix sepolicy errors for accessing PulseAudio Sockets

### DIFF
--- a/groups/device-specific/cic/sepolicy/hal_audio_default.te
+++ b/groups/device-specific/cic/sepolicy/hal_audio_default.te
@@ -1,1 +1,4 @@
 allow hal_audio_default audio_data_file:dir search;
+allow hal_audio_default audio_data_file:sock_file write;
+allow hal_audio_default kernel:unix_stream_socket connectto;
+allow hal_audio_default shell_exec:file { open read execute };


### PR DESCRIPTION
avc denial errors reported while accessing PulseAudio Sockets.
Added sepolicy permissions for hal_audio_default.

Tracked-On: OAM-90981
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>