### PR TITLE
Don't add restart argument by default

### DIFF
--- a/groups/device-specific/cic/addon/setup-aic
+++ b/groups/device-specific/cic/addon/setup-aic
@@ -192,7 +192,7 @@ fi
 #Security settings
 ./pre-requisites/secure $SECURE
 
-AIC_INSTALL_ARGUMENTS="-e -d none -r"
+AIC_INSTALL_ARGUMENTS="-e -d none"
 if [[ $MULTIPLE_USER == "true" ]]; then
 AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -j"
 fi


### PR DESCRIPTION
The cic container will be restarted automatically when host reboot if we
add docker restart argument, it may cause some problem since binderfs device
still not ready at that time. We will optimize the booting process first
before support this argument.

Tracked-On: OAM-91025
Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com>