### PR TITLE
Update tos image logic

### DIFF
--- a/groups/trusty/true/AndroidBoard.mk
+++ b/groups/trusty/true/AndroidBoard.mk
@@ -6,9 +6,7 @@ LOCAL_MAKE := make
 # Build the evmm_pkg.bin and lk.bin
 .PHONY: $(TOS_IMAGE_TARGET)
 $(TOS_IMAGE_TARGET):
-	@echo "making lk.bin.."
-	$(hide) (cd $(TOPDIR)trusty && $(TRUSTY_ENV_VAR) $(LOCAL_MAKE) {{{lk_project}}})
-	@echo "making tos image.."
+	@echo "making tos image with Trusty relase binary.."
 	$(hide) (cd $(TOPDIR)vendor/intel/fw/evmm/$(INTERNAL_PLATFORM) && $(TRUSTY_ENV_VAR) $(LOCAL_MAKE))
 
 #tos partition is assigned for trusty

--- a/groups/trusty/true/BoardConfig.mk
+++ b/groups/trusty/true/BoardConfig.mk
@@ -12,21 +12,9 @@ BOARD_SEPOLICY_DIRS += device/intel/project-celadon/sepolicy/trusty
 BOARD_SEPOLICY_M4DEFS += module_trusty=true
 
 LK_PRODUCT := project-celadon_64
-
-LKBUILD_TOOLCHAIN_ROOT = $(PWD)/vendor/intel/external/prebuilts/elf/
-LKBUILD_X86_TOOLCHAIN =
-LKBUILD_X64_TOOLCHAIN = $(LKBUILD_TOOLCHAIN_ROOT)x86_64-elf-4.9.1-Linux-x86_64/bin
-EVMMBUILD_TOOLCHAIN ?= x86_64-linux-android-
-TRUSTY_BUILDROOT = $(PWD)/$(PRODUCT_OUT)/obj/trusty/
-
-TRUSTY_ENV_VAR += LK_CORE_NUM={{lk_core_num}}
 TRUSTY_ENV_VAR += TRUSTY_REF_TARGET={{ref_target}}
 
-#for trusty lk
-TRUSTY_ENV_VAR += BUILDROOT=$(TRUSTY_BUILDROOT)
-TRUSTY_ENV_VAR += PATH=$$PATH:$(LKBUILD_X86_TOOLCHAIN):$(LKBUILD_X64_TOOLCHAIN)
-TRUSTY_ENV_VAR += CLANG_BINDIR=$(PWD)/$(LLVM_PREBUILTS_PATH)
-TRUSTY_ENV_VAR += ARCH_x86_64_TOOLCHAIN_PREFIX=${PWD}/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-${TARGET_GCC_VERSION}/bin/x86_64-linux-android-
+TRUSTY_BUILDROOT = $(PWD)/$(PRODUCT_OUT)/obj/trusty/
 
 #for trusty vmm
 # use same toolchain as android kernel
@@ -34,7 +22,11 @@ TRUSTY_ENV_VAR += COMPILE_TOOLCHAIN=$(EVMMBUILD_TOOLCHAIN)
 
 # output build dir to android out folder
 TRUSTY_ENV_VAR += BUILD_DIR=$(TRUSTY_BUILDROOT)
-TRUSTY_ENV_VAR += LKBIN_DIR=$(TRUSTY_BUILDROOT)/build-{{{lk_project}}}/
+ifeq ($(LKDEBUG),2)
+TRUSTY_ENV_VAR += LKBIN_DIR=$(PWD)/vendor/intel/fw/trusty-release-binaries/debug/
+else
+TRUSTY_ENV_VAR += LKBIN_DIR=$(PWD)/vendor/intel/fw/trusty-release-binaries/
+endif
 
 #Workaround CPU lost issue on SIMICS, will remove this line below after PO.
 BOARD_KERNEL_CMDLINE += cpu_init_udelay=500000


### PR DESCRIPTION
Previous tos image is built with Trusty source code, switch this logic
to build tos image with Trusty release binary.

Tracked-On: OAM-91074