### PR TITLE
start_android_qcow2.sh: Start vsock host utilities

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -40,3 +40,5 @@ PRODUCT_COPY_FILES += $(LOCAL_PATH)/sof_audio/blacklist-dsp.conf:$(PRODUCT_OUT)/
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/guest_pm_control:$(PRODUCT_OUT)/scripts/guest_pm_control
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/intel-thermal-conf.xml:$(PRODUCT_OUT)/scripts/intel-thermal-conf.xml
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/thermald.service:$(PRODUCT_OUT)/scripts/thermald.service
+PRODUCT_COPY_FILES += device/intel/civ/host/backend/battery/bin/batsys:$(PRODUCT_OUT)/scripts/batsys
+PRODUCT_COPY_FILES += device/intel/civ/host/backend/thermal/bin/thermsys:$(PRODUCT_OUT)/scripts/thermsys

--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -189,6 +189,8 @@ function prepare_required_scripts(){
 	mv -t $CIV_WORK_DIR/sof_audio $CIV_WORK_DIR/scripts/sof_audio/configure_sof.sh $CIV_WORK_DIR/scripts/sof_audio/blacklist-dsp.conf
 	chmod +x $CIV_WORK_DIR/scripts/guest_pm_control
 	chmod +x $CIV_WORK_DIR/scripts/findall.py
+	chmod +x $CIV_WORK_DIR/scripts/thermsys
+	chmod +x $CIV_WORK_DIR/scripts/batsys
 }
 
 function save_env(){


### PR DESCRIPTION
This patch adds the vsock host utilities to the
release. It also includes script changes
to start these utilities during CIV launch.

Tracked-On: OAM-91101
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>