### PR TITLE
Customize android not working

### DIFF
--- a/groups/ais/true/addon/setup-aic
+++ b/groups/ais/true/addon/setup-aic
@@ -197,6 +197,11 @@ if [[ $MULTIPLE_USER == "true" ]]; then
 AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -j"
 fi
 
+if [[ $SECURE == "false" ]]; then
+cp $AIC_WORK_DIR/update/customize-android $AIC_WORK_DIR/update/root/customize-android
+AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -u"
+fi
+
 #Install CIC
 cd $AIC_WORK_DIR
 echo "Installing CIC -- START"


### PR DESCRIPTION
Step to copy customize-android script to android container
was removed as part of trusty disable.
Hence, enabling it back to fix the issue.

Tracked-On: OAM-91126
Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>