### PR TITLE
Add a property for switching EDID filter

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -4,6 +4,7 @@ case "$(cat /proc/fb)" in
                 echo "intel"
                 setprop ro.hardware.hwcomposer intel
                 setprop ro.hardware.gralloc intel
+                setprop vendor.hwcomposer.edid.all 0
                 case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
                         QEMU)
                                 setprop ro.graphics.hwcomposer.kvm true
@@ -17,6 +18,7 @@ case "$(cat /proc/fb)" in
                 echo "intel"
                 setprop ro.hardware.hwcomposer intel
                 setprop ro.hardware.gralloc intel
+                setprop vendor.hwcomposer.edid.all 0
 	        case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
                         QEMU)
                                 setprop ro.graphics.hwcomposer.kvm true


### PR DESCRIPTION
By default, the property is 0, and all EDIDs will be sent
to SF.

Tracked-On: OAM-91067
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>