### PR TITLE
Separate audio folder for CIC socket creation

### DIFF
--- a/groups/ais/true/addon/pre-requisites/create_pasocket.sh
+++ b/groups/ais/true/addon/pre-requisites/create_pasocket.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # author: sundar.gnanasekaran@intel.com
 
-audio_ipc="$AIC_WORK_DIR/ipc/config/audio"
+audio_ipc="$AIC_WORK_DIR/audio"
 
 
 if [[ ! -f "$audio_ipc/cic_pulseaudio_out.socket" && ! -f $audio_ipc/cic_pulseaudio_in.socket ]]; then

--- a/groups/ais/true/addon/pre-requisites/pactl_socket
+++ b/groups/ais/true/addon/pre-requisites/pactl_socket
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # author: sundar.gnanasekaran@intel.com
 
-audio_ipc="$AIC_WORK_DIR/workdir/ipc/config/audio"
+audio_ipc="$AIC_WORK_DIR/workdir/audio"
 pactl_default_pa="/etc/pulse/default.pa"
 
 mkdir -p $audio_ipc


### PR DESCRIPTION
Pulseaudio sockets get created inside the ipc folder currently.
Moving the audio folder outside ipc directory to fix sepolicy
issues when accessing the sockets from inside android.

Tracked-On: OAM-91252
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>