### PR TITLE
Thermal: Daemon: Adding NUC10i7FNK support

### DIFF
--- a/groups/device-specific/caas/intel-thermal-conf.xml
+++ b/groups/device-specific/caas/intel-thermal-conf.xml
@@ -1,12 +1,71 @@
 <?xml version="1.0"?>
 <!-- BEGIN -->
 
-<!-- For CML NUC PLATFORM -->
+<!-- For CML NUC SKU NUC10i7FNH PLATFORM -->
 
 <ThermalConfiguration>
 	<Platform>
 		<Name> CML-NUC-U-SERIES </Name>
 		<ProductName>NUC10i7FNH</ProductName>
+		<Preference>QUIET</Preference>
+		<ThermalZones>
+			<ThermalZone>
+				<Type>cpu_passive</Type>
+				<TripPoints>
+					<TripPoint>
+						<SensorType>x86_pkg_temp</SensorType>
+						<Temperature>85000</Temperature>
+						<Type>Passive</Type>
+						<CoolingDevice>
+							<Type>rapl_limit_1</Type>
+						</CoolingDevice>
+					</TripPoint>
+					<TripPoint>
+						<SensorType>x86_pkg_temp</SensorType>
+						<Temperature>95000</Temperature>
+						<Type>Passive</Type>
+						<CoolingDevice>
+							<Type>rapl_limit_2</Type>
+						</CoolingDevice>
+					</TripPoint>
+				</TripPoints>
+			</ThermalZone>
+			<ThermalZone>
+				<Type>cpu_critical</Type>
+				<TripPoints>
+					<TripPoint>
+						<SensorType>x86_pkg_temp</SensorType>
+						<Temperature>99000</Temperature>
+						<Type>Critical</Type>
+					</TripPoint>
+				</TripPoints>
+			</ThermalZone>
+		</ThermalZones>
+		<CoolingDevices>
+			<CoolingDevice>
+				<Type>rapl_limit_1</Type>
+				<Path>/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0/constraint_0_power_limit_uw</Path>
+				<MinState>25000000</MinState>
+				<ReadBack>0</ReadBack>
+				<MaxState>13000000</MaxState>
+				<IncDecStep>-200000</IncDecStep>
+			</CoolingDevice>
+			<CoolingDevice>
+				<Type>rapl_limit_2</Type>
+				<Path>/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0/constraint_0_power_limit_uw</Path>
+				<MinState>13000000</MinState>
+				<ReadBack>0</ReadBack>
+				<MaxState>6000000</MaxState>
+				<IncDecStep>-200000</IncDecStep>
+			</CoolingDevice>
+		</CoolingDevices>
+	</Platform>
+
+<!-- For CML NUC SKU NUC10i7FNK PLATFORM -->
+
+	<Platform>
+		<Name> CML-NUC-U-SERIES </Name>
+		<ProductName>NUC10i7FNK</ProductName>
 		<Preference>QUIET</Preference>
 		<ThermalZones>
 			<ThermalZone>


### PR DESCRIPTION
Adding NUC10i7FNK support in thermal xml.

Tracked-On: OAM-91325
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>