### PR TITLE
Fix 3.5mm detection on CML NUC for CIC

### DIFF
--- a/groups/ais/true/addon/pre-requisites/setup_audio_host.sh
+++ b/groups/ais/true/addon/pre-requisites/setup_audio_host.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+ALSA_CONF="/etc/modprobe.d/alsa-base.conf"
+pa_cookie="/home/$SUDO_USER/.config/pulse/cookie"
+pa_server="$XDG_RUNTIME_DIR/pulse/native"
+mic_gain_cmd="pactl set-source-volume alsa_input.pci-0000_00_1f.3.analog-stereo "
+
+function getCpuInfo {
+        echo `lscpu | grep $1 | cut -d ":" -f2 | xargs`
+}
+
+function enableHeadset {
+        if [[ -z `grep 'dell-headset-multi' $ALSA_CONF` ]];then
+                echo "will use dell-headset-multi model for snd-hda-intel"
+                echo "options snd-hda-intel model=dell-headset-multi" >> $ALSA_CONF
+        fi
+}
+
+function setMicGain {
+        echo "set alsa mic gain to $1%"
+        `PULSE_SERVER=$pa_server PULSE_COOKIE=$pa_cookie $mic_gain_cmd $1%`
+}
+
+cpu_family=$(getCpuInfo 'family:')
+cpu_model=$(getCpuInfo 'Model:')
+#Additional handling for CML NUC
+if [[ ($cpu_family = 6) && ($cpu_model = 166) ]]; then
+        echo "CML NUC detected"
+        if [[ $1 == "setMicGain" ]]; then
+                setMicGain 15
+        else
+                enableHeadset
+        fi
+fi
+

--- a/groups/ais/true/addon/setup-aic
+++ b/groups/ais/true/addon/setup-aic
@@ -344,6 +344,7 @@ fi
 if [[ $AUDIO_PT == "true" ]]; then
   sudo rm -rf /etc/profile.d/create_pasocket.sh
 fi
+sudo ./pre-requisites/setup_audio_host.sh
 
 sudo update-grub
 echo ""


### PR DESCRIPTION
Audio driver is unable to detect 3.5mm headset on CML NUC.
This hardware requires a module parameter for snd-hda-intel:
model=dell-headset-multi

Tracked-On: OAM-91355
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>