### PR TITLE
Launch GVT/Virtio/SW virtualization dynamically

### DIFF
--- a/groups/aaf/true/init.rc
+++ b/groups/aaf/true/init.rc
@@ -8,9 +8,6 @@ on fs
     mkdir /mnt/share
     mount 9p hostshare /mnt/share
     exec - root root -- /vendor/bin/logwrapper /vendor/bin/sh /vendor/bin/auto_detection.sh
-
-#   previously these properties are set in auto_detection.sh, however, these properties are
-#   of exported_default_prop which can only be set by init or vendor_init with treble
-#   enabled, so we have to hardcod these properties here.
-    setprop ro.hardware.hwcomposer intel
-    setprop ro.hardware.gralloc intel
+    setprop ro.hardware.egl ${vendor.egl.set}
+    setprop ro.hardware.hwcomposer ${vendor.hwcomposer.set}
+    setprop ro.hardware.gralloc ${vendor.gralloc.set}

--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -2,8 +2,8 @@ auto_hal() {
 case "$(cat /proc/fb)" in
         *i915drmfb)
                 echo "intel"
-                setprop ro.hardware.hwcomposer intel
-                setprop ro.hardware.gralloc intel
+                setprop vendor.hwcomposer.set intel
+                setprop vendor.gralloc.set intel
                 setprop vendor.hwcomposer.edid.all 0
                 case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
                         QEMU)
@@ -16,8 +16,8 @@ case "$(cat /proc/fb)" in
                 ;;
         *inteldrmfb)
                 echo "intel"
-                setprop ro.hardware.hwcomposer intel
-                setprop ro.hardware.gralloc intel
+                setprop vendor.hwcomposer.set intel
+                setprop vendor.gralloc.set intel
                 setprop vendor.hwcomposer.edid.all 0
 	        case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
                         QEMU)
@@ -30,19 +30,19 @@ case "$(cat /proc/fb)" in
                 ;;
         *virtiodrmfb)
                 echo "virtio-gpu"
-                setprop ro.hardware.hwcomposer drm_minigbm
-                setprop ro.hardware.gralloc minigbm
+                setprop vendor.hwcomposer.set drm_minigbm
+                setprop vendor.gralloc.set minigbm
                 ;;
 	*virtio_gpudrmfb)
                 echo "virtio-gpu"
-                setprop ro.hardware.hwcomposer drm_minigbm
-                setprop ro.hardware.gralloc minigbm
+                setprop vendor.hwcomposer.set drm_minigbm
+                setprop vendor.gralloc.set minigbm
                 ;;
         *)
                 echo "sw rendering"
-                setprop ro.hardware.egl swiftshader
-                setprop ro.hardware.hwcomposer default
-                setprop ro.hardware.gralloc default
+                setprop vendor.egl.set swiftshader
+                setprop vendor.hwcomposer.set default
+                setprop vendor.gralloc.set default
                 setprop ro.graphics.hwcomposer.kvm false
                 ;;
 esac


### PR DESCRIPTION
With Treble is enabled, we can't setprop hwcomposer and
gralloc property with auto_detection.sh. This change to
help launch kinds of virtualization solution dynamically.

Now, GVT/Virtio virtualization could be combined with one
image.

Tracked-On: OAM-91001
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>