### PR TITLE
Increase default memory to 4G

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -139,7 +139,7 @@ common_sd_emmc="\
  -drive file=$SDEMMC_DEV_PATH,format=raw,id=sdcard0 \
 "
  common_options="\
- -m 2048 -smp 2 -M q35 \
+ -m 4096 -smp 2 -M q35 \
  -name caas-vm \
  -enable-kvm \
  -vga none \


### PR DESCRIPTION
Increase CiV default memory to 4G

Tracked-On: OAM-91388
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>