### PR TITLE
Fix low volume on the attached HDA Codec for EHL

### DIFF
--- a/groups/audio/project-celadon/default/mixer_paths_ehl.xml
+++ b/groups/audio/project-celadon/default/mixer_paths_ehl.xml
@@ -1,0 +1,28 @@
+<mixer>
+  <!-- These are the initial mixer settings -->
+  <ctl name="Master Playback Volume" value="127" />
+  <ctl name="Master Playback Switch" value="1" />
+  <ctl name="Headphone Playback Switch" value="0 0" />
+  <ctl name="Speaker Playback Switch" value="0 0" />
+  <ctl name="Capture Switch" value="0 0" />
+
+  <path name="speaker">
+    <ctl name="Master Playback Switch" value="1" />
+    <ctl name="Speaker Playback Switch" value="1 1" />
+  </path>
+
+  <path name="headphone">
+    <ctl name="Master Playback Switch" value="1" />
+    <ctl name="Headphone Playback Switch" value="1 1" />
+  </path>
+
+  <path name="main-mic">
+    <ctl name="Capture Switch" value="1 1" />
+    <ctl name="Capture Volume" value="63 63" />
+  </path>
+
+  <path name="headset-mic">
+    <ctl name="Capture Switch" value="1 1" />
+    <ctl name="Capture Volume" value="63 63" />
+  </path>
+</mixer>

--- a/groups/audio/project-celadon/product.mk
+++ b/groups/audio/project-celadon/product.mk
@@ -51,8 +51,14 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/default/policy/hdmi_audio_policy_configuration.xml:vendor/etc/hdmi_audio_policy_configuration.xml \
     $(LOCAL_PATH)/audio/default/policy/audio_policy_volumes.xml:vendor/etc/audio_policy_volumes.xml \
     $(LOCAL_PATH)/audio/default/policy/default_volume_tables.xml:vendor/etc/default_volume_tables.xml \
-    $(LOCAL_PATH)/audio/default/effect/audio_effects.xml:vendor/etc/audio_effects.xml \
+    $(LOCAL_PATH)/audio/default/effect/audio_effects.xml:vendor/etc/audio_effects.xml
+ifeq ($(BASE_YOCTO_KERNEL), true)
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/audio/default/mixer_paths_ehl.xml:vendor/etc/mixer_paths_0.xml
+else
+PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/default/mixer_paths_0.xml:vendor/etc/mixer_paths_0.xml
+endif
 
 #fallback
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
The volume of playback via 3.5mm is very low.
The mixer control "Master Playback Volume" is currently 87.
The EHL device with the reworked HDA Codec has a range of 0-127
for this mixer control, and needs to be increased accordingly.

Tracked-On: OAM-91467
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>