### PR TITLE
Legacy HDA Driver has to be picked for EHL guest kernel

### DIFF
--- a/groups/kernel/BoardConfig.mk
+++ b/groups/kernel/BoardConfig.mk
@@ -47,5 +47,10 @@ BOARD_KERNEL_CMDLINE += \
 BOARD_KERNEL_CMDLINE += \
       snd-hda-intel.model=dell-headset-multi
 
+ifeq ($(BASE_YOCTO_KERNEL), true)
+BOARD_KERNEL_CMDLINE += \
+      snd-intel-dspcfg.dsp_driver=1
+endif
+
 BOARD_SEPOLICY_M4DEFS += module_kernel=true
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/kernel


### PR DESCRIPTION
The EHL guest kernel sometimes picks the sof audio driver for
loading the HDA/HDMI audio devices. But sinc sof driver is not
yet enabled for android, adding dsp_driver param to force the
Legacy HDA Driver to be picked

Tracked-On: OAM-91412
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>