### PR TITLE
Extend caas image size to 32GB

### DIFF
--- a/groups/device-specific/caas/start_flash_usb.sh
+++ b/groups/device-specific/caas/start_flash_usb.sh
@@ -14,7 +14,7 @@ then
 	fi
 fi
 
-qemu-img create -f qcow2 android.qcow2 16G
+qemu-img create -f qcow2 android.qcow2 32G
 
 [ -d "./flashfiles_decompress" ] && rm -rf "./flashfiles_decompress"
 mkdir ./flashfiles_decompress


### PR DESCRIPTION

Extend caas image size to 32GB to meet requirement of CTS/GTS

Tracked-On: OAM-91483
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>