### PR TITLE
Fix for HDMI audio playback on EHL platform

### DIFF
--- a/groups/audio/project-celadon/BoardConfig.mk
+++ b/groups/audio/project-celadon/BoardConfig.mk
@@ -11,6 +11,8 @@ else
 INTEL_AUDIO_HAL := stub
 endif
 
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/audio
+
 # Use XML audio policy configuration file
 USE_XML_AUDIO_POLICY_CONF := 1
 # Use configurable audio policy

--- a/groups/audio/project-celadon/product.mk
+++ b/groups/audio/project-celadon/product.mk
@@ -55,6 +55,8 @@ PRODUCT_COPY_FILES += \
 ifeq ($(BASE_YOCTO_KERNEL), true)
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/default/mixer_paths_ehl.xml:vendor/etc/mixer_paths_0.xml
+
+PRODUCT_PROPERTY_OVERRIDES += ro.vendor.hdmi.audio=ehl
 else
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/default/mixer_paths_0.xml:vendor/etc/mixer_paths_0.xml


### PR DESCRIPTION
HDMI port on EHL platform is listed as device 7, where as,
the default device for HDMI was set to 3, hence,
adding an additional check for EHL platform.

Tracked-On: OAM-91411
Signed-off-by: gkdeepa <g.k.deepa@intel.com>