### PR TITLE
mixins: Avoid copying EM binaries into target

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -44,5 +44,3 @@ PRODUCT_COPY_FILES += $(LOCAL_PATH)/guest_pm_control:$(PRODUCT_OUT)/scripts/gues
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/intel-thermal-conf.xml:$(PRODUCT_OUT)/scripts/intel-thermal-conf.xml
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/thermald.service:$(PRODUCT_OUT)/scripts/thermald.service
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/qmp_events_handler.sh:$(PRODUCT_OUT)/scripts/qmp_events_handler.sh
-PRODUCT_COPY_FILES += device/intel/civ/host/backend/battery/bin/batsys:$(PRODUCT_OUT)/scripts/batsys
-PRODUCT_COPY_FILES += device/intel/civ/host/backend/thermal/bin/thermsys:$(PRODUCT_OUT)/scripts/thermsys


### PR DESCRIPTION
Host utility code is now merged into repo. The code
should be directly built into target directory.
So, remove the code to copy the host utility binaries
into target.

Tracked-On: OAM-91484
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>