### PR TITLE
Fix low Mic gain on the attached HDA Codec

### DIFF
--- a/groups/audio/project-celadon/default/mixer_paths_ehl.xml
+++ b/groups/audio/project-celadon/default/mixer_paths_ehl.xml
@@ -23,6 +23,6 @@
 
   <path name="headset-mic">
     <ctl name="Capture Switch" value="1 1" />
-    <ctl name="Capture Volume" value="63 63" />
+    <ctl name="Capture Volume" value="80 80" />
   </path>
 </mixer>


### PR DESCRIPTION
The mixer control "Capture Volume" is currently set at 63.
This results in a very low volume for audio recorded via 3.5mm.
Increasing this value to 80 to better tune the input gains.

Tracked-On: OAM-91488
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>