### PR TITLE
Add virtio input passthrough for touch screen

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -162,6 +162,16 @@ common_sd_emmc="\
  -smbios "type=2,serial=$smbios_serialno" \
  -nodefaults
 "
+
+HPI2CTouchDev=/dev/input/by-path/pci-0000:00:15.0-platform-i2c_designware.0-event
+if [ -e "$HPI2cTouchDev" ]
+then
+   common_touch_i2c_device="\
+      -device virtio-input-host-pci,evdev=/dev/input/by-path/pci-0000:00:15.0-platform-i2c_designware.0-event \
+      "
+   common_options=${common_touch_i2c_device}${common_options}
+fi
+
 usb_vfio_passthrough="false"
 for arg in $*
 do


### PR DESCRIPTION
Added virtio input passthrough for HP Canon Ball device
i2c based touch screen.

Tracked-On: OAM-89721
Signed-off-by: Jaikrishna Nemallapudi <nemallapudi.jaikrishna@intel.com>