### PR TITLE
Fix 3.5mm detection on CML NUC for CIC

### DIFF
--- a/groups/ais/false/addon/debian/postinst
+++ b/groups/ais/false/addon/debian/postinst
@@ -169,7 +169,7 @@ function install_cic() {
 }
 
 function pactl_socket() {
-  audio_ipc="$AIC_WORK_DIR_PATH/ipc/config/audio"
+  audio_ipc="$AIC_WORK_DIR_PATH/audio"
   pactl_default_pa="/etc/pulse/default.pa"
 
   mkdir -p $audio_ipc

--- a/groups/ais/false/addon/pre-requisites/create_pasocket.sh
+++ b/groups/ais/false/addon/pre-requisites/create_pasocket.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # author: sundar.gnanasekaran@intel.com
 
-audio_ipc="$AIC_WORK_DIR/ipc/config/audio"
+audio_ipc="$AIC_WORK_DIR/audio"
 
 
 if [[ ! -f "$audio_ipc/cic_pulseaudio_out.socket" && ! -f $audio_ipc/cic_pulseaudio_in.socket ]]; then

--- a/groups/ais/false/addon/pre-requisites/pactl_socket
+++ b/groups/ais/false/addon/pre-requisites/pactl_socket
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # author: sundar.gnanasekaran@intel.com
 
-audio_ipc="$AIC_WORK_DIR/workdir/ipc/config/audio"
+audio_ipc="$AIC_WORK_DIR/workdir/audio"
 pactl_default_pa="/etc/pulse/default.pa"
 
 mkdir -p $audio_ipc

--- a/groups/ais/false/addon/pre-requisites/setup_audio_host.sh
+++ b/groups/ais/false/addon/pre-requisites/setup_audio_host.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+ALSA_CONF="/etc/modprobe.d/alsa-base.conf"
+pa_cookie="/home/$SUDO_USER/.config/pulse/cookie"
+pa_server="$XDG_RUNTIME_DIR/pulse/native"
+mic_gain_cmd="pactl set-source-volume alsa_input.pci-0000_00_1f.3.analog-stereo "
+
+function getCpuInfo {
+        echo `lscpu | grep $1 | cut -d ":" -f2 | xargs`
+}
+
+function enableHeadset {
+        if [[ -z `grep 'dell-headset-multi' $ALSA_CONF` ]];then
+                echo "will use dell-headset-multi model for snd-hda-intel"
+                echo "options snd-hda-intel model=dell-headset-multi" >> $ALSA_CONF
+        fi
+}
+
+function setMicGain {
+        echo "set alsa mic gain to $1%"
+        `PULSE_SERVER=$pa_server PULSE_COOKIE=$pa_cookie $mic_gain_cmd $1%`
+}
+
+cpu_family=$(getCpuInfo 'family:')
+cpu_model=$(getCpuInfo 'Model:')
+#Additional handling for CML NUC
+if [[ ($cpu_family = 6) && ($cpu_model = 166) ]]; then
+        echo "CML NUC detected"
+        if [[ $1 == "setMicGain" ]]; then
+                setMicGain 15
+        else
+                enableHeadset
+        fi
+fi
+

--- a/groups/ais/false/addon/setup-aic
+++ b/groups/ais/false/addon/setup-aic
@@ -64,6 +64,7 @@ sudo systemctl enable cic
 
 #Run pactl
 ./pre-requisites/pactl_socket $(whoami)
+sudo ./pre-requisites/setup_audio_host.sh
 
 echo ""
 echo "Reboot required for changes to be reflected !!"

--- a/groups/ais/true/addon/pre-requisites/setup_audio_host.sh
+++ b/groups/ais/true/addon/pre-requisites/setup_audio_host.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+ALSA_CONF="/etc/modprobe.d/alsa-base.conf"
+pa_cookie="/home/$SUDO_USER/.config/pulse/cookie"
+pa_server="$XDG_RUNTIME_DIR/pulse/native"
+mic_gain_cmd="pactl set-source-volume alsa_input.pci-0000_00_1f.3.analog-stereo "
+
+function getCpuInfo {
+        echo `lscpu | grep $1 | cut -d ":" -f2 | xargs`
+}
+
+function enableHeadset {
+        if [[ -z `grep 'dell-headset-multi' $ALSA_CONF` ]];then
+                echo "will use dell-headset-multi model for snd-hda-intel"
+                echo "options snd-hda-intel model=dell-headset-multi" >> $ALSA_CONF
+        fi
+}
+
+function setMicGain {
+        echo "set alsa mic gain to $1%"
+        `PULSE_SERVER=$pa_server PULSE_COOKIE=$pa_cookie $mic_gain_cmd $1%`
+}
+
+cpu_family=$(getCpuInfo 'family:')
+cpu_model=$(getCpuInfo 'Model:')
+#Additional handling for CML NUC
+if [[ ($cpu_family = 6) && ($cpu_model = 166) ]]; then
+        echo "CML NUC detected"
+        if [[ $1 == "setMicGain" ]]; then
+                setMicGain 15
+        else
+                enableHeadset
+        fi
+fi
+

--- a/groups/ais/true/addon/setup-aic
+++ b/groups/ais/true/addon/setup-aic
@@ -318,6 +318,7 @@ fi
 if [[ $AUDIO_PT == "true" ]]; then
   sudo rm -rf /etc/profile.d/create_pasocket.sh
 fi
+sudo ./pre-requisites/setup_audio_host.sh
 
 sudo update-grub
 echo ""


### PR DESCRIPTION
1.Port cic audio changes for pulseaudio sockets to cic_dev.
2.Audio driver is unable to detect 3.5mm headset on CML NUC.
 This hardware requires a module parameter for snd-hda-intel:
 model=dell-headset-multi

Tracked-On: OAM-91355
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>