### PR TITLE
boot-arch: support dedicated data partition

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -119,6 +119,10 @@ KERNELFLINGER_USE_RPMB := true
 KERNELFLINGER_USE_RPMB_SIMULATE := true
 {{/rpmb_simulate}}
 
+{{#high_security}}
+KERNELFLINGER_USE_DEDICATED_DATA_PARTITION := true
+{{/high_security}}
+
 {{^use_cic}}
 {{#nvme_rpmb_scan}}
 KERNELFLINGER_USE_NVME_RPMB := true

--- a/groups/boot-arch/project-celadon/fstab
+++ b/groups/boot-arch/project-celadon/fstab
@@ -20,7 +20,12 @@ system   /system  ext4 ro,barrier=1 wait{{#slot-ab}},slotselect{{/slot-ab}}{{#av
 {{^slot-ab}}
 /dev/block/by-name/cache        /cache          ext4    noatime,nosuid,nodev,errors=panic                           wait,check
 {{/slot-ab}}
+{{#high_security}}
+/dev/block/vdb         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}    noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#trusty}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}{{/trusty}},quota,reservedsize=50m{{#userdata_checkpoint}},latemount{{^data_use_f2fs}},checkpoint=block{{/data_use_f2fs}}{{#data_use_f2fs}},checkpoint=fs{{/data_use_f2fs}}{{/userdata_checkpoint}}
+{{/high_security}}
+{{^high_security}}
 /dev/block/by-name/{{#dynamic-partitions}}user{{/dynamic-partitions}}data         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}    noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#trusty}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}{{/trusty}},quota,reservedsize=50m{{#userdata_checkpoint}},latemount{{^data_use_f2fs}},checkpoint=block{{/data_use_f2fs}}{{#data_use_f2fs}},checkpoint=fs{{/data_use_f2fs}}{{/userdata_checkpoint}}
+{{/high_security}}
 /dev/block/by-name/boot         /boot           emmc    defaults                                                    defaults{{#slot-ab}},slotselect{{#avb}},avb{{/avb}}{{/slot-ab}}
 {{^slot-ab}}
 /dev/block/by-name/recovery     /recovery       emmc    defaults                                                    defaults

--- a/groups/boot-arch/project-celadon/fstab.recovery
+++ b/groups/boot-arch/project-celadon/fstab.recovery
@@ -20,7 +20,12 @@ system   /system  ext4 ro,barrier=1 wait{{#slot-ab}},slotselect{{/slot-ab}}{{#av
 {{^slot-ab}}
 /dev/block/by-name/cache        /cache          ext4    noatime,nosuid,nodev,errors=panic                           wait,check
 {{/slot-ab}}
+{{#high_security}}
+/dev/block/vdb         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}     noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#trusty}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}{{/trusty}}
+{{/high_security}}
+{{^high_security}}
 /dev/block/by-name/{{#dynamic-partitions}}user{{/dynamic-partitions}}data         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}     noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#trusty}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}{{/trusty}}
+{{/high_security}}
 /dev/block/by-name/boot         /boot           emmc    defaults                                                    defaults
 {{^slot-ab}}
 /dev/block/by-name/recovery     /recovery       emmc    defaults                                                    defaults

--- a/groups/boot-arch/project-celadon/option.spec
+++ b/groups/boot-arch/project-celadon/option.spec
@@ -43,3 +43,4 @@ verity_warning = true
 watchdog_parameters = false
 mfgos = false
 use_cic = false
+high_security = false


### PR DESCRIPTION
if high_security set to true,  will mount /dev/vdb as data partition

Tracked-On: OAM-91578
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>