### PR TITLE
Fix low volume on USB Headset in Passthrough mode

### DIFF
--- a/groups/audio/project-celadon/default/mixer_paths_usb.xml
+++ b/groups/audio/project-celadon/default/mixer_paths_usb.xml
@@ -1,0 +1,7 @@
+<mixer>
+  <!-- These are the initial mixer settings -->
+  <ctl name="Headset Playback Volume" value="24 24" />
+  <path name="usb_headset">
+    <ctl name="Headset Playback Volume" value="24 24" />
+  </path>
+</mixer>

--- a/groups/audio/project-celadon/product.mk
+++ b/groups/audio/project-celadon/product.mk
@@ -54,7 +54,8 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/default/effect/audio_effects.xml:vendor/etc/audio_effects.xml
 ifeq ($(BASE_YOCTO_KERNEL), true)
 PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/audio/default/mixer_paths_ehl.xml:vendor/etc/mixer_paths_0.xml
+    $(LOCAL_PATH)/audio/default/mixer_paths_ehl.xml:vendor/etc/mixer_paths_0.xml \
+    $(LOCAL_PATH)/audio/default/mixer_paths_usb.xml:vendor/etc/mixer_paths_usb.xml
 
 PRODUCT_PROPERTY_OVERRIDES += ro.vendor.hdmi.audio=ehl
 else


### PR DESCRIPTION
Touch tones are not heard via USB Headset in Passthrough mode.
Increase volume gain to the highest value for the mixer control.
This change adds the mixer control "Headset Playback Volume".

Tracked-On: OAM-91451
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>