### PR TITLE
CiV: support GOP patching

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -496,8 +496,14 @@ function launch_hwrender_gvtd(){
 	setup_vsock_host_utilities
 	common_options=${common_options/-display $display_type /}
 	common_options=${common_options/-vga none /-vga none -nographic}
+
+	CIV_GOP_DIR=$work_dir/GOP_PKG
+	if [ -f $CIV_GOP_DIR/GOP.rom ]; then
+		GOP_ROM="$CIV_GOP_DIR/GOP.rom"
+	fi
+
 	qemu-system-x86_64 \
-	-device vfio-pci,host=00:02.0,x-igd-gms=2,id=hostdev0,bus=pcie.0,addr=0x2,x-igd-opregion=on \
+	-device vfio-pci,host=00:02.0,x-igd-gms=2,id=hostdev0,bus=pcie.0,addr=0x2,x-igd-opregion=on,romfile=$GOP_ROM \
 	$WIFI_VFIO_OPTIONS \
 	${common_options/-device virtio-9p-pci,fsdev=fsdev0,mount_tag=hostshare /} > $qmp_log <<< "{ \"execute\": \"qmp_capabilities\" }"
 	setup_usb_vfio_passthrough remove


### PR DESCRIPTION
If $CIV_WORK_DIR/GOP_PKG folder exists, then do related steps.

The path structure of $CIV_WORK_DIR/GOP_PKG must be:
>     $CIV_WORK_DIR/GOP_PKG
>      ├--IntelGopDriver.efi
>      ├--ovmf/
>      |  ├--*.patch
>      |  └--Vbt.bin
>      └--qemu/
>         └--*.patch

Tracked-On: OAM-91560
Signed-off-by: Qi, Yadong <yadong.qi@intel.com>