### PR TITLE
Reduce the script sleep time in guest-pm-control

### DIFF
--- a/groups/device-specific/caas/guest_pm_control
+++ b/groups/device-specific/caas/guest_pm_control
@@ -65,14 +65,14 @@ def main():
                             print("VM is rebooting")
                             print("Reason: guest reset request")
                             cmdCommand = "reboot"
-                            time.sleep(3)
+                            time.sleep(2)
                             process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
                             break
                         elif "host-qmp-system-reset" in json.dumps(resp["data"]):
                             print("VM is rebooting")
                             print("Reason: Reboot triggered by host")
                             cmdCommand = "reboot"
-                            time.sleep(3)
+                            time.sleep(2)
                             process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
                             break
                         elif "host-qmp-quit" in json.dumps(resp["data"]):
@@ -91,13 +91,13 @@ def main():
                             print("VM is getting Shutdown")
                             print("Reason: An error prevents further use of guest and results in shutdown")
                         cmdCommand = "shutdown -h now"
-                        time.sleep(3)
+                        time.sleep(2)
                         process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
                     elif val == "SUSPEND":
                         # Put the host in to sleep state
                         cmdCommand = "systemctl suspend"
                         process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
-                        time.sleep(1)
+                        time.sleep(0.75)
                         # Send power button event to wake the android
                         cmdCommand = "./scripts/sendkey --vm 0 --power 0"
                         process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)


### PR DESCRIPTION
Reduce the sleep time to 2 seconds during guest SHUTDOWN and REBOOT
case. Also reduce the sleep time of script to 0.75 seconds in
SUSPEND case so that it does not create Qemu sync issues (eg, guest
wakeup even before the Host wake up)

Tracked-On: OAM-91610
Signed-off-by: Shwetha B <shwetha.b@intel.com>