### PR TITLE
Disable NN HAL

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -282,17 +282,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.neuralnetworks</name>
-        <transport>hwbinder</transport>
-        <version>1.2</version>
-        <interface>
-            <name>IDevice</name>
-            <instance>CPU</instance>
-            <instance>GPU</instance>
-            <instance>gpgpu</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.sensors</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
As NN inferencing not yet enabled in CIV, removing the enablement
patches to skip NNAPI CTS tests.

Tracked-On: OAM-91618
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>