### PR TITLE
[PM] Handle multiple suspend scenarios in guest

### DIFF
--- a/groups/device-specific/caas/guest_pm_control
+++ b/groups/device-specific/caas/guest_pm_control
@@ -33,6 +33,7 @@ def main():
         exit(1)
 
     qemu = qmp.QEMUMonitorProtocol(argv[1])
+    suspend_cnt = 0
 
     # Make a connection to QMP server. Break while loop only when the connection is made.
     # put a timeout 2 minutes if connection is not successful
@@ -94,13 +95,20 @@ def main():
                         time.sleep(3)
                         process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
                     elif val == "SUSPEND":
+                        if suspend_cnt == 1:
+                            cmdCommand = "./scripts/sendkey --vm 0 --power 0"
+                            process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
+                            suspend_cnt = 0;
+                            continue
                         # Put the host in to sleep state
                         cmdCommand = "systemctl suspend"
                         process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
+                        suspend_cnt = 1;
                         time.sleep(1)
                         # Send power button event to wake the android
                         cmdCommand = "./scripts/sendkey --vm 0 --power 0"
                         process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
+                        suspend_cnt = 0;
 
         except KeyboardInterrupt:
             print('interrupted!')


### PR DESCRIPTION
This patch is to handle the scenario if the guest sends multiple suspend events to Host.
When the host is already in suspend mode, and receives another suspend
command, we are just waking the guest.
Every time the guest wakes up, suspend_cnt values is toggled.
This ensures that multiple suspend commands are not sent to the Host.

Tracked-On: OAM-91610
signed-off-by: Kaushlendra Kumar <kaushlendra.kumar@intel.com>
Signed-off-by: Shwetha B <shwetha.b@intel.com>