### PR TITLE
usb-gadget: Update UDC name for CIV

### DIFF
--- a/groups/usb-gadget/auto/AndroidBoard.mk
+++ b/groups/usb-gadget/auto/AndroidBoard.mk
@@ -1,0 +1,1 @@
+AUTO_IN += $(TARGET_DEVICE_DIR)/{{_extra_dir}}/auto_hal.in

--- a/groups/usb-gadget/auto/BoardConfig.mk
+++ b/groups/usb-gadget/auto/BoardConfig.mk
@@ -1,0 +1,1 @@
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/usb-gadget/configfs

--- a/groups/usb-gadget/auto/auto_hal.in
+++ b/groups/usb-gadget/auto/auto_hal.in
@@ -1,0 +1,11 @@
+auto_hal() {
+case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in 
+	QEMU)
+		setprop vendor.usb.controller "dwc3.2.auto"
+		;;
+	*)
+		setprop vendor.usb.controller "dwc3.1.auto"
+		;;
+esac
+}
+auto_hal&

--- a/groups/usb-gadget/auto/files.spec
+++ b/groups/usb-gadget/auto/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+auto_hal.in: "auto USB device controller script"

--- a/groups/usb-gadget/auto/init.rc
+++ b/groups/usb-gadget/auto/init.rc
@@ -1,0 +1,157 @@
+on boot
+    mount configfs none /config
+    mkdir /config/usb_gadget/g1 0770 shell shell
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/bcdDevice {{{bcdDevice}}}
+    write /config/usb_gadget/g1/bcdUSB {{{bcdUSB}}}
+    mkdir /config/usb_gadget/g1/strings/0x409 0770
+    write /config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
+    write /config/usb_gadget/g1/strings/0x409/manufacturer ${ro.product.manufacturer}
+    write /config/usb_gadget/g1/strings/0x409/product ${ro.product.model}
+    mkdir /config/usb_gadget/g1/functions/ffs.adb
+    mkdir /config/usb_gadget/g1/functions/ffs.mtp
+    mkdir /config/usb_gadget/g1/functions/ffs.ptp
+    mkdir /config/usb_gadget/g1/functions/accessory.gs2
+    mkdir /config/usb_gadget/g1/functions/audio_source.gs3
+    mkdir /config/usb_gadget/g1/functions/rndis.gs4
+    mkdir /config/usb_gadget/g1/functions/midi.gs5
+{{#f_acm}}
+    mkdir /config/usb_gadget/g1/functions/acm.gs6
+    mkdir /config/usb_gadget/g1/functions/acm.gs7
+    mkdir /config/usb_gadget/g1/functions/acm.gs8
+    write /config/usb_gadget/g1/functions/acm.gs6/string_data at_commands
+    write /config/usb_gadget/g1/functions/acm.gs6/protocol_function_iad 0
+    write /config/usb_gadget/g1/functions/acm.gs6/protocol_interface_ctrl 0
+    write /config/usb_gadget/g1/functions/acm.gs7/string_data oct_trace
+    write /config/usb_gadget/g1/functions/acm.gs7/protocol_function_iad 0
+    write /config/usb_gadget/g1/functions/acm.gs7/protocol_interface_ctrl 0
+    write /config/usb_gadget/g1/functions/acm.gs8/string_data gti_ipicom
+    write /config/usb_gadget/g1/functions/acm.gs8/protocol_function_iad 0
+    write /config/usb_gadget/g1/functions/acm.gs8/protocol_interface_ctrl 0
+{{/f_acm}}
+{{#dvctrace_source_dev}}
+    mkdir /config/usb_gadget/g1/functions/dvctrace.{{{dvctrace_source_dev}}}
+{{/dvctrace_source_dev}}
+    mkdir /config/usb_gadget/g1/configs/b.1 0770 shell shell
+    mkdir /config/usb_gadget/g1/configs/b.1/strings/0x409 0770 shell shell
+{{#dvctrace_source_dev}}
+{{^f_dvc_trace}}
+    # This should not be removed
+    symlink /config/usb_gadget/g1/functions/dvctrace.{{{dvctrace_source_dev}}} /config/usb_gadget/g1/configs/b.1/f9
+{{/f_dvc_trace}}
+{{/dvctrace_source_dev}}
+    write /config/usb_gadget/g1/os_desc/b_vendor_code 0x1
+    write /config/usb_gadget/g1/os_desc/qw_sign "MSFT100"
+    write /config/usb_gadget/g1/configs/b.1/MaxPower 500
+    symlink /config/usb_gadget/g1/configs/b.1 /config/usb_gadget/g1/os_desc/b.1
+    mkdir /dev/usb-ffs 0775 shell shell
+    mkdir /dev/usb-ffs/adb 0770 shell shell
+    mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000
+    setprop sys.usb.configfs 1
+    setprop sys.usb.controller ${vendor.usb.controller}
+
+#create mtp+ffs gadget function
+    mkdir /dev/usb-ffs/mtp 0770 mtp mtp
+    mount functionfs mtp /dev/usb-ffs/mtp rmode=0770,fmode=0660,uid=1024,gid=1024,no_disconnect=1
+
+#create ptp+ffs gadget function
+    mkdir /dev/usb-ffs/ptp 0770 mtp mtp
+    mount functionfs ptp /dev/usb-ffs/ptp rmode=0770,fmode=0660,uid=1024,gid=1024,no_disconnect=1
+    setprop sys.usb.mtp.device_type 3
+
+on property:sys.usb.config=none && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/os_desc/use 0
+    setprop sys.usb.ffs.ready 0
+
+on property:sys.usb.config=mtp && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/functions/mtp.gs0/os_desc/interface.MTP/compatible_id "MTP"
+    write /config/usb_gadget/g1/os_desc/use 1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct 0x0a5e
+    symlink /config/usb_gadget/g1/functions/ffs.mtp /config/usb_gadget/g1/configs/b.1/f1
+
+on property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/functions/mtp.gs0/os_desc/interface.MTP/compatible_id "MTP"
+    write /config/usb_gadget/g1/os_desc/use 1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct {{{mtp_adb_pid}}}
+    symlink /config/usb_gadget/g1/functions/ffs.mtp /config/usb_gadget/g1/configs/b.1/f1
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f2
+
+on property:sys.usb.config=rndis && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct {{{rndis_pid}}}
+
+on property:sys.usb.config=rndis,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct {{{rndis_adb_pid}}}
+
+on property:sys.usb.config=ptp && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/functions/ptp.gs1/os_desc/interface.MTP/compatible_id "PTP"
+    write /config/usb_gadget/g1/os_desc/use 1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct 0x0a60
+    symlink /config/usb_gadget/g1/functions/ffs.ptp /config/usb_gadget/g1/configs/b.1/f1
+
+on property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/functions/ptp.gs1/os_desc/interface.MTP/compatible_id "PTP"
+    write /config/usb_gadget/g1/os_desc/use 1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct {{{ptp_adb_pid}}}
+    symlink /config/usb_gadget/g1/functions/ffs.ptp /config/usb_gadget/g1/configs/b.1/f1
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f2
+
+on property:sys.usb.config=adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct 0x09ef
+
+on property:sys.usb.config=midi && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct 0x0a65
+
+on property:sys.usb.config=midi,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct 0x0a67
+
+{{#dvctrace_source_dev}}
+{{#f_dvc_trace}}
+on property:sys.usb.config=adb,dvctrace && property:sys.usb.configfs=1
+    start adbd
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct 0x0a1f
+
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=adb,dvctrace && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "dvc_trace_adb"
+    rm /config/usb_gadget/g1/configs/b.1/f1
+    rm /config/usb_gadget/g1/configs/b.1/f2
+    rm /config/usb_gadget/g1/configs/b.1/f3
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
+    symlink /config/usb_gadget/g1/functions/dvctrace.{{{dvctrace_source_dev}}} /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+{{/f_dvc_trace}}
+{{/dvctrace_source_dev}}
+
+on property:sys.usb.config=accessory && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x18d1
+    write /config/usb_gadget/g1/idProduct 0x2d00
+
+on property:sys.usb.config=accessory,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x18d1
+    write /config/usb_gadget/g1/idProduct 0x2d01
+
+on property:sys.usb.config=audio_source && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x18d1
+    write /config/usb_gadget/g1/idProduct 0x2d02
+
+on property:sys.usb.config=audio_source,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x18d1
+    write /config/usb_gadget/g1/idProduct 0x2d03
+
+on property:sys.usb.config=accessory,audio_source && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x18d1
+    write /config/usb_gadget/g1/idProduct 0x2d04
+
+on property:sys.usb.config=accessory,audio_source,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/idVendor 0x18d1
+    write /config/usb_gadget/g1/idProduct 0x2d05

--- a/groups/usb-gadget/auto/init.recovery.rc
+++ b/groups/usb-gadget/auto/init.recovery.rc
@@ -1,0 +1,35 @@
+on boot
+    mkdir /config 0500 root root
+    mkdir /udiska 0666 root root
+    mkdir /udiskb 0666 root root
+    mount configfs none /config
+    mkdir /config/usb_gadget/g1 0770 shell shell
+    write /config/usb_gadget/g1/idVendor 0x8087
+    write /config/usb_gadget/g1/idProduct 0x09ef
+    write /config/usb_gadget/g1/bcdDevice {{{bcdDevice}}}
+    write /config/usb_gadget/g1/bcdUSB {{{bcdUSB}}}
+    mkdir /config/usb_gadget/g1/strings/0x409 0770
+    write /config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
+    write /config/usb_gadget/g1/strings/0x409/manufacturer ${ro.product.manufacturer}
+    write /config/usb_gadget/g1/strings/0x409/product ${ro.product.model}
+    mkdir /config/usb_gadget/g1/functions/ffs.adb
+    mkdir /config/usb_gadget/g1/functions/ffs.fastboot
+    mkdir /config/usb_gadget/g1/configs/b.1 0770 shell shell
+    mkdir /config/usb_gadget/g1/configs/b.1/strings/0x409 0770 shell shell
+    write /config/usb_gadget/g1/configs/b.1/MaxPower 500
+    mkdir /dev/usb-ffs 0775 shell shell
+    mkdir /dev/usb-ffs/adb 0770 shell shell
+    mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000
+    mkdir /dev/usb-ffs/fastboot 0770 system system
+    mount functionfs fastboot /dev/usb-ffs/fastboot rmode=0770,fmode=0660,uid=1000,gid=1000
+    setprop sys.usb.configfs 1
+    setprop sys.usb.controller {{{controller}}}
+
+on property:sys.usb.config=none && property:sys.usb.configfs=1
+    setprop sys.usb.ffs.ready 0
+
+on property:sys.usb.ffs.ready=1
+    symlink /config/usb_gadget/g1/configs/b.1 /config/usb_gadget/g1/os_desc/b.1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC {{controller}}

--- a/groups/usb-gadget/auto/mixinfo.spec
+++ b/groups/usb-gadget/auto/mixinfo.spec
@@ -1,0 +1,2 @@
+[mixinfo]
+deps = sepolicy

--- a/groups/usb-gadget/auto/option.spec
+++ b/groups/usb-gadget/auto/option.spec
@@ -1,0 +1,4 @@
+[defaults]
+dvctrace_source_dev =
+usb_config = mtp
+


### PR DESCRIPTION
In CIV, the device controller name is changed
to "dwc3.2.auto". So, utilize auto detection
framework to set this new UDC name for CIV.
For, other cases, UDC name will remain as
"dwc3.1.auto".

Tracked-On: OAM-91635
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>