### PR TITLE
Add nonroot user option for cic

### DIFF
--- a/groups/ais/true/addon/setup-aic
+++ b/groups/ais/true/addon/setup-aic
@@ -227,6 +227,8 @@ if [[ $SECURE == "false" ]]; then
   cp $AIC_WORK_DIR/update/customize-android $AIC_WORK_DIR/update/root/customize-android
   AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -u"
 else
+  # under secure mode, let root processes run as system user
+  AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -y"
   # Enable FBE for secure installation
   AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -g"
 


### PR DESCRIPTION
We will use '-y' flag to control the rootless feature,
with this flag, the root processes under android container
will run as system user. This flag is added to secure mode
by default.

Tracked-On: OAM-90885
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>