### PR TITLE
mixin: add software Trusted Platform Module to CIV

### DIFF
--- a/groups/device-specific/caas/setup_host.sh
+++ b/groups/device-specific/caas/setup_host.sh
@@ -193,6 +193,35 @@ function ubu_thermal_conf (){
 	systemctl start thermald.service
 }
 
+TPMS_VER=v0.7.0
+TPMS_LIB=libtpms-0.7.0
+SWTPM_VER=v0.2.0
+SWTPM=swtpm-0.2.0
+function install_swtpm(){
+	#install libtpms
+	apt-get -y install automake autoconf gawk
+	[ ! -f $TPMS_VER.tar.gz ] && wget https://github.com/stefanberger/libtpms/archive/$TPMS_VER.tar.gz -P $CIV_WORK_DIR
+	[ -d $CIV_WORK_DIR/$TPMS_LIB ] && rm -rf  $CIV_WORK_DIR/$TPMS_LIB
+	tar zxvf $CIV_WORK_DIR/$TPMS_VER.tar.gz
+	cd $CIV_WORK_DIR/$TPMS_LIB
+	./autogen.sh --with-tpm2 --with-openssl --prefix=/usr
+	make -j24
+	make -j24 check
+	make install
+	cd -
+
+	#install swtpm
+	apt-get -y install net-tools libseccomp-dev libtasn1-6-dev libgnutls28-dev expect
+	[ ! -f $SWTPM_VER.tar.gz ] && wget https://github.com/stefanberger/swtpm/archive/$SWTPM_VER.tar.gz -P $CIV_WORK_DIR
+	[ -d $CIV_WORK_DIR/$SWTPM ] && rm -rf  $CIV_WORK_DIR/$SWTPM
+	tar zxvf $CIV_WORK_DIR/$SWTPM_VER.tar.gz
+	cd $CIV_WORK_DIR/$SWTPM
+	./autogen.sh --with-openssl --prefix=/usr
+	make -j24
+	make install
+	cd -
+}
+
 version=`cat /proc/version`
 
 if [[ $version =~ "Ubuntu" ]]; then
@@ -216,6 +245,7 @@ if [[ $version =~ "Ubuntu" ]]; then
 	#starting Intel Thermal Deamon, currently supporting CML/EHL only.
 	ubu_thermal_conf
 	install_9p_module
+	install_swtpm
 	ask_reboot
 
 elif [[ $version =~ "Clear Linux OS" ]]; then

--- a/groups/device-specific/caas/start_flash_usb.sh
+++ b/groups/device-specific/caas/start_flash_usb.sh
@@ -33,6 +33,11 @@ else
 	display_type="gtk,gl=on"
 fi
 
+#start software Trusted Platform Module
+work_dir=$PWD
+mkdir -p $work_dir/myvtpm0
+swtpm socket --tpmstate dir=$work_dir/myvtpm0 --tpm2 --ctrl type=unixio,path=$work_dir/myvtpm0/swtpm-sock &
+
 qemu-system-x86_64 \
   -m 2048 -smp 2 -M q35 \
   -name caas-vm \
@@ -52,5 +57,8 @@ qemu-system-x86_64 \
   -no-reboot \
   -display $display_type \
   -boot menu=on,splash-time=5000,strict=on \
+  -chardev socket,id=chrtpm,path=./myvtpm0/swtpm-sock \
+  -tpmdev emulator,id=tpm0,chardev=chrtpm \
+  -device tpm-crb,tpmdev=tpm0 \
 
 echo "Flashing is completed"


### PR DESCRIPTION
1. install libtpms and swtpm library
2. start swtpm service when using start_flash_usb.sh
3. start swtpm service when launching android

Tracked-On: OAM-91814
Signed-off-by: Chen Gang G <gang.g.chen@intel.com>