### PR TITLE
Add RPMB simulation support for virtio_gpu

### DIFF
--- a/groups/device-specific/caas/start_android_qcow2.sh
+++ b/groups/device-specific/caas/start_android_qcow2.sh
@@ -581,12 +581,14 @@ function launch_virtio_gpu(){
 	setup_usb_vfio_passthrough setup
 	setup_audio
 	setup_vsock_host_utilities
+	setup_rpmb
 	qemu-system-x86_64 \
 	-device virtio-gpu-pci \
 	$WIFI_VFIO_OPTIONS \
 	$common_options > $qmp_log <<< "{ \"execute\": \"qmp_capabilities\" }"
 	setup_usb_vfio_passthrough remove
 	cleanup_vsock_host_utilities
+	cleanup_rpmb_sock
 }
 
 function launch_swrender(){


### PR DESCRIPTION
This changes help to add RPMB simulation support for virtio_gpu,
which could help fix the virtio_gpu launch issue.

Tracked-On: OAM-91857
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>