### PR TITLE
Fix for CTS testHidePid2 failure

### DIFF
--- a/groups/kernel/init.rc
+++ b/groups/kernel/init.rc
@@ -82,5 +82,8 @@ on property:sys.boot_completed=1
 
 {{/disable_cpuidle_on_boot}}
 
+on early-init
+	mount proc proc /proc remount hidepid=2,gid=3009
+
 on boot
 	setrlimit 8 8388608 8388608


### PR DESCRIPTION
Test case testHidePid2 is failing as /proc is not mounted with
hidepid=2 option.

Fix the issue by remounting /proc/ with hideId=2 and gid 3009
option so only users in group 3009 can see all information.

Tracked-On: OAM-91410
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>