### PR TITLE
Add frame rate limit for cts testcase c2.android.hevc.encoder.320x240

### DIFF
--- a/groups/codecs/configurable/media_codecs_performance_bxt.xml
+++ b/groups/codecs/configurable/media_codecs_performance_bxt.xml
@@ -82,6 +82,9 @@
             <Limit name="measured-frame-rate-1280x720" range="65-75" />
             <Limit name="measured-frame-rate-1920x1080" range="30-35" />
         </MediaCodec>
+        <MediaCodec name="c2.android.hevc.encoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="17-22" />
+        </MediaCodec>
         <MediaCodec name="c2.android.h263.encoder" type="video/3gpp" update="true">
             <Limit name="measured-frame-rate-176x144" range="710-790" />
         </MediaCodec>


### PR DESCRIPTION
Signed-off-by: zhezhu <zhe.zhu@intel.com>
Tracked-On: OAM-91815