### PR TITLE
intel-thermal-conf.xml: Remove thermal critical trip

### DIFF
--- a/groups/device-specific/caas/intel-thermal-conf.xml
+++ b/groups/device-specific/caas/intel-thermal-conf.xml
@@ -30,16 +30,6 @@
 					</TripPoint>
 				</TripPoints>
 			</ThermalZone>
-			<ThermalZone>
-				<Type>cpu_critical</Type>
-				<TripPoints>
-					<TripPoint>
-						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>99000</Temperature>
-						<Type>Critical</Type>
-					</TripPoint>
-				</TripPoints>
-			</ThermalZone>
 		</ThermalZones>
 		<CoolingDevices>
 			<CoolingDevice>
@@ -86,16 +76,6 @@
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>
 						</CoolingDevice>
-					</TripPoint>
-				</TripPoints>
-			</ThermalZone>
-			<ThermalZone>
-				<Type>cpu_critical</Type>
-				<TripPoints>
-					<TripPoint>
-						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>99000</Temperature>
-						<Type>Critical</Type>
 					</TripPoint>
 				</TripPoints>
 			</ThermalZone>
@@ -148,16 +128,6 @@
 					</TripPoint>
 				</TripPoints>
 			</ThermalZone>
-			<ThermalZone>
-				<Type>cpu_critical</Type>
-				<TripPoints>
-					<TripPoint>
-						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>99000</Temperature>
-						<Type>Critical</Type>
-					</TripPoint>
-				</TripPoints>
-			</ThermalZone>
 		</ThermalZones>
 		<CoolingDevices>
 			<CoolingDevice>
@@ -204,16 +174,6 @@
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>
 						</CoolingDevice>
-					</TripPoint>
-				</TripPoints>
-			</ThermalZone>
-			<ThermalZone>
-				<Type>cpu_critical</Type>
-				<TripPoints>
-					<TripPoint>
-						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>99000</Temperature>
-						<Type>Critical</Type>
 					</TripPoint>
 				</TripPoints>
 			</ThermalZone>


### PR DESCRIPTION
Thermal shutdown happens during benchmark tests and
stability tests because thermal daemon shuts down
after reaching critical temperature. Remove critical
trip from thermal daemon. Thermal shutdown can
alternatively tested by launching CIV with
--enable-vsock and --guest-pm options.

Tracked-On: OAM-91733
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>