### PR TITLE
Update volume gain for 3.5mm

### DIFF
--- a/groups/device-specific/caas/setup_audio_host.sh
+++ b/groups/device-specific/caas/setup_audio_host.sh
@@ -18,7 +18,7 @@ function enableHeadset {
 function setMicGain {
         echo "set alsa mic gain to $1%"
         `PULSE_SERVER=$pa_server PULSE_COOKIE=$pa_cookie $mic_gain_cmd $1%`
-        `PULSE_SERVER=$pa_server PULSE_COOKIE=$pa_cookie $audio_volume 30%`
+        `PULSE_SERVER=$pa_server PULSE_COOKIE=$pa_cookie $audio_volume 60%`
 }
 
 cpu_family=$(getCpuInfo 'family:')


### PR DESCRIPTION
Increase pulse audio volume gain to 60% from 30%.

Tracked-On: OAM-91531
Signed-off-by: padmashree9110 <padmashree.mandri@intel.com>