### PR TITLE
EM: Add phony script to build EM host utilities

### DIFF
--- a/groups/device-specific/caas/AndroidBoard.mk
+++ b/groups/device-specific/caas/AndroidBoard.mk
@@ -5,3 +5,11 @@ KERNEL_DIFFCONFIG += $(KERNEL_caas_DIFFCONFIG)
 
 # Specify /dev/mmcblk0 size here
 BOARD_MMC_SIZE = 15335424K
+
+.PHONY: em-host-utilities
+
+em-host-utilities:
+	cd device/intel/civ/host/backend/battery/vm_battery_utility && make
+	cp device/intel/civ/host/backend/battery/vm_battery_utility/batsys $(PRODUCT_OUT)/scripts/
+	cd device/intel/civ/host/backend/thermal/vm_thermal_utility && make
+	cp device/intel/civ/host/backend/thermal/vm_thermal_utility/thermsys $(PRODUCT_OUT)/scripts/

--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -26,8 +26,6 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     android.hardware.renderscript@1.0-impl \
                     android.hardware.graphics.composer@2.1-impl \
                     android.hardware.graphics.composer@2.1-service \
-                    batsys \
-                    thermsys \
                     vinput-manager \
                     sendkey
 
@@ -48,8 +46,6 @@ PRODUCT_COPY_FILES += device/intel/civ/host/vm-manager/scripts/setup_host.sh:$(P
 PRODUCT_COPY_FILES += device/intel/civ/host/vm-manager/scripts/guest_time_keeping.sh:$(PRODUCT_OUT)/scripts/guest_time_keeping.sh
 PRODUCT_COPY_FILES += device/intel/civ/host/vm-manager/scripts/start_flash_usb.sh:$(PRODUCT_OUT)/scripts/start_flash_usb.sh
 PRODUCT_COPY_FILES += vendor/intel/fw/trusty-release-binaries/rpmb_dev:$(PRODUCT_OUT)/scripts/rpmb_dev
-PRODUCT_COPY_FILES += device/intel/civ/host/backend/battery/bin/batsys:$(PRODUCT_OUT)/scripts/batsys
-PRODUCT_COPY_FILES += device/intel/civ/host/backend/thermal/bin/thermsys:$(PRODUCT_OUT)/scripts/thermsys
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/wakeup.py:$(PRODUCT_OUT)/scripts/wakeup.py
 PRODUCT_COPY_FILES += device/intel/civ/host/virtual-input-manager/bin/sendkey:$(PRODUCT_OUT)/scripts/sendkey
 PRODUCT_COPY_FILES += device/intel/civ/host/virtual-input-manager/bin/vinput-manager:$(PRODUCT_OUT)/scripts/vinput-manager


### PR DESCRIPTION
This patch adds a phony script to build battery
and thermal host utilities directly and put
them in scripts directory.

Tracked-On: OAM-91960
Signed-off-by: saranya <saranya.gopal@intel.com>