### PR TITLE
OpenCL libraries enabling for CAAS CiV.

### DIFF
--- a/groups/graphics/mesa/init.rc.1
+++ b/groups/graphics/mesa/init.rc.1
@@ -46,3 +46,6 @@ on boot
     chown media media /sys/kernel/debug/tracing/events/i915/i915_ring_wait_end/enable
     chown media media /sys/devices/pci0000:00/0000:00:02.0/drm/card0/gt_max_freq_mhz
     chown media media /sys/devices/pci0000:00/0000:00:02.0/drm/card0/gt_min_freq_mhz
+    #Give permission to system to check GEN Graphics device id
+    chown system system /sys/devices/pci0000:00/0000:00:02.0/device
+    chown system system /sys/devices/pci0000:00/0000:00:02.0/vendor

--- a/groups/graphics/mesa/product.mk
+++ b/groups/graphics/mesa/product.mk
@@ -1,7 +1,13 @@
 # Mesa
 PRODUCT_PACKAGES += \
     libGLES_mesa \
-    libGLES_android
+    libGLES_android \
+    libigdrcl \
+    libOpenCL \
+    libcommon_clang \
+    libigc \
+    libigdfcl
+
 
 PRODUCT_PACKAGES += \
     libdrm \

--- a/groups/media/mesa/product.mk
+++ b/groups/media/mesa/product.mk
@@ -10,6 +10,7 @@ PRODUCT_PACKAGES += \
 
 # Open source media_driver
 PRODUCT_PACKAGES += i965_drv_video
+PRODUCT_PACKAGES += libgmm_umd
 PRODUCT_PACKAGES += libigfxcmrt
 
 # Open source hdcp

--- a/groups/neuralnetworks/true/product.mk
+++ b/groups/neuralnetworks/true/product.mk
@@ -9,7 +9,10 @@ PRODUCT_PACKAGES += \
 
 PRODUCT_PACKAGES += \
     libMKLDNNPlugin\
-    libmkldnn
+    libmkldnn \
+    libmkldnn \
+    libclDNNPlugin \
+    libclDNN64
 
 PRODUCT_PACKAGES += \
     graphtest_cpu


### PR DESCRIPTION
Integrates OpenCL relevant share libraries;
Add the gen9 device access rules.

Change-Id: I09d8a353c89006975106de51ab3dedf54c0d3085
Tracked-On: OAM-91697
Signed-off-by: Wan Shuang <shuang.wan@intel.com>