### PR TITLE
Don't add FBE argument when support multi user

### DIFF
--- a/groups/ais/true/addon/setup-aic
+++ b/groups/ais/true/addon/setup-aic
@@ -229,8 +229,12 @@ if [[ $SECURE == "false" ]]; then
 else
   # under secure mode, let root processes run as system user
   AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -y"
-  # Enable FBE for secure installation
-  AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -g"
+
+  # FBE and multi user feature is conflict, can only support one of them
+  if [[ $MULTIPLE_USER == "false" ]]; then
+    # Enable FBE for secure installation
+    AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -g"
+  fi
 
   # lvm2 and thin-provisioning-tools are required by FBE
   if [ ! -x "$(command -v pvcreate)" ]; then


### PR DESCRIPTION
Multi user feature designed as dynamically bind different data
path for different host users, it's not compatible with FBE
feature, so don't add FBE argument when support multi user.

Pls revert this patch if we can find a good solution to support
both multi user and FBE at the same time later.

Tracked-On: OAM-92056
Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com>