### PR TITLE
Integrate the openCL relevant so files for caas target.

### DIFF
--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -3,7 +3,12 @@ PRODUCT_PACKAGES += \
     libGLESv1_CM_swiftshader \
     libGLESv2_swiftshader \
     libGLES_mesa \
-    libGLES_android
+    libGLES_android \
+    libigdrcl \
+    libOpenCL \
+    libcommon_clang \
+    libigc \
+    libigdfcl
 
 PRODUCT_PACKAGES += \
     libdrm \


### PR DESCRIPTION
The openCL relevant so files need to be added into mixin group
of graphic/auto/product.mk.

Change-Id: Ia487f6ec0678d68c3f65d7207c29d542aeff75d5
Tracked-On: OAM-92070
Signed-off-by: Wan Shuang <shuang.wan@intel.com>