### PR TITLE
Adding AAF support for 9p/pm/gfx

### DIFF
--- a/groups/aaf/true/auto_hal.in
+++ b/groups/aaf/true/auto_hal.in
@@ -1,11 +1,11 @@
 auto_hal() {
 
-config="/mnt/share/config.txt"
+GUEST_AAF_CONFIG="/mnt/share/mixins.spec"
 
-value=`grep -i suspend $config | cut -d ':' -f2`
+value=`grep -i suspend $GUEST_AAF_CONFIG | cut -d ':' -f2`
 setprop vendor.suspend $value
 
-gpu=`grep -i gpu-type $config | cut -d ':' -f2`
+gpu=`grep -i gpu-type $GUEST_AAF_CONFIG | cut -d ':' -f2`
 setprop vendor.gpu.type $gpu
 
 }

--- a/groups/aaf/true/init.rc
+++ b/groups/aaf/true/init.rc
@@ -6,7 +6,7 @@ on init
 
 on fs
     mkdir /mnt/share
-    mount 9p hostshare /mnt/share
+    mount 9p aaf /mnt/share
     exec - root root -- /vendor/bin/logwrapper /vendor/bin/sh /vendor/bin/auto_detection.sh
     setprop ro.hardware.egl ${vendor.egl.set}
     setprop ro.hardware.hwcomposer ${vendor.hwcomposer.set}


### PR DESCRIPTION
Changes-include:
   -Using 9pfs to share the file to /mnt/share
   -Set property for suspend,gpu-type
   -Enable/disable suspend using --allow-suspend option

Tracked-On: OAM-92075
Signed-off-by: rnaidu <ramya.v.naidu@intel.com>