### PR TITLE
Increase the super_partition_size for opencl so files integration.

### DIFF
--- a/groups/dynamic-partitions/true/option.spec
+++ b/groups/dynamic-partitions/true/option.spec
@@ -1,5 +1,5 @@
 [defaults]
-super_partition_size = 6400
+super_partition_size = 8000
 overhead_size = 4
 dp_retrofit = false
 super_img_in_flashzip = false


### PR DESCRIPTION
Existing partition size is too small to include opencl so files.
This caused the pre-integration build failure. So we extend the
size accordingly.

Change-Id: I0227815a9cfc91f13b7a4fbdc228b933c15d61e0
Tracked-On: OAM-92070
Signed-off-by: Wan Shuang <shuang.wan@intel.com>