### PR TITLE
usb: dbc: enable DbC for EHL guest

### DIFF
--- a/groups/dbc/true/init.rc
+++ b/groups/dbc/true/init.rc
@@ -6,6 +6,7 @@ on property:persist.vendor.sys.usb.adbover=dwc
 
 # switch adb over dbc
 on property:persist.vendor.sys.usb.adbover=dbc && property:sys.boot_completed=1
+    write /sys/bus/pci/devices/0000:00:06.0/dbc enable
     write /sys/bus/pci/devices/0000:00:14.0/dbc enable
     write /sys/bus/pci/devices/0000:00:15.0/dbc enable
     write /sys/bus/pci/devices/0000:00:16.0/dbc enable


### PR DESCRIPTION
xHCI PCI ID in EHL guest is 0000:00:06.0.
So adding this into dbc group.

Tracked-On: OAM-92261
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>