### PR TITLE
Disable FBE if multi-user feature is enabled

### DIFF
--- a/groups/ais/true/addon/setup-aic
+++ b/groups/ais/true/addon/setup-aic
@@ -231,7 +231,7 @@ else
   AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -y"
 
   # FBE and multi user feature is conflict, can only support one of them
-  if [[ $MULTIPLE_USER == "false" ]]; then
+  if [[ ! $MULTIPLE_USER == "true" ]]; then
     # Enable FBE for secure installation
     AIC_INSTALL_ARGUMENTS="$AIC_INSTALL_ARGUMENTS -g"
   fi


### PR DESCRIPTION
Currently multi user feature cannot co-exist with FBE feature,
so previously a patch is committed to disable FBE if multi user
is enabled. However if the '-j' arg is not applied to setup-aic,
the value of MULTIPLE_USER is empty, not false. So FBE is still not
enabled when the multi user feature is not enabled.
Need to modify the judge logic to enable FBE when multi user is
not enabled under the secure mode.

Tracked-On: OAM-92614
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>