### PR TITLE
[SDL] Remove root user privilege for watchdogd

### DIFF
--- a/groups/boot-arch/project-celadon/init.rc
+++ b/groups/boot-arch/project-celadon/init.rc
@@ -12,7 +12,7 @@ on fs
     {{/mountfstab-flag}}
 
 service watchdogd /system/bin/watchdogd{{#watchdog_parameters}} {{{watchdog_parameters}}}{{/watchdog_parameters}}
-    user root
+    user system
     class core
     oneshot
     seclabel u:r:watchdogd:s0


### PR DESCRIPTION
Change the user of watchdogd service to system from root
Tracked-On: OAM-92697
Signed-off-by: svenate <salini.venate@intel.com>