### PR TITLE
Add keybox provision feature

### DIFF
--- a/groups/trusty/true/init.rc
+++ b/groups/trusty/true/init.rc
@@ -10,6 +10,14 @@ on early-boot
 service storageproxyd /vendor/bin/storageproxyd -d /dev/trusty-ipc-dev0 -p /data/vendor/securestorage -r /dev/vport0p1 -t virt
     user system
     group system
+
+on boot
+    start keyboxd
+
+service keyboxd /vendor/bin/keybox_provisioning -d /dev/trusty-ipc-dev0 -p /dev/block/by-name/teedata
+    user system
+    group system
+    oneshot
 {{/enable_storage_proxyd}}
 {{/enable_hw_sec}}
 

--- a/groups/trusty/true/product.mk
+++ b/groups/trusty/true/product.mk
@@ -22,6 +22,7 @@ PRODUCT_PACKAGES += \
 	gatekeeper.trusty \
 	android.hardware.gatekeeper@1.0-impl \
 	android.hardware.gatekeeper@1.0-service \
+	keybox_provisioning \
 
 PRODUCT_PACKAGES_DEBUG += \
 	intel-secure-storage-unit-test \


### PR DESCRIPTION
Keybox service is used to provision keybox at boot stage. Before
provisioning keybox, keybox data must be written to teedata partition
at fastboot mode.

Keybox can be provisioned only one time. Once keybox has been
provisioned, it cannot be provisioned again.

Tracked-On: OAM-92859
Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>