### PR TITLE
load_modules: Fix issue with load_modules

### DIFF
--- a/groups/load_modules/true/init.rc
+++ b/groups/load_modules/true/init.rc
@@ -1,14 +1,9 @@
 service load_modules /vendor/bin/load_modules.sh
-    user 5200
-    group shell
+    user system
+    group system shell
     capabilities SYS_MODULE MKNOD
     oneshot
     disabled
 
-{{^firststage-mount}}
-on fs
-{{/firststage-mount}}
-{{#firststage-mount}}
-on early-init
-{{/firststage-mount}}
+on init
     start load_modules


### PR DESCRIPTION
This patch makes required changes to make
load_modules script start in the latest
build. The load_modules script now has
system permissions and also starts on
init.

Tracked-On: OAM-92853
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>