### PR TITLE
Add mapper 2.1 support

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -21,6 +21,7 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     android.hardware.camera.provider@2.4-impl \
                     android.hardware.camera.provider@2.4-service \
                     android.hardware.graphics.mapper@2.0-impl \
+                    android.hardware.graphics.mapper@2.0-impl-2.1 \
                     android.hardware.graphics.allocator@2.0-impl \
                     android.hardware.graphics.allocator@2.0-service \
                     android.hardware.renderscript@1.0-impl \


### PR DESCRIPTION
This change is to help support mapper 2.1

Tracked-On: OAM-92929
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>