### PR TITLE
Add android.software.vulkan.deqp.level to pass CTS case

### DIFF
--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -106,6 +106,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.vulkan.version-1_1.xml:vendor/etc/permissions/android.hardware.vulkan.version.xml
 
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.vulkan.deqp.level-2020-03-01.xml:vendor/etc/permissions/android.software.vulkan.deqp.level.xml
+
 PRODUCT_PACKAGES += \
     vulkan.$(TARGET_BOARD_PLATFORM) \
     libvulkan_intel


### PR DESCRIPTION
Android 11 CTS needs android.software.vulkan.deqp.level to pass
testVulkanDeqpLevel case in CtsGraphicsTestCases module

Tracked-On: OAM-92949
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>