### PR TITLE
mixins: storage: Add replacement for sdcardsfs

### DIFF
--- a/groups/storage/sdcard-mmc0-v-usb-sd-r/fstab
+++ b/groups/storage/sdcard-mmc0-v-usb-sd-r/fstab
@@ -1,0 +1,6 @@
+*/usb*/*/host*/*/block/sdb*              auto             vfat    defaults                                   voldmanaged=usbdisk:auto{{#adoptableusb}},encryptable=userdata{{/adoptableusb}}
+*/usb*/*/host*/*/block/sdc*              auto             vfat    defaults                                   voldmanaged=usbdisk:auto{{#adoptableusb}},encryptable=userdata{{/adoptableusb}}
+*/usb*/*/host*/*/block/sdd*              auto             vfat    defaults                                   voldmanaged=usbdisk:auto{{#adoptableusb}},encryptable=userdata{{/adoptableusb}}
+*/block/sda*                        auto            auto    defaults                                   voldmanaged=sdcard1:auto,encryptable=userdata
+/dev/block/sda1                    /sdcard          vfat    defaults                                   recoveryonly
+

--- a/groups/storage/sdcard-mmc0-v-usb-sd-r/fstab.recovery
+++ b/groups/storage/sdcard-mmc0-v-usb-sd-r/fstab.recovery
@@ -1,0 +1,2 @@
+/dev/block/sdb1                         /udiskb          vfat    defaults                                   voldmanaged=udiskb:auto
+/dev/block/sda1                    /sdcard          vfat    defaults                                   voldmanaged=sdcard:auto

--- a/groups/storage/sdcard-mmc0-v-usb-sd-r/init.rc
+++ b/groups/storage/sdcard-mmc0-v-usb-sd-r/init.rc
@@ -1,0 +1,4 @@
+on init
+    # Support legacy paths
+    symlink /sdcard /mnt/sdcard
+    symlink /sdcard /storage/sdcard0

--- a/groups/storage/sdcard-mmc0-v-usb-sd-r/product.mk
+++ b/groups/storage/sdcard-mmc0-v-usb-sd-r/product.mk
@@ -1,0 +1,1 @@
+$(call inherit-product, $(SRC_TARGET_DIR)/product/emulated_storage.mk)


### PR DESCRIPTION
This patch adds fuse replacement for sdcardfs to
comply with Android 11 CDD.

Tracked-On: OAM-92905
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>