### PR TITLE
Change hwc & gralloc library name

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -2,8 +2,8 @@ auto_hal() {
 case "$(cat /proc/fb)" in
         *i915drmfb)
                 echo "intel"
-                setprop vendor.hwcomposer.set intel
-                setprop vendor.gralloc.set intel
+                setprop vendor.hwcomposer.set celadon
+                setprop vendor.gralloc.set celadon
                 setprop vendor.hwcomposer.edid.all 0
                 case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
                         QEMU)
@@ -16,8 +16,8 @@ case "$(cat /proc/fb)" in
                 ;;
         *inteldrmfb)
                 echo "intel"
-                setprop vendor.hwcomposer.set intel
-                setprop vendor.gralloc.set intel
+                setprop vendor.hwcomposer.set celadon
+                setprop vendor.gralloc.set celadon
                 setprop vendor.hwcomposer.edid.all 0
 	        case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
                         QEMU)

--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -37,10 +37,7 @@ PRODUCT_PACKAGES += \
 
 # HWComposer IA
 PRODUCT_PACKAGES += \
-    hwcomposer.$(TARGET_GFX_INTEL)
-
-# PRODUCT_PROPERTY_OVERRIDES += \
-#   ro.hardware.hwcomposer=$(TARGET_GFX_INTEL)
+    hwcomposer.$(TARGET_BOARD_PLATFORM)
 
 INTEL_HWC_CONFIG := $(INTEL_PATH_VENDOR)/external/hwcomposer-intel
 
@@ -53,12 +50,10 @@ endif
 
 {{#minigbm}}
 # Mini gbm
-# PRODUCT_PROPERTY_OVERRIDES += \
-#    ro.hardware.gralloc=$(TARGET_GFX_INTEL)
 
 PRODUCT_PACKAGES += \
     gralloc.minigbm \
-    gralloc.$(TARGET_GFX_INTEL)
+    gralloc.$(TARGET_BOARD_PLATFORM)
 {{/minigbm}}
 
 {{^minigbm}}


### PR DESCRIPTION
This is to help change hwc & gralloc library name
from "intel" to "celadon". With this change, we
could delete some bsp diff

Tracked-On: OAM-92961
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>