### PR TITLE
Remove Dumpstate HAL for now

### DIFF
--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -209,15 +209,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.dumpstate</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IDumpstateDevice</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.camera.provider</name>
         <transport>hwbinder</transport>
         <version>2.4</version>

--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -182,15 +182,6 @@
         <fqname>@1.1::IDrmFactory/widevine</fqname>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.dumpstate</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IDumpstateDevice</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.camera.provider</name>
         <transport>hwbinder</transport>
         <version>2.4</version>

--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -15,8 +15,6 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     android.hardware.keymaster@3.0-service \
                     android.hardware.usb@1.0-impl \
                     android.hardware.usb@1.0-service \
-                    android.hardware.dumpstate@1.0-impl \
-                    android.hardware.dumpstate@1.0-service \
                     camera.device@1.0-impl \
                     android.hardware.camera.provider@2.4-impl \
                     android.hardware.camera.provider@2.4-service \


### PR DESCRIPTION
This patch removes the optional Dumpstate HAL for now.
This is crashing and blocking developer options to work.
This will be revisited and enabled at a later stage.

Tracked-On: OAM-92709
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>