### PR TITLE
iwlwifi: cleanup iwlwifi mixins

### DIFF
--- a/groups/wlan/iwlwifi/BoardConfig.mk
+++ b/groups/wlan/iwlwifi/BoardConfig.mk
@@ -7,59 +7,7 @@ WPA_SUPPLICANT_VERSION := VER_2_1_DEVEL
 BOARD_WLAN_DEVICE := iwlwifi
 {{/libwifi-hal}}
 
-BOARD_WPA_SUPPLICANT_PRIVATE_LIB ?= lib_driver_cmd_intc
-
-# Enabling iwlwifi
-BOARD_USING_INTEL_IWL := true
-INTEL_IWL_MODULE_SUB_FOLDER := {{{iwl_sub_folder}}}
-INTEL_IWL_PLATFORM := {{{iwl_platform}}}
-INTEL_IWL_BOARD_CONFIG := {{{iwl_defconfig}}}
-INTEL_IWL_PNVM_HW := {{{iwl_pnvm_hw}}}
-INTEL_IWL_USE_COMPAT_INSTALL := y
-INTEL_IWL_COMPAT_INSTALL_DIR := updates
-INTEL_IWL_COMPAT_INSTALL_PATH ?= .
-INTEL_IWL_INSTALL_MOD_STRIP := INSTALL_MOD_STRIP=1
-CROSS_COMPILE ?= CROSS_COMPILE=$(YOCTO_CROSSCOMPILE)
-INSTALLED_KERNEL_TARGET ?= $(PREVIOUS_KERNEL_MODULE)
-KERNEL_OUT_DIR ?= $(PRODUCT_OUT)/obj/kernel
-
-COMBO_CHIP_VENDOR := intel
-COMBO_CHIP := lnp
-
-# SoftAp FW reload definitions.
-# we don't really need this, it's to avoid error when the framework
-# will trigger the fwReloadSoftap function, what will lead to an error
-# enabling the SoftAp.
-# so we set up this for letting the function execute gracefully.
-WIFI_DRIVER_FW_PATH_STA := "/vendor/firmware/iwlwifi-softap-dummy.ucode"
-WIFI_DRIVER_FW_PATH_AP  := "/vendor/firmware/iwlwifi-softap-dummy.ucode"
-WIFI_DRIVER_FW_PATH_P2P := "/vendor/firmware/iwlwifi-softap-dummy.ucode"
-WIFI_DRIVER_FW_PATH_PARAM := "/dev/null"
-
-# config_wifi_background_scan_support=true:
-DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-pno
-
-DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-tcp-buffers
-
-# Add SIM , AKA and AKA' methods in EAP entries of WiFi UI
-DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-eap-methods
-
-ifneq (lhp,$(INTEL_IWL_MODULE_SUB_FOLDER))
-    DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-dual-band
-endif
-
-# WiDi / Miracast Optimisations
-DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-miracast-go
-DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-p2p-connected-stop-scan
-DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-miracast-force-single-ch
-
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/load_iwlwifi
-
-{{#gpp}}
-ifeq ($(findstring cws_manu,$(BOARD_SEPOLICY_DIRS)),)
-    BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/cws_manu
-endif
-{{/gpp}}
 
 BOARD_SEPOLICY_M4DEFS += module_iwlwifi=true
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/iwlwifi

--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -1,13 +1,5 @@
 on post-fs-data
     chmod 0660 /data/misc/wifi/p2p_supplicant.conf
-
-    # create config WiFi NVM folder
-    mkdir /oem_config/wlan 0770 wifi system
-{{#gpp}}
-    start wlan_rest_nvm
-    wait /oem_config/wlan/iwl_nvm.bin
-{{/gpp}}
-
     setprop wifi.interface wlan0
     setprop wifi.direct.interface p2p-dev-wlan0
 
@@ -19,11 +11,15 @@ on zygote-start
 
 service dhcpcd_wlan0 /system/bin/dhcpcd -ABDKL
     class main
+    user wifi
+    group wifi system dhcp inet
     disabled
     oneshot
 
 service iprenew_wlan0 /system/bin/dhcpcd -n
     class main
+    user wifi
+    group wifi system dhcp inet
     disabled
     oneshot
 
@@ -42,18 +38,13 @@ service wpa_supplicant /vendor/bin/hw/wpa_supplicant \
     oneshot
 
 service dhcpcd_p2p /system/bin/dhcpcd -aABKL
+    user wifi
+    group wifi system dhcp inet
     disabled
     oneshot
 
 service iprenew_p2p /system/bin/dhcpcd -n
-    disabled
-    oneshot
-
-{{#gpp}}
-service wlan_rest_nvm /system/bin/wlan_intel_restore.sh
-    class main
     user wifi
-    group system wifi
+    group wifi system dhcp inet
     disabled
     oneshot
-{{/gpp}}

--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -8,20 +8,7 @@ PRODUCT_PACKAGES += \
     iw
 
 PRODUCT_PACKAGES += \
-  android.hardware.wifi@1.0-service
-
-# FW and PNVM
-PRODUCT_PACKAGES += \
-{{#firmware}}
-    {{firmware}} \
-{{/firmware}}
-{{#nvm}}
-    iwl-nvm
-{{/nvm}}
-
-# iwlwifi USC
-PRODUCT_PACKAGES += \
-    wifi_intel_usc
+    android.hardware.wifi@1.0-service
 
 #copy iwlwifi wpa config files
 PRODUCT_COPY_FILES += \
@@ -30,25 +17,5 @@ PRODUCT_COPY_FILES += \
         $(INTEL_PATH_COMMON)/wlan/iwlwifi/p2p_supplicant_overlay.conf:vendor/etc/wifi/p2p_supplicant_overlay.conf \
         frameworks/native/data/etc/android.hardware.wifi.xml:vendor/etc/permissions/android.hardware.wifi.xml \
         frameworks/native/data/etc/android.hardware.wifi.direct.xml:vendor/etc/permissions/android.hardware.wifi.direct.xml
-
-PRODUCT_COPY_FILES += \
-    vendor/linux/firmware/iwlwifi-9260-th-b0-jf-b0-43.ucode:$(TARGET_COPY_OUT_VENDOR)/firmware/iwlwifi-9260-th-b0-jf-b0-43.ucode \
-    vendor/linux/firmware/iwlwifi-3168-29.ucode:$(TARGET_COPY_OUT_VENDOR)/firmware/iwlwifi-3168-29.ucode \
-    vendor/linux/firmware/iwlwifi-8265-36.ucode:$(TARGET_COPY_OUT_VENDOR)/firmware/iwlwifi-8265-36.ucode
-
-{{#gpp}}
-# Add Manufacturing tool
-PRODUCT_PACKAGES += \
-    wlan_intel_restore.sh
-{{/gpp}}
-
-{{#softap_dualband_allow}}
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
-    ro.wifi.softap_dualband_allow=true
-{{/softap_dualband_allow}}
-{{^softap_dualband_allow}}
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
-    ro.wifi.softap_dualband_allow=false
-{{/softap_dualband_allow}}
 
 PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-disable_keepalive_offload


### PR DESCRIPTION
Changes include:
- Remove not used config from iwlwifi mixins
- Added correct user and group for dhcpcd

Tracked-On: OAM-93073
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>