### PR TITLE
Rename HWC & Gralloc library name to "intel"

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -2,8 +2,8 @@ auto_hal() {
 case "$(cat /proc/fb)" in
         *i915drmfb)
                 echo "intel"
-                setprop vendor.hwcomposer.set celadon
-                setprop vendor.gralloc.set celadon
+                setprop vendor.hwcomposer.set intel
+                setprop vendor.gralloc.set intel
                 setprop vendor.hwcomposer.edid.all 0
                 case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
                         QEMU)
@@ -16,8 +16,8 @@ case "$(cat /proc/fb)" in
                 ;;
         *inteldrmfb)
                 echo "intel"
-                setprop vendor.hwcomposer.set celadon
-                setprop vendor.gralloc.set celadon
+                setprop vendor.hwcomposer.set intel
+                setprop vendor.gralloc.set intel
                 setprop vendor.hwcomposer.edid.all 0
 	        case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in
                         QEMU)

--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -32,12 +32,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     hwcomposer.drm_minigbm
 
-# PRODUCT_PROPERTY_OVERRIDES += \
-#   ro.hardware.hwcomposer=drm
-
 # HWComposer IA
 PRODUCT_PACKAGES += \
-    hwcomposer.$(TARGET_BOARD_PLATFORM)
+    hwcomposer.$(TARGET_GFX_INTEL)
 
 INTEL_HWC_CONFIG := $(INTEL_PATH_VENDOR)/external/hwcomposer-intel
 
@@ -53,14 +50,12 @@ endif
 
 PRODUCT_PACKAGES += \
     gralloc.minigbm \
-    gralloc.$(TARGET_BOARD_PLATFORM)
+    gralloc.$(TARGET_GFX_INTEL)
 {{/minigbm}}
 
 {{^minigbm}}
-#Gralloc
-# PRODUCT_PROPERTY_OVERRIDES += \
-#    ro.hardware.gralloc=drm
 
+#Gralloc
 PRODUCT_PACKAGES += \
     gralloc.drm
 {{/minigbm}}


### PR DESCRIPTION
We need support SW rendering dynamicly, which uses
"default" property. If we name HWC & Gralloc to
"celadon", HWC "celadon" will be loaded instead of
"default" for SW rendering, as 1a583d5c518 set the
"ro.board.platform" to "celadon"

Tracked-On: OAM-93101
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>