### PR TITLE
Revert "Upgrade hwc API version for Android 11"

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -127,7 +127,7 @@
     <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
-        <version>2.3</version>
+        <version>2.1</version>
         <interface>
             <name>IComposer</name>
             <instance>default</instance>

--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -22,7 +22,8 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     android.hardware.graphics.allocator@2.0-impl \
                     android.hardware.graphics.allocator@2.0-service \
                     android.hardware.renderscript@1.0-impl \
-                    android.hardware.graphics.composer@2.3-service\
+                    android.hardware.graphics.composer@2.1-impl \
+                    android.hardware.graphics.composer@2.1-service\
 					android.hardware.health@2.1-service\
 					android.hardware.health@2.1-impl
 


### PR DESCRIPTION
revert due to unable booting regression.