### PR TITLE
wifi: Set BOARD_WPA_SUPPLICANT_PRIVATE_LIB to lib_driver_cmd_intc

### DIFF
--- a/groups/wlan/iwlwifi/BoardConfig.mk
+++ b/groups/wlan/iwlwifi/BoardConfig.mk
@@ -7,6 +7,8 @@ WPA_SUPPLICANT_VERSION := VER_2_1_DEVEL
 BOARD_WLAN_DEVICE := iwlwifi
 {{/libwifi-hal}}
 
+BOARD_WPA_SUPPLICANT_PRIVATE_LIB ?= lib_driver_cmd_intc
+
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/load_iwlwifi
 
 BOARD_SEPOLICY_M4DEFS += module_iwlwifi=true


### PR DESCRIPTION
Wi-Fi supplicant VTS test cases are failingi.

Wi-Fi supplicant VTS test cases are failing as vendor specific
supplicant library is not set.

Fixed the issue by setting BOARD_WPA_SUPPLICANT_PRIVATE_LIB
to lib_driver_cmd_intc.

Tracked-On: OAM-94267
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>