### PR TITLE
Increase super_partition_size for OneAPI IPP library integration

### DIFF
--- a/groups/dynamic-partitions/true/option.spec
+++ b/groups/dynamic-partitions/true/option.spec
@@ -1,5 +1,5 @@
 [defaults]
-super_partition_size = 8000
+super_partition_size = 10000
 overhead_size = 4
 dp_retrofit = false
 super_img_in_flashzip = false


### PR DESCRIPTION
Existing partition size is too small to include OneAPI IPP so files.
This caused the pre-integration build failure. So we extend the
size accordingly

Tracked-On:
Signed-off-by: ahs <amrita.h.s@intel.com>