### PR TITLE
thermal: Disable thermal daemon for CIV

### DIFF
--- a/groups/thermal/thermal-daemon/AndroidBoard.mk
+++ b/groups/thermal/thermal-daemon/AndroidBoard.mk
@@ -1,0 +1,1 @@
+AUTO_IN += $(TARGET_DEVICE_DIR)/{{_extra_dir}}/auto_hal.in

--- a/groups/thermal/thermal-daemon/auto_hal.in
+++ b/groups/thermal/thermal-daemon/auto_hal.in
@@ -1,0 +1,11 @@
+auto_hal() {
+case "$(cat /sys/class/dmi/id/chassis_vendor | head -1)" in 
+	QEMU)
+		setprop vendor.thermal.enable 0
+		;;
+	*)
+		setprop vendor.thermal.enable 1
+		;;
+esac
+}
+auto_hal&

--- a/groups/thermal/thermal-daemon/files.spec
+++ b/groups/thermal/thermal-daemon/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+auto_hal.in: "auto thermal daemon enable/disable script"

--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -2,6 +2,7 @@ service thermal-daemon /system/vendor/bin/thermal-daemon --config-file /system/v
     class main
     user system
     group system
+    disabled
 
 on boot
     chown system system /sys/devices/system/cpu/intel_pstate/max_perf_pct
@@ -19,3 +20,5 @@ on post-fs-data
     setprop persist.thermal.mode thermal-daemon
     mkdir /data/vendor/thermal-daemon 0660 system system
 
+on property:sys.boot_completed=1 && property:vendor.thermal.enable=1
+    start thermal-daemon


### PR DESCRIPTION
In CIV, thermal management is done by host OS
and so thermal daemon should be disabled in guest.
This patch adds auto_hal script to start thermal
daemon only if it is not running as a VM.

Tracked-On: OAM-94301
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>