### PR TITLE
Set service.adb.tcp.port to 5555

### DIFF
--- a/groups/device-specific/caas/system.prop
+++ b/groups/device-specific/caas/system.prop
@@ -10,3 +10,4 @@ ro.board.platform=celadon
 audio.safemedia.bypass=true
 debug.nn.cpuonly=0
 camera.disable_treble=false
+service.adb.tcp.port=5555


### PR DESCRIPTION
This patch sets the service.adb.tcp.port to 5555
This is needed in case of User Build to enable ADB functionality.
In Android 11 vendor_init cannot set shell_prop.

Tracked-On: OAM-93155
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>