### PR TITLE
Enable Gatekeeper HAL

### DIFF
--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -51,25 +51,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gatekeeper</name>
-        {{#trusty}}
-        {{^gk_force_passthrough}}
-        <transport>hwbinder</transport>
-        {{/gk_force_passthrough}}
-        {{#gk_force_passthrough}}
-        <transport arch="32+64">passthrough</transport>
-        {{/gk_force_passthrough}}
-        {{/trusty}}
-        {{^trusty}}
-        <transport arch="32+64">passthrough</transport>
-        {{/trusty}}
-        <version>1.0</version>
-        <interface>
-            <name>IGatekeeper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.light</name>
         <transport>hwbinder</transport>
         <version>2.0</version>

--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -51,25 +51,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gatekeeper</name>
-        {{#trusty}}
-        {{^gk_force_passthrough}}
-        <transport>hwbinder</transport>
-        {{/gk_force_passthrough}}
-        {{#gk_force_passthrough}}
-        <transport arch="32+64">passthrough</transport>
-        {{/gk_force_passthrough}}
-        {{/trusty}}
-        {{^trusty}}
-        <transport arch="32+64">passthrough</transport>
-        {{/trusty}}
-        <version>1.0</version>
-        <interface>
-            <name>IGatekeeper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.light</name>
         <transport>hwbinder</transport>
         <version>2.0</version>

--- a/groups/device-specific/caas/option.spec
+++ b/groups/device-specific/caas/option.spec
@@ -1,7 +1,6 @@
 [defaults]
 target = caas
 ref_target = caas
-gk_force_passthrough = false
 ota-update = false
 
 [mixinfo]

--- a/groups/device-specific/caas_dev/framework_manifest.xml
+++ b/groups/device-specific/caas_dev/framework_manifest.xml
@@ -51,25 +51,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gatekeeper</name>
-        {{#trusty}}
-        {{^gk_force_passthrough}}
-        <transport>hwbinder</transport>
-        {{/gk_force_passthrough}}
-        {{#gk_force_passthrough}}
-        <transport arch="32+64">passthrough</transport>
-        {{/gk_force_passthrough}}
-        {{/trusty}}
-        {{^trusty}}
-        <transport arch="32+64">passthrough</transport>
-        {{/trusty}}
-        <version>1.0</version>
-        <interface>
-            <name>IGatekeeper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.light</name>
         <transport>hwbinder</transport>
         <version>2.0</version>

--- a/groups/device-specific/caas_dev/manifest.xml
+++ b/groups/device-specific/caas_dev/manifest.xml
@@ -51,25 +51,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gatekeeper</name>
-        {{#trusty}}
-        {{^gk_force_passthrough}}
-        <transport>hwbinder</transport>
-        {{/gk_force_passthrough}}
-        {{#gk_force_passthrough}}
-        <transport arch="32+64">passthrough</transport>
-        {{/gk_force_passthrough}}
-        {{/trusty}}
-        {{^trusty}}
-        <transport arch="32+64">passthrough</transport>
-        {{/trusty}}
-        <version>1.0</version>
-        <interface>
-            <name>IGatekeeper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.light</name>
         <transport>hwbinder</transport>
         <version>2.0</version>

--- a/groups/device-specific/caas_dev/option.spec
+++ b/groups/device-specific/caas_dev/option.spec
@@ -1,7 +1,6 @@
 [defaults]
 target = caas_dev
 ref_target = caas_dev
-gk_force_passthrough = false
 ota-update = false
 
 [mixinfo]

--- a/groups/device-specific/celadon_ivi/manifest.xml
+++ b/groups/device-specific/celadon_ivi/manifest.xml
@@ -51,25 +51,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gatekeeper</name>
-        {{#trusty}}
-        {{^gk_force_passthrough}}
-        <transport>hwbinder</transport>
-        {{/gk_force_passthrough}}
-        {{#gk_force_passthrough}}
-        <transport arch="32+64">passthrough</transport>
-        {{/gk_force_passthrough}}
-        {{/trusty}}
-        {{^trusty}}
-        <transport arch="32+64">passthrough</transport>
-        {{/trusty}}
-        <version>1.0</version>
-        <interface>
-            <name>IGatekeeper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.audio</name>
         <transport>hwbinder</transport>
         <version>5.0</version>

--- a/groups/device-specific/celadon_ivi/option.spec
+++ b/groups/device-specific/celadon_ivi/option.spec
@@ -1,7 +1,6 @@
 [defaults]
 target = celadon_ivi
 ref_target = celadon_ivi
-gk_force_passthrough = false
 ota-update = false
 
 [mixinfo]

--- a/groups/device-specific/celadon_tablet/manifest.xml
+++ b/groups/device-specific/celadon_tablet/manifest.xml
@@ -41,25 +41,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gatekeeper</name>
-        {{#trusty}}
-        {{^gk_force_passthrough}}
-        <transport>hwbinder</transport>
-        {{/gk_force_passthrough}}
-        {{#gk_force_passthrough}}
-        <transport arch="32+64">passthrough</transport>
-        {{/gk_force_passthrough}}
-        {{/trusty}}
-        {{^trusty}}
-        <transport arch="32+64">passthrough</transport>
-        {{/trusty}}
-        <version>1.0</version>
-        <interface>
-            <name>IGatekeeper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.light</name>
         <transport>hwbinder</transport>
         <version>2.0</version>

--- a/groups/device-specific/celadon_tablet/option.spec
+++ b/groups/device-specific/celadon_tablet/option.spec
@@ -1,7 +1,6 @@
 [defaults]
 target = celadon_tablet
 ref_target = celadon_tablet
-gk_force_passthrough = false
 ota-update = false
 
 [mixinfo]

--- a/groups/trusty/false/BoardConfig.mk
+++ b/groups/trusty/false/BoardConfig.mk
@@ -1,0 +1,1 @@
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/trusty/disabled

--- a/groups/trusty/false/product.mk
+++ b/groups/trusty/false/product.mk
@@ -1,0 +1,2 @@
+PRODUCT_PACKAGES += \
+    android.hardware.gatekeeper@1.0-service.software

--- a/groups/trusty/true/BoardConfig.mk
+++ b/groups/trusty/true/BoardConfig.mk
@@ -8,7 +8,7 @@ endif
 BOARD_USES_TRUSTY := true
 BOARD_USES_KEYMASTER1 := true
 {{/enable_hw_sec}}
-BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/trusty
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/trusty/enabled
 BOARD_SEPOLICY_M4DEFS += module_trusty=true
 
 TRUSTY_BUILDROOT = $(PWD)/$(PRODUCT_OUT)/obj/trusty/

--- a/groups/trusty/true/product.mk
+++ b/groups/trusty/true/product.mk
@@ -19,9 +19,7 @@ PRODUCT_PACKAGES += \
 	storageproxyd \
 	libinteltrustystorage \
 	libinteltrustystorageinterface \
-	gatekeeper.trusty \
-	android.hardware.gatekeeper@1.0-impl \
-	android.hardware.gatekeeper@1.0-service \
+	android.hardware.gatekeeper@1.0-service.trusty \
 
 PRODUCT_PACKAGES_DEBUG += \
 	intel-secure-storage-unit-test \


### PR DESCRIPTION
There are two different binary dor the case:
Trusty enabled:
android.hardware.gatekeeper@1.0-service.trusty
Trusty disabled:
android.hardware.gatekeeper@1.0-service.software

The different sepolicy for the both are enabled.

Tracked-On: OAM-93148
Signed-off-by: Huang Yang <yang.huang@intel.com>