### PR TITLE
Fixing  wifi modules not loading issues

### DIFF
--- a/groups/wlan/iwlwifi/AndroidBoard.mk
+++ b/groups/wlan/iwlwifi/AndroidBoard.mk
@@ -1,8 +1,0 @@
-{{#iwl_upstream_drv}}
-LOAD_MODULES_IN += $(TARGET_DEVICE_DIR)/{{_extra_dir}}/load_legacy_iwlwifi.in
-{{/iwl_upstream_drv}}
-{{^iwl_upstream_drv}}
-LOCAL_KERNEL_PATH := $(abspath $(PRODUCT_OUT)/obj/kernel) is not defined yet
-$(abspath $(PRODUCT_OUT)/obj/kernel)/copy_modules: iwlwifi
-LOAD_MODULES_IN += $(TARGET_DEVICE_DIR)/{{_extra_dir}}/load_iwlwifi.in
-{{/iwl_upstream_drv}}

--- a/groups/wlan/iwlwifi/files.spec
+++ b/groups/wlan/iwlwifi/files.spec
@@ -1,3 +1,0 @@
-[extrafiles]
-load_iwlwifi.in: "load wlan driver module"
-load_legacy_iwlwifi.in: "load wlan driver module"

--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -3,6 +3,15 @@ on post-fs-data
     setprop wifi.interface wlan0
     setprop wifi.direct.interface p2p-dev-wlan0
 
+on post-fs
+{{^iwl_upstream_drv}}
+    insmod /vendor/lib/modules/compat.ko
+{{/iwl_upstream_drv}} 
+    insmod /vendor/lib/modules/cfg80211.ko
+    insmod /vendor/lib/modules/mac80211.ko
+    insmod /vendor/lib/modules/iwlwifi.ko
+    insmod /vendor/lib/modules/iwlmvm.ko power_scheme=1
+
 on zygote-start
     # Create the directories used by the Wireless subsystem
     mkdir /data/vendor/wifi 0771 wifi wifi

--- a/groups/wlan/iwlwifi/load_iwlwifi.in
+++ b/groups/wlan/iwlwifi/load_iwlwifi.in
@@ -1,9 +1,0 @@
-load_iwlwifi_modules() {
-    insmod $modules/compat.ko
-
-    insmod $modules/cfg80211.ko
-    insmod $modules/mac80211.ko
-    insmod $modules/iwlwifi.ko d0i3_disable=1
-    insmod $modules/iwlmvm.ko power_scheme=1
-}
-load_iwlwifi_modules&

--- a/groups/wlan/iwlwifi/load_legacy_iwlwifi.in
+++ b/groups/wlan/iwlwifi/load_legacy_iwlwifi.in
@@ -1,7 +1,0 @@
-load_iwlwifi_modules() {
-    insmod $modules/cfg80211.ko
-    insmod $modules/mac80211.ko
-    insmod $modules/iwlwifi.ko d0i3_disable=1
-    insmod $modules/iwlmvm.ko power_scheme=1
-}
-load_iwlwifi_modules&


### PR DESCRIPTION
wifi modules are not loaded during adb reboot and
sometimes during boot.so now modules will be loaded
at init.rc on post-fs property.

Tracked-On: OAM-94223
Signed-off-by: Balaji Manoharan m.balaji@intel.com
Signed-off-by: Jeevaka Prabu Badrappan jeevaka.badrappan@intel.com