### PR TITLE
Add perf variants of libraries into product pakages

### DIFF
--- a/groups/avx/auto/AndroidBoard.mk
+++ b/groups/avx/auto/AndroidBoard.mk
@@ -1,0 +1,28 @@
+# kernel modules must be copied before vendorimage is generated
+$(PRODUCT_OUT)/super.img: handle_isa_perf_modules
+
+ISA_PERF_LIB_PATH:= "IA-Perf/avx2"
+isa_perf_libs: avx2_libs
+
+avx2_libs: libneuralnetworks_avx2 \
+	   libaudioprocessing_avx2 \
+	   libRSCpuRef_avx2 \
+	   libart_avx2.com.android.art.debug \
+	   libart_avx2.com.android.art.release \
+	   libartd_avx2.com.android.art.debug
+
+handle_isa_perf_modules: isa_perf_libs
+	mv $(PRODUCT_OUT)/system/lib/$(ISA_PERF_LIB_PATH)/libaudioprocessing_avx2.so $(PRODUCT_OUT)/system/lib/$(ISA_PERF_LIB_PATH)/libaudioprocessing.so
+	mv $(PRODUCT_OUT)/system/lib64/$(ISA_PERF_LIB_PATH)/libaudioprocessing_avx2.so $(PRODUCT_OUT)/system/lib64/$(ISA_PERF_LIB_PATH)/libaudioprocessing.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.neuralnetworks/lib/$(ISA_PERF_LIB_PATH)/libneuralnetworks_avx2.so $(PRODUCT_OUT)/system/apex/com.android.neuralnetworks/lib/$(ISA_PERF_LIB_PATH)/libneuralnetworks.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.neuralnetworks/lib64/$(ISA_PERF_LIB_PATH)/libneuralnetworks_avx2.so $(PRODUCT_OUT)/system/apex/com.android.neuralnetworks/lib64/$(ISA_PERF_LIB_PATH)/libneuralnetworks.so
+	mv $(PRODUCT_OUT)/system/lib/$(ISA_PERF_LIB_PATH)/libRSCpuRef_avx2.so $(PRODUCT_OUT)/system/lib/$(ISA_PERF_LIB_PATH)/libRSCpuRef.so
+	mv $(PRODUCT_OUT)/system/lib64/$(ISA_PERF_LIB_PATH)/libRSCpuRef_avx2.so $(PRODUCT_OUT)/system/lib64/$(ISA_PERF_LIB_PATH)/libRSCpuRef.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.vndk.current/lib/$(ISA_PERF_LIB_PATH)/libRSCpuRef_avx2.so $(PRODUCT_OUT)/system/apex/com.android.vndk.current/lib/$(ISA_PERF_LIB_PATH)/libRSCpuRef.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.vndk.current/lib64/$(ISA_PERF_LIB_PATH)/libRSCpuRef_avx2.so $(PRODUCT_OUT)/system/apex/com.android.vndk.current/lib64/$(ISA_PERF_LIB_PATH)/libRSCpuRef.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.art.release/lib/$(ISA_PERF_LIB_PATH)/libart_avx2.so $(PRODUCT_OUT)/system/apex/com.android.art.release/lib/$(ISA_PERF_LIB_PATH)/libart.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.art.release/lib64/$(ISA_PERF_LIB_PATH)/libart_avx2.so $(PRODUCT_OUT)/system/apex/com.android.art.release/lib64/$(ISA_PERF_LIB_PATH)/libart.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.art.debug/lib/$(ISA_PERF_LIB_PATH)/libart_avx2.so $(PRODUCT_OUT)/system/apex/com.android.art.debug/lib/$(ISA_PERF_LIB_PATH)/libart.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.art.debug/lib64/$(ISA_PERF_LIB_PATH)/libart_avx2.so $(PRODUCT_OUT)/system/apex/com.android.art.debug/lib64/$(ISA_PERF_LIB_PATH)/libart.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.art.debug/lib/$(ISA_PERF_LIB_PATH)/libartd_avx2.so $(PRODUCT_OUT)/system/apex/com.android.art.debug/lib/$(ISA_PERF_LIB_PATH)/libartd.so
+	mv $(PRODUCT_OUT)/system/apex/com.android.art.debug/lib64/$(ISA_PERF_LIB_PATH)/libartd_avx2.so $(PRODUCT_OUT)/system/apex/com.android.art.debug/lib64/$(ISA_PERF_LIB_PATH)/libartd.so

--- a/groups/avx/auto/product.mk
+++ b/groups/avx/auto/product.mk
@@ -1,1 +1,8 @@
-PRODUCT_COPY_FILES += $(LOCAL_PATH)/extra_files/avx/checkavx.sh:vendor/bin/checkavx.sh 
+PRODUCT_COPY_FILES += $(LOCAL_PATH)/extra_files/avx/checkavx.sh:vendor/bin/checkavx.sh
+
+PRODUCT_PACKAGES += libaudioprocessing_avx2 \
+		    libneuralnetworks_avx2 \
+		    libRSCpuRef_avx2 \
+		    libart_avx2.com.android.art.debug \
+		    libart_avx2.com.android.art.release \
+		    libartd_avx2.com.android.art.debug


### PR DESCRIPTION
This enables us to have One-image catering to multiple
IA CPUs which may or may not support all ISA features.
Example: Pentium SKUs dont support AVX.

Tracked-On: OAM-94488
Signed-off-by: ahs <amrita.h.s@intel.com>