### PR TITLE
exclude DRM interface from framework-manifest

### DIFF
--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -164,23 +164,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.drm</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>ICryptoFactory</name>
-            <instance>default</instance>
-        </interface>
-        <interface>
-            <name>IDrmFactory</name>
-            <instance>default</instance>
-        </interface>
-        <fqname>@1.1::ICryptoFactory/clearkey</fqname>
-        <fqname>@1.1::IDrmFactory/clearkey</fqname>
-        <fqname>@1.1::ICryptoFactory/widevine</fqname>
-        <fqname>@1.1::IDrmFactory/widevine</fqname>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.usb</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
such interface is declared in project manifest instead.
The duplicated interface will cause CTS failures.

Tracked-On: OAM-94521
Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>