### PR TITLE
x86_64_defconfig: Enable incremental FS

### DIFF
--- a/groups/kernel/gmin64/config-lts/lts2019-chromium/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/lts2019-chromium/x86_64_defconfig
@@ -6066,7 +6066,7 @@ CONFIG_FUSE_FS=y
 # CONFIG_CUSE is not set
 # CONFIG_VIRTIO_FS is not set
 # CONFIG_OVERLAY_FS is not set
-# CONFIG_INCREMENTAL_FS is not set
+CONFIG_INCREMENTAL_FS=y
 
 #
 # Caches


### PR DESCRIPTION
This patch enables incremental FS which is a
new feature in Android 11.

Tracked-On: OAM-94234
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>