### PR TITLE
Adding new binder domain for vendor services

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -13,6 +13,8 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/ueventd.rc:root/ueventd.$(TARGET_PRODUCT).rc \
 {{/treble}}
 
+PRODUCT_PACKAGES += vndservicemanager
+
 PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     android.hardware.keymaster@3.0-service \
                     android.hardware.usb@1.0-impl \


### PR DESCRIPTION
Android 8 supports a new binder domain for use by vendor
services, accessed using /dev/vndbinder instead of /dev/binder.
With the addition of /dev/vndbinder.

Devices launching with Android 11 or later which need to use
these features must explicitly opt into using vndservicemanager
by specifying PRODUCT_PACKAGES += vndservicemanager.

Tracked-On: OAM-95426
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>