### PR TITLE
Enable aidl light hal service

### DIFF
--- a/groups/lights/true/product.mk
+++ b/groups/lights/true/product.mk
@@ -3,6 +3,4 @@ BOARD_SEPOLICY_DIRS += \
     $(INTEL_PATH_SEPOLICY)/light
 
 PRODUCT_PACKAGES += lights.$(TARGET_BOARD_PLATFORM) \
-    android.hardware.light@2.0-service \
-    android.hardware.light@2.0-impl
-
+    android.hardware.lights-service.intel


### PR DESCRIPTION
This patch enables the light hal service for aidl.

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>