### PR TITLE
mixin configuration for partner_module

### DIFF
--- a/groups/googleservice/gms/product.mk
+++ b/groups/googleservice/gms/product.mk
@@ -1,4 +1,5 @@
 FLAG_GMS_AVAILABLE ?= true
 ifeq ($(FLAG_GMS_AVAILABLE),true)
 $(call inherit-product-if-exists, vendor/google/gms/products/gms.mk)
+$(call inherit-product, vendor/partner_modules/build/mainline_modules.mk)
 endif


### PR DESCRIPTION
This is the mixin configuration for partner_modules.
Partner_module is required to pass GTS tests. 

Linked to issue: OAM-94563

Tracked-On:OAM-95453
Signed-off-by: svenate <salini.venate@intel.com>