### PR TITLE
Mixin changes for using Power HAL AIDL

### DIFF
--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -173,15 +173,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.power</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IPower</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.boot</name>
         <transport>hwbinder</transport>
         <version>1.0</version>

--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -161,15 +161,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.power</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IPower</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.boot</name>
         <transport>hwbinder</transport>
         <version>1.0</version>

--- a/groups/power/true/BoardConfig.mk
+++ b/groups/power/true/BoardConfig.mk
@@ -11,4 +11,4 @@ HAS_THD := true
 {{/has_thd}}
 
 BOARD_SEPOLICY_M4DEFS += module_power=true
-#BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/power
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/power

--- a/groups/power/true/product.mk
+++ b/groups/power/true/product.mk
@@ -1,6 +1,5 @@
 # Power HAL
 PRODUCT_PACKAGES += power.$(TARGET_BOARD_PLATFORM) \
-                    android.hardware.power@1.0-service \
-                    android.hardware.power@1.0-impl \
+                    android.hardware.power-service.example \
                     power_hal_helper
 


### PR DESCRIPTION
Removing the entry for power from manifest.xml and
framework_manifest.xml because it will be added to
VINTF manifest in vendor-intel-hardware-interfaces

Include the sepolicy for Power in Boardconfig.mk

Tracked On: OAM-95367
Signed-off-by: Shwetha B <shwetha.b@intel.com>