### PR TITLE
Disable casefold/projectid

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -32,6 +32,12 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
 PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce
 PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.useautofastjni=true
 
+PRODUCT_QUOTA_PROJID := 0
+PRODUCT_PROPERTY_OVERRIDES += external_storage.projid.enabled=0
+
+PRODUCT_FS_CASEFOLD := 0
+PRODUCT_PROPERTY_OVERRIDES += external_storage.casefold.enabled=0
+
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.device_admin.xml:vendor/etc/permissions/android.software.device_admin.xml \
     frameworks/native/data/etc/android.software.managed_users.xml:vendor/etc/permissions/android.software.managed_users.xml \

--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -38,6 +38,11 @@ PRODUCT_PROPERTY_OVERRIDES += external_storage.projid.enabled=0
 PRODUCT_FS_CASEFOLD := 0
 PRODUCT_PROPERTY_OVERRIDES += external_storage.casefold.enabled=0
 
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.crypto.volume.metadata.method=dm-default-key \
+    ro.crypto.dm_default_key.options_format.version=2 \
+    ro.crypto.volume.options=::v2
+
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.device_admin.xml:vendor/etc/permissions/android.software.device_admin.xml \
     frameworks/native/data/etc/android.software.managed_users.xml:vendor/etc/permissions/android.software.managed_users.xml \


### PR DESCRIPTION
Disable optional casefold/projectid. Revert this patch once
the kernel support is enabled.

Tracked-On:
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>