### PR TITLE
Enabling the Dreams support

### DIFF
--- a/groups/device-specific/caas/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/groups/device-specific/caas/overlay/frameworks/base/core/res/res/values/config.xml
@@ -180,7 +180,7 @@
          Consider setting this resource to false or disabling dreams by default when a
          doze component is specified below since dreaming will supercede dozing and
          will prevent the system from entering a low power state until the dream ends. -->
-    <bool name="config_dreamsSupported">false</bool>
+    <bool name="config_dreamsSupported">true</bool>
 
     <!-- Arbitrary max 8 users. -->
     <integer name="config_multiuserMaximumUsers">8</integer>


### PR DESCRIPTION
Enabled the dreams support in config file to fix the failures
in CtsWindowManagerDeviceTestCases module.

Tracked-On: OAM-95553
Signed-off-by: mbegumx <mogalx.begum@intel.com>