### PR TITLE
Start thermal-daemon without conf file

### DIFF
--- a/groups/device-specific/caas/thermald.service
+++ b/groups/device-specific/caas/thermald.service
@@ -5,7 +5,7 @@ Description=Thermal Daemon Service
 Type=dbus
 SuccessExitStatus=1
 BusName=org.freedesktop.thermald
-ExecStart=/usr/sbin/thermald --config-file=/etc/thermald/intel-thermal-conf.xml --no-daemon --dbus-enable
+ExecStart=/usr/sbin/thermald --no-daemon --dbus-enable
 
 [Install]
 WantedBy=multi-user.target

--- a/groups/device-specific/caas_dev/thermald.service
+++ b/groups/device-specific/caas_dev/thermald.service
@@ -5,7 +5,7 @@ Description=Thermal Daemon Service
 Type=dbus
 SuccessExitStatus=1
 BusName=org.freedesktop.thermald
-ExecStart=/usr/sbin/thermald --config-file=/etc/thermald/intel-thermal-conf.xml --no-daemon --dbus-enable
+ExecStart=/usr/sbin/thermald --no-daemon --dbus-enable
 
 [Install]
 WantedBy=multi-user.target

--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -1,4 +1,4 @@
-service thermal-daemon /system/vendor/bin/thermal-daemon --config-file /system/vendor/etc/thermal-daemon/thermal-conf.xml
+service thermal-daemon /system/vendor/bin/thermal-daemon
     class main
     user system
     group system


### PR DESCRIPTION
As numbers in conf file are not tuned, start the thermal-daemon
without config file.

Tracked-On: OAM-94251
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>