### PR TITLE
Removing not used automotive-evs HAL

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -170,16 +170,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.automotive.evs</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IEvsEnumerator</name>
-            <instance>EvsEnumeratorHw</instance>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.renderscript</name>
         <transport arch="32+64">passthrough</transport>
         <version>1.0</version>


### PR DESCRIPTION
This patch removes the HAL automotive-evs which is unused.

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>