### PR TITLE
update drm interfaces to fix sts issue

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -139,15 +139,6 @@
     <hal format="hidl">
         <name>android.hardware.drm</name>
         <transport>hwbinder</transport>
-        <version>1.3</version>
-        <interface>
-            <name>ICryptoFactory</name>
-            <instance>default</instance>
-        </interface>
-        <interface>
-            <name>IDrmFactory</name>
-            <instance>default</instance>
-        </interface>
         <fqname>@1.3::ICryptoFactory/clearkey</fqname>
         <fqname>@1.3::IDrmFactory/clearkey</fqname>
     </hal>


### PR DESCRIPTION
there're 2 reasons to remove default 1.3:
1. default implementation of drm is actually unavailable from v1.1+,
   update hardly to 1.3 caused sts failure, so we need revert it back.
2. for target-api level 5, drm interface v1.3 is allowed only, just revert back
   is not enough to match level 5 requirement, so we remove 1.0/default 
   to avoid compiling error.

Tracked-on: OAM-95524
Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>