### PR TITLE
Revert "Upgrade hwc api version to 2.4"

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -99,7 +99,7 @@
     <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
-        <version>2.4</version>
+        <version>2.1</version>
         <interface>
             <name>IComposer</name>
             <instance>default</instance>

--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -26,7 +26,8 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
                     android.hardware.graphics.allocator@2.0-impl \
                     android.hardware.graphics.allocator@2.0-service \
                     android.hardware.renderscript@1.0-impl \
-                    android.hardware.graphics.composer@2.4-service
+                    android.hardware.graphics.composer@2.1-impl \
+                    android.hardware.graphics.composer@2.1-service
 
 
 PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce


### PR DESCRIPTION
This reverts commit b46b3416e54f32b2b02d1a90482397661c13ab88.

upgrade hwc api version to 2.4 will make Virtio mode not work 

Signed-off-by: Kanli Hu <kanlix.hu@intel.com>