### PR TITLE
Revert disablement of projectid

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -31,9 +31,6 @@ PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
 PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce
 PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.useautofastjni=true
 
-PRODUCT_QUOTA_PROJID := 0
-PRODUCT_PROPERTY_OVERRIDES += external_storage.projid.enabled=0
-
 PRODUCT_FS_CASEFOLD := 0
 PRODUCT_PROPERTY_OVERRIDES += external_storage.casefold.enabled=0
 


### PR DESCRIPTION
This patch will address SETXATTR failure and
also testPrimaryStorage CTS failue.

Tracked-On: OAM-95586
Signed-off-by: nitishat <nitisha.tomar@intel.com>