### PR TITLE
fix vendor boot image build failure

### DIFF
--- a/groups/vendor-boot/true/AndroidBoard.mk
+++ b/groups/vendor-boot/true/AndroidBoard.mk
@@ -8,5 +8,6 @@ vendor_boot_prebuilt:
 	$(hide) if [ -d "$(BOARD_PREBUILT_VENDOR_BOOT_DIR)" ]; then \
 		$(ACP) -r $(BOARD_PREBUILT_VENDOR_BOOT_DIR)/* $(TARGET_VENDOR_RAMDISK_OUT)/; \
 	fi
+	$(ACP) $(TARGET_DEVICE_DIR)/fstab $(TARGET_VENDOR_RAMDISK_OUT)/first_stage_ramdisk/fstab.$(TARGET_PRODUCT)
 
 $(INTERNAL_VENDOR_RAMDISK_TARGET): vendor_boot_prebuilt

--- a/groups/vendor-boot/true/product.mk
+++ b/groups/vendor-boot/true/product.mk
@@ -1,2 +1,0 @@
-PRODUCT_COPY_FILES += \
-        $(LOCAL_PATH)/fstab:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/fstab.$(TARGET_PRODUCT)


### PR DESCRIPTION
Move the copy action in product.mk to Android.mk.
When built with multi-thread, folder TARGET_VENDOR_RAMDISK_OUT may be removed
by command in Android.mk asynchronously. In this case, file copy to folder
TARGET_VENDOR_RAMDISK_OUT in product.mk will be failure and result in build
failure.

Tracked-On: OAM-95693
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>