### PR TITLE
audio server restart on boot complete

### DIFF
--- a/groups/audio/project-celadon/init.rc
+++ b/groups/audio/project-celadon/init.rc
@@ -1,2 +1,6 @@
 on boot
     insmod /vendor/lib/modules/snd-dummy.ko
+
+on property:sys.boot_completed=1 && property:ro.vendor.hdmi.audio=tgl
+    stop audioserver
+    start audioserver


### PR DESCRIPTION
Since hda driver is unable to get the HDMI
sound devices, it is waiting till the timeout
and then listing the ALC256 cards.
By then Android would have started the Audioserver
and finds that there are no sink devices availabe.
Till we get the HDMI solution working this can be
a WA fix for the audio 3.5mm playback

Tracked-On: OAM-95721
Signed-off-by: gkdeepa g.k.deepa@intel.com