### PR TITLE
Added check to fix testNeverallowRules1051 in CTS

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -1,6 +1,8 @@
 TARGET_BOARD_PLATFORM := celadon
 
+ifneq ($(TARGET_BUILD_VARIANT),user)
 PRODUCT_REQUIRES_INSECURE_EXECMEM_FOR_SWIFTSHADER := true
+endif
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.rc:root/init.recovery.$(TARGET_PRODUCT).rc \


### PR DESCRIPTION
Added a check while Allowing system_server to use execmem in
non-user builds with software rendering.

Tracked-On: OAM-96007
Signed-off-by: mbegumx <mogalx.begum@intel.com>