### PR TITLE
Replace /data/logs with /data/vendor/logs

### DIFF
--- a/groups/debug-crashlogd/true/init.crashlogd.rc
+++ b/groups/debug-crashlogd/true/init.crashlogd.rc
@@ -36,8 +36,8 @@ on property:logd.logpersistd=logcatd
 
 on property:logd.logpersistd=clear
     stop vendor.aplog
-    exec u:r:logsvc:s0 -- /vendor/bin/rm -rf /data/logs/aplogs
-    mkdir /data/logs/aplogs 0775 system log
+    exec u:r:logsvc:s0 -- /vendor/bin/rm -rf {{logs_dir}}/aplogs
+    mkdir {{logs_dir}}/aplogs 0775 system log
 
 service vendor.logfs /vendor/bin/logfs.sh
     group root shell log

--- a/groups/debug-crashlogd/true/option.spec
+++ b/groups/debug-crashlogd/true/option.spec
@@ -1,4 +1,4 @@
 [defaults]
-logs_dir = /data/logs
+logs_dir = /data/vendor/logs
 ramdump =
 logger_rot_cnt = 100


### PR DESCRIPTION
/data/logs is needed by crashlogd, which is developed by Intel.
As a vendor domain, it should to store its data to /data/vendor
basing on the treble requirement.

Tracked-On: OAM-95647
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>