### PR TITLE
Use make, complier and linker from prebuilts

### DIFF
--- a/groups/device-specific/caas/AndroidBoard.mk
+++ b/groups/device-specific/caas/AndroidBoard.mk
@@ -6,18 +6,24 @@ KERNEL_DIFFCONFIG += $(KERNEL_caas_DIFFCONFIG)
 # Specify /dev/mmcblk0 size here
 BOARD_MMC_SIZE = 15335424K
 
+LOCAL_CLANG_PATH = $(CLANG_PREBUILTS_PATH)/host/$(HOST_OS)-x86/$(KERNEL_CLANG_VERSION)/bin
+
+LOCAL_MAKE:= \
+        PATH="$(LOCAL_CLANG_PATH):$(PWD)/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8/x86_64-linux/bin:$$PATH" \
+	$(PWD)/prebuilts/build-tools/linux-x86/bin/make
+
 .PHONY: vinput-manager
 vinput-manager:
-	cd device/intel/civ/host/virtual-input-manager && make
+	cd device/intel/civ/host/virtual-input-manager && $(LOCAL_MAKE)
 	cp device/intel/civ/host/virtual-input-manager/vinput-manager $(PRODUCT_OUT)/scripts/
 	cp device/intel/civ/host/virtual-input-manager/sendkey $(PRODUCT_OUT)/scripts/
 
 .PHONY: em-host-utilities
 em-host-utilities:
 	mkdir -p $(PRODUCT_OUT)/scripts/
-	cd device/intel/civ/host/backend/battery/vm_battery_utility && make
+	cd device/intel/civ/host/backend/battery/vm_battery_utility && $(LOCAL_MAKE)
 	cp device/intel/civ/host/backend/battery/vm_battery_utility/batsys $(PRODUCT_OUT)/scripts/
-	cd device/intel/civ/host/backend/thermal/vm_thermal_utility && make
+	cd device/intel/civ/host/backend/thermal/vm_thermal_utility && $(LOCAL_MAKE)
 	cp device/intel/civ/host/backend/thermal/vm_thermal_utility/thermsys $(PRODUCT_OUT)/scripts/
 
 .PHONY: host-pkg

--- a/groups/kernel/AndroidBoard.mk
+++ b/groups/kernel/AndroidBoard.mk
@@ -128,6 +128,10 @@ CHECK_CONFIG_LOG :=  $(LOCAL_KERNEL_PATH)/.config.check
 
 KERNEL_DEPS := $(shell find $(LOCAL_KERNEL_SRC) \( -name *.git -prune \) -o -print )
 
+KERNEL_MAKE_CMD:= \
+      PATH="$(PWD)/prebuilts/build-tools/linux-x86/bin:$(TARGET_KERNEL_CLANG_PATH):$(PWD)/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8/x86_64-linux/bin:$$PATH" \
+      make -j24
+
 # Before building final defconfig with debug diffconfigs
 # Check that base defconfig is correct. Check is performed
 # by comparing generated .config with .config.old if it exists.
@@ -141,7 +145,7 @@ $(CHECK_CONFIG_LOG): $(KERNEL_DEFCONFIG) $(KERNEL_DEPS)
 	-$(hide) [[ -e $(KERNEL_CONFIG) ]] && mv -f $(KERNEL_CONFIG) $(KERNEL_CONFIG).save
 	$(hide) rm -f $(KERNEL_CONFIG).old
 	$(hide) cat $< > $(KERNEL_CONFIG)
-	$(hide) $(MAKE) $(KERNEL_MAKE_OPTIONS) olddefconfig
+	$(hide) $(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS) olddefconfig
 	$(hide) if [[ -e  $(KERNEL_CONFIG).old ]] ; then \
 	  $(CHECK_CONFIG_SCRIPT) $(KERNEL_CONFIG).old $(KERNEL_CONFIG) > $@ ;  fi;
 	-$(hide) [[ -e $(KERNEL_CONFIG).save ]] && mv -f $(KERNEL_CONFIG).save $(KERNEL_CONFIG)
@@ -159,7 +163,7 @@ $(CHECK_CONFIG_LOG): $(KERNEL_DEFCONFIG) $(KERNEL_DEPS)
 .PHONY: menuconfig xconfig gconfig
 
 menuconfig xconfig gconfig: $(CHECK_CONFIG_LOG)
-	$(hide) xterm -e $(MAKE) $(KERNEL_MAKE_OPTIONS) $@
+	$(hide) xterm -e $(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS) $@
 	$(hide) cp -f $(KERNEL_CONFIG) $(KERNEL_DEFCONFIG)
 	@echo ===========
 	@echo $(KERNEL_DEFCONFIG) has been modified !
@@ -168,7 +172,7 @@ menuconfig xconfig gconfig: $(CHECK_CONFIG_LOG)
 $(KERNEL_CONFIG): $(KERNEL_CONFIG_DEPS) | $(CHECK_CONFIG_LOG)
 	$(hide) cat $(KERNEL_CONFIG_DEPS) > $@
 	@echo "Generating Kernel configuration, using $(KERNEL_CONFIG_DEPS)"
-	$(hide) $(MAKE) $(KERNEL_MAKE_OPTIONS) olddefconfig </dev/null
+	$(hide) $(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS) olddefconfig </dev/null
 
 # BOARD_KERNEL_CONFIG_FILE and BOARD_KERNEL_VERSION can be used to override the values extracted
 # from INSTALLED_KERNEL_TARGET.
@@ -231,9 +235,9 @@ endif
 
 {{/slot-ab}}
 $(LOCAL_KERNEL): $(MINIGZIP) $(KERNEL_CONFIG) $(BOARD_DTB) $(KERNEL_DEPS)
-	$(MAKE) $(KERNEL_MAKE_OPTIONS)
-	$(MAKE) $(KERNEL_MAKE_OPTIONS) modules
-	$(MAKE) $(KERNEL_MAKE_OPTIONS) INSTALL_MOD_STRIP=1 modules_install
+	$(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS)
+	$(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS) modules
+	$(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS) INSTALL_MOD_STRIP=1 modules_install
 {{#build_dtbs}}
 	cp $(LOCAL_KERNEL_PATH)/scripts/dtc/dtc $(LOCAL_KERNEL_PATH)
 {{/build_dtbs}}
@@ -251,12 +255,12 @@ $(eval MODULE_DEPS_$(2) := $(shell find kernel/modules/$(1) \( -name *.git -prun
 $(LOCAL_KERNEL_PATH)/build_$(2): $(LOCAL_KERNEL) $(MODULE_DEPS_$(2)) $(PREVIOUS_KERNEL_MODULE)
 	@echo BUILDING $(1)
 	@mkdir -p $(LOCAL_KERNEL_PATH)/../modules/$(1)
-	$(hide) $(MAKE) $$(KERNEL_MAKE_OPTIONS) M=$(EXTMOD_SRC)/$(1) V=1 $(ADDITIONAL_ARGS_$(subst /,_,$(1))) modules
+	$(hide) $(KERNEL_MAKE_CMD) $$(KERNEL_MAKE_OPTIONS) M=$(EXTMOD_SRC)/$(1) V=1 $(ADDITIONAL_ARGS_$(subst /,_,$(1))) modules
 	@touch $$(@)
 
 $(LOCAL_KERNEL_PATH)/install_$(2): $(LOCAL_KERNEL_PATH)/build_$(2) $(PREVIOUS_KERNEL_MODULE)
 	@echo INSTALLING $(1)
-	$(hide) $(MAKE) $$(KERNEL_MAKE_OPTIONS) M=$(EXTMOD_SRC)/$(1) INSTALL_MOD_STRIP=1 modules_install
+	$(hide) $(KERNEL_MAKE_CMD) $$(KERNEL_MAKE_OPTIONS) M=$(EXTMOD_SRC)/$(1) INSTALL_MOD_STRIP=1 modules_install
 	@touch $$(@)
 
 $(LOCAL_KERNEL_PATH)/copy_modules: $(LOCAL_KERNEL_PATH)/install_$(2)
@@ -277,7 +281,7 @@ $(foreach m,$(EXTERNAL_MODULES),$(eval $(call bld_external_module,$(m),$(subst /
 
 {{#build_dtbs}}
 $(BOARD_DTB): $(KERNEL_CONFIG)
-	$(MAKE) $(KERNEL_MAKE_OPTIONS) dtbs
+	$(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS) dtbs
 	cp $(LOCAL_KERNEL_PATH)/arch/x86/boot/dts/{{{board_dtb}}} $@
 {{/build_dtbs}}
 

--- a/groups/trusty/true/AndroidBoard.mk
+++ b/groups/trusty/true/AndroidBoard.mk
@@ -3,8 +3,11 @@
 EVMM_PKG := $(TOP)/$(PRODUCT_OUT)/obj/trusty/evmm_pkg.bin
 EVMM_LK_PKG := $(TOP)/$(PRODUCT_OUT)/obj/trusty/evmm_lk_pkg.bin
 
-LOCAL_MAKE := make
+LOCAL_CLANG_PATH = $(CLANG_PREBUILTS_PATH)/host/$(HOST_OS)-x86/$(KERNEL_CLANG_VERSION)/bin
 
+LOCAL_MAKE := \
+        PATH="$(LOCAL_CLANG_PATH):$(PWD)/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8/x86_64-linux/bin:$$PATH" \
+        $(PWD)/prebuilts/build-tools/linux-x86/bin/make
 $(EVMM_PKG):
 	@echo "making evmm.."
 	$(hide) (cd $(TOPDIR)$(INTEL_PATH_VENDOR)/fw/evmm && $(TRUSTY_ENV_VAR) $(LOCAL_MAKE))


### PR DESCRIPTION
This is required to enable path restrictions
for Android 11

Tracked-On: OAM-95316
Signed-off-by: yaravapa <yasoda.aravapalli@intel.com>