### PR TITLE
Mixin changes for renaming vendor properties

### DIFF
--- a/groups/avx/auto/init.rc
+++ b/groups/avx/auto/init.rc
@@ -1,4 +1,2 @@
 on post-fs-data
     exec - system system -- /vendor/bin/checkavx.sh
-    setprop dalvik.vm.isa.x86.variant ${vendor.dalvik.vm.isa.x86.variant}
-    setprop dalvik.vm.isa.x86_64.variant ${vendor.dalvik.vm.isa.x86_64.variant}


### PR DESCRIPTION
The vendor properties dalvik_vm_isa_x86_variant_prop and
dalvik_vm_isa_x86_64_variant_prop are being renamed with
vendor_ prefix to fix VTS failures. This patch introduces
the corresponding mixin changes.

Tracked-On: OAM-95808
Signed-off-by: svenate <salini.venate@intel.com>