### PR TITLE
Auto hal for setting fixed performance

### DIFF
--- a/groups/aaf/true/init.rc
+++ b/groups/aaf/true/init.rc
@@ -5,3 +5,4 @@ on fs
     setprop ro.hardware.egl ${vendor.egl.set}
     setprop ro.hardware.hwcomposer ${vendor.hwcomposer.set}
     setprop ro.hardware.gralloc ${vendor.gralloc.set}
+    setprop ro.power.fixed_performance_scale_factor ${vendor.power.fixed_performance_scale_factor}

--- a/groups/power/true/AndroidBoard.mk
+++ b/groups/power/true/AndroidBoard.mk
@@ -1,0 +1,1 @@
+AUTO_IN += $(TARGET_DEVICE_DIR)/{{_extra_dir}}/auto_hal.in

--- a/groups/power/true/auto_hal.in
+++ b/groups/power/true/auto_hal.in
@@ -1,0 +1,14 @@
+update_power() {
+CMD_CPU_INFO="/proc/cpuinfo"
+
+value_model=`grep -i model /proc/cpuinfo | cut -d ':' -f2 | head -n 1`
+
+if [ $value_model == 142 ]; then
+    setprop vendor.power.fixed_performance_scale_factor 55
+elif [ $value_model == 140 ]; then
+    setprop vendor.power.fixed_performance_scale_factor 53
+else
+    setprop vendor.power.fixed_performance_scale_factor 50
+fi
+}
+update_power

--- a/groups/power/true/files.spec
+++ b/groups/power/true/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+auto_hal.in: "script to set propery for fixed performance"


### PR DESCRIPTION
Based on the platform, set the fixed performance
scale factor to an integer as mentioned in Mode.aidl
of Power hal AIDL.

Tracked-On: OAM-95866
Signed-off-by: Shwetha B <shwetha.b@intel.com>