### PR TITLE
Fix GTS wellbeing testcase failures

### DIFF
--- a/groups/device-specific/caas/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/groups/device-specific/caas/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -28,4 +28,12 @@
     <integer name="config_warningTemperature">100</integer>
     <integer name="config_warning_pkg_Temperature">105</integer>
 
+    <!-- Tiles to auto add to Quick Settings upon first change of a given secure setting.
+         The syntax is setting-name:spec. If the tile is a TileService, the spec should be specified
+         as custom(package/class). Relative class name is supported. -->
+    <string-array name="config_quickSettingsAutoAdd" translatable="false">
+	<item>focus_mode_first_time_setup:custom(com.google.android.apps.wellbeing/com.google.android.apps.wellbeing.focusmode.quicksettings.FocusModeTileService)</item>
+	<item>wind_down_first_time_setup:custom(com.google.android.apps.wellbeing/com.google.android.apps.wellbeing.screen.ui.GrayscaleTileService)</item>
+    </string-array>
+
 </resources>


### PR DESCRIPTION
This patch will fix GtsWellbeingTestCases:
1) testQuickSettingsAutoAddContainFocusModeTile
2) testQuickSettingsAutoAddContainWindDownTile

Tracked-On: OAM-95935
Signed-off-by: Salini Venate <salini.venate@intel.com>