### PR TITLE
Removing unused policy engine files

### DIFF
--- a/groups/audio/project-celadon/product.mk
+++ b/groups/audio/project-celadon/product.mk
@@ -36,11 +36,7 @@ PRODUCT_PACKAGES += \
 
 #Audio policy engine configuration files
 PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/audio/default/policy/audio_policy_criteria.conf:vendor/etc/audio_policy_criteria.conf \
-    $(LOCAL_PATH)/audio/default/policy/audio_policy_engine_product_strategies.xml:vendor/etc/audio_policy_engine_product_strategies.xml \
-    $(LOCAL_PATH)/audio/default/policy/audio_policy_engine_configuration.xml:vendor/etc/audio_policy_engine_configuration.xml \
-    $(LOCAL_PATH)/audio/default/policy/audio_policy_engine_criteria.xml:vendor/etc/audio_policy_engine_criteria.xml \
-    $(LOCAL_PATH)/audio/default/policy/audio_policy_engine_criterion_types.xml.in:vendor/etc/audio_policy_engine_criterion_types.xml.in
+    $(LOCAL_PATH)/audio/default/policy/audio_policy_criteria.conf:vendor/etc/audio_policy_criteria.conf
 
 # Vendor audio configuration files
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
removing unused policy engine files which
may introduce VTS issues.

Tracked-On: OAM-96119
Signed-off-by: gkdeepa g.k.deepa@intel.com