### PR TITLE
sign tos.img

### DIFF
--- a/groups/trusty/true/trusty_efi.mk
+++ b/groups/trusty/true/trusty_efi.mk
@@ -18,7 +18,8 @@ $(INSTALLED_TOS_IMAGE_TARGET): $(LK_ELF) $(EVMM_LK_PKG) $(MKBOOTIMG) $(AVBTOOL)
 	$(hide) $(AVBTOOL) add_hash_footer \
 		--image $@ \
 		--partition_size $(BOARD_TOSIMAGE_PARTITION_SIZE) \
-		--partition_name tos
+		--partition_name tos \
+		--algorithm $(BOARD_AVB_ALGORITHM) --key $(BOARD_AVB_KEY_PATH)
 	$(hide) mkdir -p $(INTEL_PATH_PREBUILTS_OUT)
 	$(hide) (cp $@ $(INTEL_PATH_PREBUILTS_OUT))
 else # BOARD_AVB_ENABLE == false


### PR DESCRIPTION
In the case avb verification disabled and device unlocked, tos image will not
be verified, hacker may read SEED by tampering tos image.

To pretect SEED, sign tos image so bootloader can verify it mandatory.

Tracked-On: OAM-96212
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>