### PR TITLE
Add the service.adb.tcp.port system property

### DIFF
--- a/groups/device-specific/caas/init.rc
+++ b/groups/device-specific/caas/init.rc
@@ -26,6 +26,9 @@ on boot
     write /sys/class/gpio/gpio444/direction out
     write /sys/class/gpio/gpio444/value 1
 
+# Set adb over network tcp port
+    setprop service.adb.tcp.port 5555
+
 # workaround for the sys fs create
 on post-fs
    # Create trace buffer, and set basic configuration.

--- a/groups/device-specific/caas/system.prop
+++ b/groups/device-specific/caas/system.prop
@@ -10,5 +10,4 @@ ro.board.platform=celadon
 audio.safemedia.bypass=true
 debug.nn.cpuonly=0
 camera.disable_treble=false
-service.adb.tcp.port=5555
 ro.incremental.enable=yes


### PR DESCRIPTION
This patch sets the service.adb.tcp.port property in vendor
image so that it is available in GSI image.

Tracked-On: OAM-96158
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>