### PR TITLE
Fix DRM interface default service version

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -139,15 +139,6 @@
     <hal format="hidl">
         <name>android.hardware.drm</name>
         <transport>hwbinder</transport>
-        <version>1.3</version>
-        <interface>
-            <name>ICryptoFactory</name>
-            <instance>default</instance>
-        </interface>
-        <interface>
-            <name>IDrmFactory</name>
-            <instance>default</instance>
-        </interface>
         <fqname>@1.3::ICryptoFactory/clearkey</fqname>
         <fqname>@1.3::IDrmFactory/clearkey</fqname>
     </hal>


### PR DESCRIPTION
Remove DRM 1.0 default service, only use DRM 1.3 clearkey service.

As VTS do not allow DRM 1.0 service in HAL. Remove DRM 1.0 default service.

Tracked-On: OAM-96026
Signed-off-by: Long, Hanyu <hanyu.long@intel.com>