### PR TITLE
Enble 3.5mm jack detection for TGL

### DIFF
--- a/groups/device-specific/caas/setup_audio_host.sh
+++ b/groups/device-specific/caas/setup_audio_host.sh
@@ -24,7 +24,7 @@ function setMicGain {
 cpu_family=$(getCpuInfo 'family:')
 cpu_model=$(getCpuInfo 'Model:')
 #Additional handling for CML NUC
-if [[ ($cpu_family = 6) && ($cpu_model = 166) ]]; then
+if [[ ($cpu_family = 6) && (($cpu_model = 166) || ($cpu_model = 140)) ]]; then
         echo "CML NUC detected"
         if [[ $1 == "setMicGain" ]]; then
                 setMicGain 15


### PR DESCRIPTION
Audio driver is unable to detect the headset on CML NUC.
This hardware requires a module parameter for snd-hda-intel:
model=dell-headset-multi

Tracked-On: OAM-96698
Signed-off-by: pmandri <padmasree.mandri@intel.com>