### PR TITLE
Remove lock screen and navigation bar from caas_dev

### DIFF
--- a/groups/device-specific/caas_dev/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/groups/device-specific/caas_dev/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+
+    <!-- Height of the bottom navigation / system bar -->
+    <dimen name="navigation_bar_height">0dp</dimen>
+
+    <!-- Height of the bottom navigation bar in landscape -->
+    <dimen name="navigation_bar_height_landscape">0dp</dimen>
+
+</resources>

--- a/groups/device-specific/caas_dev/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/groups/device-specific/caas_dev/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -21,6 +21,9 @@
     <!-- Default for Settings.Secure.WAKE_GESTURE_ENABLED -->
     <bool name="def_wake_gesture_enabled">false</bool>
 
+    <!-- Disable lock screen -->
+    <bool name="def_lockscreen_disabled">true</bool>
+
     <!-- Keep screen on at all times by default -->
     <bool name="def_stay_on_while_plugged_in">true</bool>
 


### PR DESCRIPTION
Basing on the requirements of the Penguin Peak customer, remove lock screen and navigation bar from caas_dev.

Tracked-On: OAM-97103
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>