### PR TITLE
Include the utilities to dump the installed app info

### DIFF
--- a/groups/device-specific/caas_dev/BoardConfig.mk
+++ b/groups/device-specific/caas_dev/BoardConfig.mk
@@ -11,6 +11,7 @@ BOARD_KERNEL_CMDLINE += \
 
 BOARD_FLASHFILES += ${TARGET_DEVICE_DIR}/bldr_utils.img:bldr_utils.img
 BOARD_FLASHFILES += $(PRODUCT_OUT)/LICENSE
+BOARD_FLASHFILES += $(PRODUCT_OUT)/scripts/cfc-0.1.0-x64.deb
 BOARD_FLASHFILES += $(PRODUCT_OUT)/scripts/start_civ.sh
 BOARD_FLASHFILES += $(PRODUCT_OUT)/scripts/start_flash_usb.sh
 BOARD_FLASHFILES += $(PRODUCT_OUT)/scripts/auto_switch_pt_usb_vms.sh

--- a/groups/device-specific/caas_dev/product.mk
+++ b/groups/device-specific/caas_dev/product.mk
@@ -38,6 +38,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.crypto.dm_default_key.options_format.version=2 \
     ro.crypto.volume.options=::v2
 
+PRODUCT_COPY_FILES += vendor/intel/app_icon_manager/host/bins/cfc-0.1.0-x64.deb:$(PRODUCT_OUT)/scripts/cfc-0.1.0-x64.deb
+
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.device_admin.xml:vendor/etc/permissions/android.software.device_admin.xml \
     frameworks/native/data/etc/android.software.managed_users.xml:vendor/etc/permissions/android.software.managed_users.xml \

--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -11,6 +11,8 @@ PRODUCT_PACKAGES += \
     libigdfcl
 
 PRODUCT_PACKAGES += \
+    ServiceAgent \
+    pm_agent_client \
     libdrm \
     libdrm_intel \
     libsync \


### PR DESCRIPTION
There are 2 packages to be installed in Android: ServiceAgent
and client command line binary for this service. One package
will be installed in host side for host side desktop app launcher
to launch app running in Android guest.

Change-Id: I4ec89c0238c20b235b0b48a5ed799fa652f0d9be
Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Tracked-On: OAM-96944