### PR TITLE
Enble 3.5mm jack detection for TGL

### DIFF
--- a/groups/device-specific/caas/setup_audio_host.sh
+++ b/groups/device-specific/caas/setup_audio_host.sh
@@ -23,9 +23,9 @@ function setMicGain {
 
 cpu_family=$(getCpuInfo 'family:')
 cpu_model=$(getCpuInfo 'Model:')
-#Additional handling for CML NUC
-if [[ ($cpu_family = 6) && ($cpu_model = 166) ]]; then
-        echo "CML NUC detected"
+#Additional handling for CML and TGL NUC
+if [[ ($cpu_family = 6) && (($cpu_model = 166) || ($cpu_model = 140)) ]]; then
+        echo "CML/TGL NUC detected"
         if [[ $1 == "setMicGain" ]]; then
                 setMicGain 15
         else


### PR DESCRIPTION
Audio driver is unable to detect the headset on TGL NUC.
This hardware requires a module parameter for snd-hda-intel:
model=dell-headset-multi

Tracked-On: OAM-96698
Signed-off-by: pmandri <padmasree.mandri@intel.com>