### PR TITLE
Enable 3.5mm on TGL platform

### DIFF
--- a/groups/device-specific/caas_dev/setup_audio_host.sh
+++ b/groups/device-specific/caas_dev/setup_audio_host.sh
@@ -23,9 +23,9 @@ function setMicGain {
 
 cpu_family=$(getCpuInfo 'family:')
 cpu_model=$(getCpuInfo 'Model:')
-#Additional handling for CML NUC
-if [[ ($cpu_family = 6) && ($cpu_model = 166) ]]; then
-        echo "CML NUC detected"
+#Additional handling for CML and TGL platform
+if [[ ($cpu_family = 6) && (($cpu_model = 166) || ($cpu_model = 140)) ]]; then
+        echo "CML/TGL NUC detected"
         if [[ $1 == "setMicGain" ]]; then
                 setMicGain 15
         else


### PR DESCRIPTION
Audio driver is unable to detect the headset on TGL platform.
So enabling 3.5mm support for TGL aswell in addition to CML.

Tracked-On: OAM-97268
Signed-off-by: pmandri <padmasree.mandri@intel.com>