### PR TITLE
Set the gles property when virgl 3d acceleration is not enabled

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -21,6 +21,9 @@ case "$(cat /proc/fb)" in
                 echo "virtio-gpu"
                 setprop vendor.hwcomposer.set drm_minigbm
                 setprop vendor.gralloc.set intel
+                if [ "$(cat /sys/kernel/debug/dri/0/virtio-gpu-features |grep virgl |awk '{print $3}')" = "no" ];then
+                        setprop vendor.gles.set softpipe
+                fi
                 ;;
         *)
                 echo "sw rendering"


### PR DESCRIPTION
When the virgl 3d acceleration is not enabled, it is software
rendering, set the vendor.gles value for the pixel format setting.

Tracked-On: OAM-97202
Signed-off-by: HeYue <yue.he@intel.com>
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>