### PR TITLE
Dummy NoDeprecatedHalsOnManifest

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -138,7 +138,16 @@
     </hal>
     <hal format="hidl">
         <name>android.hardware.drm</name>
-        <transport>hwbinder</transport>
+	<transport>hwbinder</transport>
+        <version>1.3</version>
+        <interface>
+            <name>ICryptoFactory</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IDrmFactory</name>
+            <instance>default</instance>
+        </interface>
         <fqname>@1.3::ICryptoFactory/clearkey</fqname>
         <fqname>@1.3::IDrmFactory/clearkey</fqname>
     </hal>


### PR DESCRIPTION
Remove DRM 1.0 default service, only use DRM 1.3
As VTS do not allow DRM 1.0 service in HAL. Remove DRM 1.0 default service.

Tracked-On: OAM-97749
Signed-off-by: Patibandla, KiranX Kumar <kiranx.kumar.patibandla@intel.com>