### PR TITLE
VTS fix for Thermal

### DIFF
--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -34,7 +34,6 @@
     <hal format="hidl">
         <name>android.hardware.thermal</name>
         <transport>hwbinder</transport>
-        <version>1.0</version>
         <version>2.0</version>
         <interface>
             <name>IThermal</name>

--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -34,7 +34,6 @@
     <hal format="hidl">
         <name>android.hardware.thermal</name>
         <transport>hwbinder</transport>
-        <version>1.0</version>
         <version>2.0</version>
         <interface>
             <name>IThermal</name>


### PR DESCRIPTION
ThermalHidlTest in VtsHalThermalV1_0TargetTest
Moving to newer version of HAL 2.0 and removing unused
version 1.0

Tracked-On: OAM-97800
Signed-off-by: Deepa g.k.deepa@intel.com