### PR TITLE
Camera screen flicker in camera preview switch

### DIFF
--- a/groups/camera-ext/ext-camera-only/external_camera_config.xml
+++ b/groups/camera-ext/ext-camera-only/external_camera_config.xml
@@ -27,7 +27,7 @@
         <!-- Size of v4l2 buffer queue when streaming >= 30fps -->
         <!-- Larger value: more request can be cached pipeline (less janky)  -->
         <!-- Smaller value: use less memory -->
-        <NumVideoBuffers count="8"/>
+        <NumVideoBuffers count="2"/>
         <!-- Size of v4l2 buffer queue when streaming < 30fps -->
         <NumStillBuffers count="2"/>
 


### PR DESCRIPTION
With NumVideoBuffers count = 8 screen flicker frequency is high.
After reducing the buffer count to '2' , issue occurence rate became low.

Tracked-On: OAM-97356
Signed-off-by: Patibandla, KiranX Kumar <kiranx.kumar.patibandla@intel.com>