### PR TITLE
Remove unsupported HALs from vendor manifest

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -60,15 +60,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.broadcastradio</name>
-        <transport>hwbinder</transport>
-        <version>1.1</version>
-        <interface>
-            <name>IBroadcastRadioFactory</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.graphics.mapper</name>
         <transport arch="32+64">passthrough</transport>
         <version>4.0</version>
@@ -93,15 +84,6 @@
         <version>2.4</version>
         <interface>
             <name>IComposer</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
-        <name>android.hardware.automotive.vehicle</name>
-        <transport>hwbinder</transport>
-        <version>2.0</version>
-        <interface>
-            <name>IVehicle</name>
             <instance>default</instance>
         </interface>
     </hal>


### PR DESCRIPTION
Remove BroadcastRadio and vehicle HAL from vendor manifest

VTS Test: vts_treble_vintf_vendor_test
Tracked-On: OAM-97805
Signed-off-by: svenate <salini.venate@intel.com>