### PR TITLE
Update due to python 3 ConfigParser

### DIFF
--- a/groups/codecs/configurable/files.spec
+++ b/groups/codecs/configurable/files.spec
@@ -1,11 +1,9 @@
 [extrafiles]
-media_codecs_{{gpu}}.xml: "Specific configuration for audio and video codecs"
 media_codecs_gen9.xml: "Specific configuration for audio and video codecs for gen9"
 media_codecs_gen12.xml: "Specific configuration for audio and video codecs for gen12"
 mfx_omxil_core.conf: "MSDK configuration for video codecs"
 media_profiles.xml: "Media profile file"
 media_profiles_1080p.xml: "Media profile file with 1080p support"
-media_codecs_performance_{{platform}}.xml: "Media codecs performance file"
 media_codecs_performance_cml.xml: "Media codecs performance file for cml"
 media_codecs_performance_tgl.xml: "Media codecs performance file for tgl"
 media_codecs_performance_{{platform}}_xen.xml: "Media codecs performance file for xen"


### PR DESCRIPTION
strict is True for configparser so the parser won’t
allow for any section duplicates while reading from
a single source.

Change-Id: Ib5aa190c2cbd1871a1a9caa7a20e5b96126d0d53
Tracked-On: OAM-97993
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>