### PR TITLE
[media] set hardware codec when using new kernel

### DIFF
--- a/groups/media/auto/auto_hal.in
+++ b/groups/media/auto/auto_hal.in
@@ -8,6 +8,10 @@ case "$(cat /proc/fb)" in
                 echo "intel"
                 setprop vendor.intel.video.codec hardware
                 ;;
+        *i915)
+                echo "intel"
+                setprop vendor.intel.video.codec hardware
+                ;;
         *)
                 echo "software codec"
                 setprop vendor.intel.video.codec software


### PR DESCRIPTION
It will check /proc/fb, if it is i915drmfb and inteldrmfb ,
, codec will be hardware, otherwise codec will be software.

Add new case i915

Tracked-On: OAM-97996
Signed-off-by: Kanli Hu <kanli.hu@intel.com>