### PR TITLE
Add UIO device mixin changes

### DIFF
--- a/groups/device-specific/caas_cfc/init.rc
+++ b/groups/device-specific/caas_cfc/init.rc
@@ -41,3 +41,14 @@ on post-fs
     insmod /vendor/lib/modules/asix.ko
     insmod /vendor/lib/modules/r8152.ko
     insmod /vendor/lib/modules/r8169.ko
+
+#For UIO device
+on post-fs
+    chmod 0660 /dev/uio0
+    chown system system /dev/uio0
+    chmod 0660 /dev/uio1
+    chown system system /dev/uio1
+    chmod 0660 /dev/uio2
+    chown system system /dev/uio2
+    chmod 0660 /dev/uio3
+    chown system system /dev/uio3


### PR DESCRIPTION
Hwc vhal need 0600 to read & write uio device

Tracked-On: OAM-98094
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>