### PR TITLE
Switch to omx software codec

### DIFF
--- a/groups/codecs/configurable/media_codecs_gen12.xml
+++ b/groups/codecs/configurable/media_codecs_gen12.xml
@@ -232,6 +232,9 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
 {{/hw_ve_h265}}
     </Encoders>
+{{#sw_omx_video}}
+    <Include href="media_codecs_google_video.xml" />
+{{/sw_omx_video}}
     <Include href="media_codecs_google_audio.xml" />
     <Settings>
         <Setting name="max-video-encoder-input-buffers" value="9" />

--- a/groups/codecs/configurable/media_codecs_gen9.xml
+++ b/groups/codecs/configurable/media_codecs_gen9.xml
@@ -224,6 +224,9 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
 {{/hw_ve_h265}}
     </Encoders>
+{{#sw_omx_video}}
+    <Include href="media_codecs_google_video.xml" />
+{{/sw_omx_video}}
     <Include href="media_codecs_google_audio.xml" />
     <Settings>
         <Setting name="max-video-encoder-input-buffers" value="9" />

--- a/groups/codecs/configurable/media_codecs_vp9.xml
+++ b/groups/codecs/configurable/media_codecs_vp9.xml
@@ -210,6 +210,9 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
 {{/hw_ve_h265}}
     </Encoders>
+{{#sw_omx_video}}
+    <Include href="media_codecs_google_video.xml" />
+{{/sw_omx_video}}
     <Include href="media_codecs_google_audio.xml" />
     <Settings>
         <Setting name="max-video-encoder-input-buffers" value="9" />

--- a/groups/codecs/configurable/option.spec
+++ b/groups/codecs/configurable/option.spec
@@ -13,6 +13,7 @@ sw_vd_h264 = false
 hw_vd_h264 = true
 hw_vd_h264_secure = false
 hw_vd_mp2 = false
+sw_omx_video = false
 codec_perf_xen = false
 profile_file = media_profiles.xml
 gpu = gen12

--- a/groups/codecs/configurable/product.mk
+++ b/groups/codecs/configurable/product.mk
@@ -3,6 +3,11 @@ PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:vendor/etc/media_codecs_google_audio.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/{{profile_file}}:vendor/etc/media_profiles_V1_0.xml
 
+{{#sw_omx_video}}
+PRODUCT_COPY_FILES += \
+    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:vendor/etc/media_codecs_google_video.xml
+{{/sw_omx_video}}
+
 ifeq ($(BASE_YOCTO_KERNEL),true)
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_vp9.xml:vendor/etc/media_codecs.xml \

--- a/groups/device-specific/caas_cfc/init.rc
+++ b/groups/device-specific/caas_cfc/init.rc
@@ -52,3 +52,7 @@ on post-fs
     chown system system /dev/uio2
     chmod 0660 /dev/uio3
     chown system system /dev/uio3
+
+#For OMX
+on post-fs-data
+    setprop debug.stagefright.ccodec 0


### PR DESCRIPTION
Video format is not supported by c2 on VritIO GPU,
change back to omx software codec.

Tracked-On: OAM-98101
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>