### PR TITLE
trusty: use ueventd.rc script to set trusty-ipc-dev0 permissions

### DIFF
--- a/groups/trusty/true/init.rc
+++ b/groups/trusty/true/init.rc
@@ -23,6 +23,4 @@ service keyboxd /vendor/bin/keybox_provisioning -d /dev/trusty-ipc-dev0 -p /dev/
 
 on post-fs
     wait_for_prop vendor.modules.trusty.ready true
-    # Update device node r/w attribute
-    chmod 666 /dev/trusty-ipc-dev0
     chmod 666 /dev/vport0p1

--- a/groups/trusty/true/ueventd.rc
+++ b/groups/trusty/true/ueventd.rc
@@ -1,2 +1,2 @@
 /dev/block/p*/*/*/by-name/teedata      0660 system system
-
+/dev/trusty-ipc-dev0                   0666 root root


### PR DESCRIPTION
To set permission on a node created by the ueventd daemon, the
uevent.rc configuration file must be used to ensure that the new
permissions are applied as soon as the node file gets created.

The current implementation based on the init.rc script can lead to a
race condition where the module is loaded but the ueventrd daemon has
not created the node yet and the chmod command is run on a
non-exisiting file.

The following logs have been observed and root cause to this race
condition.

    2710 2710 I TrustyKeymaster: Creating device
    2710 2710 D TrustyKeymaster: Device address: 0x719381226200
    2710 2710 E TrustyKeymaster: failed to connect to keymaster (-13)
    2710 2710 D TrustyKeymaster: Device received configure

Signed-off-by: Maxim Pleshivenkov <Maxim.Pleshivenkov@harman.com>
Signed-off-by: Jeremy Compostella <jeremy.compostella@intel.com>
(cherry picked from commit 58e94ee4439e9266632383bdccc21a3c5e98c49a)

Tracked-On: OAM-98130
Signed-off-by: Basanagouda Koppad <Basanagoudax.n.Koppad@intel.com>