### PR TITLE
Remove the overlay configuration for status bar

### DIFF
--- a/groups/device-specific/caas_cfc/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/groups/device-specific/caas_cfc/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -25,22 +25,4 @@
     <!-- Width of the navigation bar when it is placed vertically on the screen -->
     <dimen name="navigation_bar_width">0dp</dimen>
 
-    <!-- Height of the status bar -->
-    <dimen name="status_bar_height">0dp</dimen>
-
-    <!-- Height of the status bar in portrait -->
-    <dimen name="status_bar_height_portrait">0dp</dimen>
-
-    <!-- Height of the status bar in landscape -->
-    <dimen name="status_bar_height_landscape">0dp</dimen>
-
-    <!-- Size of the giant number (unread count) in the notifications -->
-    <dimen name="status_bar_content_number_size">0sp</dimen>
-
-    <!-- Desired size of system icons in status bar. -->
-    <dimen name="status_bar_system_icon_size">0dp</dimen>
-
-    <!-- Height of notification icons in the status bar -->
-    <dimen name="status_bar_icon_size">0dip</dimen>
-
 </resources>


### PR DESCRIPTION
We hide the status bar by modifying the AOSP code

Tracked-On: OAM-96162
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>