### PR TITLE
change H265 encoder min res to 176x144

### DIFF
--- a/groups/codecs/configurable/media_codecs_gen12.xml
+++ b/groups/codecs/configurable/media_codecs_gen12.xml
@@ -223,7 +223,7 @@ Only the three quirks included above are recognized at this point:
 {{/hw_ve_vp9}}
 {{#hw_ve_h265}}
         <MediaCodec name="OMX.Intel.hw_ve.h265" type="video/hevc" >
-            <Limit name="size" min="64x64" max="8192x8192" />
+            <Limit name="size" min="176x144" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="blocks-per-second" range="1-972000" />


### PR DESCRIPTION
To pass CTS VideoEncoderTest for testOtherH265,
change H265 encoder min resolution to 176x144.

Tracked-On: OAM-99358
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>