### PR TITLE
Add Mainline patch level

### DIFF
--- a/groups/googleservice/gms/product.mk
+++ b/groups/googleservice/gms/product.mk
@@ -2,4 +2,5 @@ FLAG_GMS_AVAILABLE ?= true
 ifeq ($(FLAG_GMS_AVAILABLE),true)
 $(call inherit-product-if-exists, vendor/google/gms/products/gms.mk)
 $(call inherit-product, vendor/partner_modules/build/mainline_modules.mk)
+MAINLINE_PATCH_LEVEL_1 := true
 endif


### PR DESCRIPTION
As per Partner Security Advisory, Google has identified
a potential issue where Android 11 devices receiving
Mainline updates could enter an unusable state. To adress that
patches:A-182960918 and A-193932765 should be applied and
mainline patch level flag should be updated.

Tracked-On: OAM-99831
Signed-off-by: Salini Venate <salini.venate@intel.com>