### PR TITLE
Set the status bar height to a small value

### DIFF
--- a/groups/device-specific/caas_cfc/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/groups/device-specific/caas_cfc/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -25,4 +25,7 @@
     <!-- Width of the navigation bar when it is placed vertically on the screen -->
     <dimen name="navigation_bar_width">0dp</dimen>
 
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">1dp</dimen>
+
 </resources>


### PR DESCRIPTION
If the status bar's height is set to 0, some apps like
WeChat will display abnormally. Set the status bar height
to a very small value as a workaround.

Tracked-On: OAM-99354
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>