### PR TITLE
Enable keymint related HALs

### DIFF
--- a/groups/device-specific/caas/caas.mk
+++ b/groups/device-specific/caas/caas.mk
@@ -40,6 +40,9 @@ INTEL_PATH_PREKERNEL := device/intel/prebuilt_kernel
 INTEL_PATH_PREBUILTS := vendor/intel/prebuilts
 INTEL_PATH_PREBUILTS_OUT = $(PRODUCT_OUT)/prebuilts
 
+# Set Vendor SPL to match platform
+VENDOR_SECURITY_PATCH = $(PLATFORM_SECURITY_PATCH)
+
 # refer board_config_mk definition in build/make/core/envsetup.mk file to get TARGET_DEVICE
 _board_config_mk := $(shell find $(dir $(current_product_makefile)) -maxdepth 2 -name BoardConfig.mk)
 #TARGET_DEVICE_DIR := $(shell dirname $(_board_config_mk))

--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -4,12 +4,32 @@
 {{#ota-update}}
 <manifest version="1.0" type="framework">
 {{/ota-update}}
-    <hal format="hidl">
-        <name>android.hardware.keymaster</name>
-        <transport>hwbinder</transport>
-        <version>3.0</version>
+    <hal format="aidl">
+        <name>android.hardware.security.keymint</name>
+        <version>1</version>
         <interface>
-            <name>IKeymasterDevice</name>
+            <name>IKeyMintDevice</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="aidl">
+        <name>android.hardware.security.keymint</name>
+        <interface>
+            <name>IRemotelyProvisionedComponent</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="aidl">
+        <name>android.hardware.security.secureclock</name>
+        <interface>
+            <name>ISecureClock</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="aidl">
+        <name>android.hardware.security.sharedsecret</name>
+        <interface>
+            <name>ISharedSecret</name>
             <instance>default</instance>
         </interface>
     </hal>

--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -4,12 +4,32 @@
 {{#ota-update}}
 <manifest version="1.0" type="device">
 {{/ota-update}}
-    <hal format="hidl">
-        <name>android.hardware.keymaster</name>
-        <transport>hwbinder</transport>
-        <version>3.0</version>
+    <hal format="aidl">
+        <name>android.hardware.security.keymint</name>
+        <version>1</version>
         <interface>
-            <name>IKeymasterDevice</name>
+            <name>IKeyMintDevice</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="aidl">
+        <name>android.hardware.security.keymint</name>
+        <interface>
+            <name>IRemotelyProvisionedComponent</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="aidl">
+        <name>android.hardware.security.secureclock</name>
+        <interface>
+            <name>ISecureClock</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="aidl">
+        <name>android.hardware.security.sharedsecret</name>
+        <interface>
+            <name>ISharedSecret</name>
             <instance>default</instance>
         </interface>
     </hal>

--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -17,8 +17,7 @@ PRODUCT_COPY_FILES += \
 
 PRODUCT_PACKAGES += vndservicemanager
 
-PRODUCT_PACKAGES += android.hardware.keymaster@3.0-impl \
-                    android.hardware.keymaster@3.0-service \
+PRODUCT_PACKAGES +=  \
                     android.hardware.usb@1.0-impl \
                     android.hardware.usb@1.0-service \
                     camera.device@1.0-impl \

--- a/groups/trusty/false/product.mk
+++ b/groups/trusty/false/product.mk
@@ -1,2 +1,3 @@
 PRODUCT_PACKAGES += \
-    android.hardware.gatekeeper@1.0-service.software
+    android.hardware.gatekeeper@1.0-service.software \
+    android.hardware.security.keymint-service

--- a/groups/trusty/true/option.spec
+++ b/groups/trusty/true/option.spec
@@ -2,5 +2,4 @@
 lk_project       = sand-x86-64
 enable_hw_sec    = true
 enable_storage_proxyd = true
-keymaster_version   = 2
 ref_target =

--- a/groups/trusty/true/product.mk
+++ b/groups/trusty/true/product.mk
@@ -1,25 +1,12 @@
 {{#enable_hw_sec}}
 
-KM_VERSION := {{{keymaster_version}}}
-
-ifeq ($(KM_VERSION),2)
-PRODUCT_PACKAGES += \
-	keystore.trusty
-PRODUCT_PROPERTY_OVERRIDES += \
-	ro.hardware.keystore=trusty
-endif
-
-ifeq ($(KM_VERSION),1)
-PRODUCT_PACKAGES += \
-	keystore.${TARGET_BOARD_PLATFORM}
-endif
-
 PRODUCT_PACKAGES += \
 	libtrusty \
 	storageproxyd \
 	libinteltrustystorage \
 	libinteltrustystorageinterface \
 	android.hardware.gatekeeper@1.0-service.trusty \
+	android.hardware.security.keymint-service.trusty \
 	keybox_provisioning \
 
 PRODUCT_PACKAGES_DEBUG += \
@@ -30,4 +17,9 @@ PRODUCT_PACKAGES_DEBUG += \
 
 PRODUCT_PROPERTY_OVERRIDES += \
 	ro.hardware.gatekeeper=trusty \
+	ro.hardware.keystore=trusty
+
+PRODUCT_COPY_FILES += \
+	frameworks/native/data/etc/android.hardware.keystore.app_attest_key.xml:vendor/etc/permissions/android.hardware.keystore.app_attest_key.xml
+
 {{/enable_hw_sec}}


### PR DESCRIPTION
It include the following hals:
IKeyMintDevice,
IRemotelyProvisionedComponent,
ISecureClock,
ISharedSecret

And it will use different service binaries based on whether trusty
is enabled or disabled:
w/ trusty:
android.hardware.security.keymint-service.trusty
w/o Trusty:
android.hardware.security.keymint-service

Tracked-On: OAM-99223
Signed-off-by: yuxincui <yuxin.cui@intel.com>