### PR TITLE
Add civ flag to load iwl7000 driver

### DIFF
--- a/groups/wlan/iwlwifi/auto_hal.in
+++ b/groups/wlan/iwlwifi/auto_hal.in
@@ -1,0 +1,8 @@
+update_wlan() {
+
+GUEST_AAF_CONFIG="/mnt/share/mixins.spec"
+
+value=`grep -i wifi_iwl7000 $GUEST_AAF_CONFIG | cut -d ':' -f2`
+setprop vendor.intel.wifi_iwl7000 $value
+}
+update_wlan

--- a/groups/wlan/iwlwifi/files.spec
+++ b/groups/wlan/iwlwifi/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+auto_hal.in : "auto script"

--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -7,8 +7,16 @@ on early-boot
 {{^iwl_upstream_drv}}
     insmod /vendor/lib/modules/compat.ko
 {{/iwl_upstream_drv}} 
+
+on property:vendor.intel.wifi_iwl7000=true
     insmod /vendor/lib/modules/cfg80211.ko
     insmod /vendor/lib/modules/iwl7000_mac80211.ko
+    insmod /vendor/lib/modules/iwlwifi.ko
+    insmod /vendor/lib/modules/iwlmvm.ko power_scheme=1
+
+on property:vendor.intel.wifi_iwl7000=false
+    insmod /vendor/lib/modules/cfg80211.ko
+    insmod /vendor/lib/modules/mac80211.ko
     insmod /vendor/lib/modules/iwlwifi.ko
     insmod /vendor/lib/modules/iwlmvm.ko power_scheme=1
 

--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -22,3 +22,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.ipsec_tunnels.xml:vendor/etc/permissions/android.software.ipsec_tunnels.xml
 
 PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-disable_keepalive_offload
+
+PRODUCT_PROPERTY_OVERRIDES += vendor.intel.wifi_iwl7000=false
+
+AUTO_IN += $(TARGET_DEVICE_DIR)/{{_extra_dir}}/auto_hal.in


### PR DESCRIPTION
Changes made to add new civ_target flag for conditional loading
of iwl7000 driver.

Tracked-On: OAM-99828
Signed-off-by: Bharat B Panda <bharat.b.panda@intel.com>