### PR TITLE
Put prebuilt sh and toolbox ELF file to vendor/bin/ in recovery mode

### DIFF
--- a/groups/vendor-partition/true/AndroidBoard.mk
+++ b/groups/vendor-partition/true/AndroidBoard.mk
@@ -17,4 +17,14 @@ $(RECOVERY_VENDOR_LINKS):
 	$(hide) touch $(dir $@)$(PRV_TARGET)
 	$(hide) ln -sf $(PRV_TARGET) $@
 
-ALL_DEFAULT_INSTALLED_MODULES += $(RECOVERY_VENDOR_LINKS)
+RECOVERY_VENDOR_BINARIES := $(PRODUCT_OUT)/recovery/root/vendor/bin/sh
+
+$(RECOVERY_VENDOR_BINARIES):  $(RECOVERY_VENDOR_LINKS)
+	$(hide) if [[ -e $(PRODUCT_OUT)/recovery/root/vendor/bin/toolbox_static ]] ; then \
+			rm $(PRODUCT_OUT)/recovery/root/vendor/bin/toolbox_static ; \
+		fi ;
+	$(hide) cp $(INTEL_PATH_TARGET_DEVICE)/${TARGET_PRODUCT}/{{_extra_dir}}/sh_recovery $(PRODUCT_OUT)/recovery/root/vendor/bin/sh
+	$(hide) cp $(INTEL_PATH_TARGET_DEVICE)/${TARGET_PRODUCT}/{{_extra_dir}}/toolbox_recovery $(PRODUCT_OUT)/recovery/root/vendor/bin/toolbox_static
+
+ALL_DEFAULT_INSTALLED_MODULES += \
+       $(RECOVERY_VENDOR_BINARIES)

--- a/groups/vendor-partition/true/product.mk
+++ b/groups/vendor-partition/true/product.mk
@@ -2,9 +2,7 @@
 PRODUCT_VENDOR_VERITY_PARTITION := /dev/block/by-name/{{partition_name}}
 {{/avb}}
 
-PRODUCT_COPY_FILES += $(LOCAL_PATH)/{{_extra_dir}}/sh_recovery:recovery/root/vendor/bin/sh
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/{{_extra_dir}}/mkshrc_recovery:recovery/root/vendor/etc/mkshrc
-PRODUCT_COPY_FILES += $(LOCAL_PATH)/{{_extra_dir}}/toolbox_recovery:recovery/root/vendor/bin/toolbox_static
 PRODUCT_PACKAGES += \
      toybox_static \
      toybox_vendor \


### PR DESCRIPTION
PRODUCT_COPY_FILES can't be used for ELF file copy any more. So use
another way to copy them to recovery/boot vendor bin. The two ELF files
are used for OTA postinstall

Tracked-On: OAM-98182
Signed-off-by: Chen Gang G <gang.g.chen@intel.com>