### PR TITLE
Enable com.android.remoteprovisioner service

### DIFF
--- a/groups/trusty/true/product.mk
+++ b/groups/trusty/true/product.mk
@@ -8,12 +8,15 @@ PRODUCT_PACKAGES += \
 	android.hardware.gatekeeper@1.0-service.trusty \
 	android.hardware.security.keymint-service.trusty \
 	keybox_provisioning \
+	RemoteProvisioner
 
 PRODUCT_PACKAGES_DEBUG += \
 	intel-secure-storage-unit-test \
 	gatekeeper-unit-tests \
 	libscrypt_static \
 	scrypt_test \
+	RemoteProvisionerUnitTests \
+	libkeymint_remote_prov_support_test
 
 PRODUCT_PROPERTY_OVERRIDES += \
 	ro.hardware.gatekeeper=trusty \


### PR DESCRIPTION
It enables com.android.remoteprovisioner service.

Tracked-On: OAM-100082
Signed-off-by: yuxincui <yuxin.cui@intel.com>