### PR TITLE
Increase size of super image to integrate new GMS package

### DIFF
--- a/groups/dynamic-partitions/true/option.spec
+++ b/groups/dynamic-partitions/true/option.spec
@@ -1,5 +1,5 @@
 [defaults]
-super_partition_size = 8000
+super_partition_size = 10000
 overhead_size = 4
 dp_retrofit = false
 super_img_in_flashzip = false


### PR DESCRIPTION
Celadon build was failing at creation of super.img during
integration of latest gms package - gmsversion 11_202111.

Failure:
lpmake E [liblp]Partition product_a is part of group group_sys_a
which does not have enough space free
(1824354304 requested, 2373951488 used out of 4190109696)

Tracked-On: OAM-100067
Signed-off-by: svenate <salini.venate@intel.com>