### PR TITLE
Enable block-level deduplication for product partition 

### DIFF
--- a/groups/product-partition/true/BoardConfig.mk
+++ b/groups/product-partition/true/BoardConfig.mk
@@ -10,3 +10,4 @@ TARGET_USE_PRODUCT := true
 {{#slot-ab}}
 AB_OTA_PARTITIONS += product
 {{/slot-ab}}
+BOARD_EXT4_SHARE_DUP_BLOCKS := true


### PR DESCRIPTION
Celadon build was failing at creation of super.img during
integration of latest gms package - gmsversion 11_202111.
Failure:
lpmake E [liblp]Partition product_a is part of group
group_sys_a which does not have enough space free
(1824354304 requested, 2373951488 used out of 4190109696)

So enabling block-level deduplication to resolve the issue as per
https://source.android.com/devices/tech/ota/dynamic_partitions/implement

Tracked-On: OAM-100067
Signed-off-by: Salini Venate <salini.venate@intel.com>