### PR TITLE
Removing hcitools from product.mk

### DIFF
--- a/groups/bluetooth/btusb/product.mk
+++ b/groups/bluetooth/btusb/product.mk
@@ -1,12 +1,3 @@
-PRODUCT_PACKAGES += \
-    hciconfig
-
-# Bluetooth tools eng / userdebug
-ifneq ($(TARGET_BUILD_VARIANT),user)
-PRODUCT_PACKAGES += \
-    btmon \
-    hcitool
-endif
 
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.bluetooth.xml:vendor/etc/permissions/android.hardware.bluetooth.xml \


### PR DESCRIPTION
hcitools are used only for debugging and hence removing
it from Android source tree

Tracked-On: OAM-100207
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>