### PR TITLE
Enable zram swap for device having <= 4G ram

### DIFF
--- a/groups/swap/zram_auto/check_lowmem.sh
+++ b/groups/swap/zram_auto/check_lowmem.sh
@@ -1,13 +1,13 @@
 #!/vendor/bin/sh
 
-# 2G size in kB
-SIZE_2G=2097152
+# 4G size in kB
+SIZE_4G=4194304
 
 mem_size=`cat /proc/meminfo | grep MemTotal | tr -s ' ' | cut -d ' ' -f 2`
 
-if [ "$mem_size" -le "$SIZE_2G" ]
+if [ "$mem_size" -le "$SIZE_4G" ]
 then
-    setprop vendor.low_ram 1
+    setprop vendor.le_4g_ram 1
 else
-    setprop vendor.low_ram 0
+    setprop vendor.le_4g_ram 0
 fi

--- a/groups/swap/zram_auto/init.rc
+++ b/groups/swap/zram_auto/init.rc
@@ -4,7 +4,7 @@ on boot
     write /proc/sys/vm/page-cluster 0
 {{#swappiness}}
    # Avoid evicting pages and use zram disk
-    write /proc/sys/vm/swappiness 100
+    write /proc/sys/vm/swappiness 10
 {{/swappiness}}
 {{#disk_based_swap}}
    # Enable disk_based_swap on Chromium kernels
@@ -14,6 +14,6 @@ on boot
 on post-fs
     exec - system system -- /vendor/bin/check_lowmem.sh
 
-on property:vendor.low_ram=1
+on property:vendor.le_4g_ram=1
     # Enable swaps described in the fstab
     swapon_all /vendor/etc/fstab.${ro.hardware}


### PR DESCRIPTION
zram swap to increase available memory when device is
under memory pressure.

Tracked-On: OAM-100254
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>