### PR TITLE
Set TARGET_BOARD_KERNEL_HEADERS based on ernel used for build

### DIFF
--- a/groups/kernel/BoardConfig.mk
+++ b/groups/kernel/BoardConfig.mk
@@ -1,5 +1,13 @@
 # Specify location of board-specific kernel headers
-TARGET_BOARD_KERNEL_HEADERS := $(INTEL_PATH_COMMON)/{{{src_path}}}/kernel-headers
+ifeq ($(BASE_CHROMIUM_KERNEL), true)
+  TARGET_BOARD_KERNEL_HEADERS := $(INTEL_PATH_COMMON)/{{{chromium_src_path}}}/kernel-headers
+else ifeq ($(BASE_LTS2020_YOCTO_KERNEL), true)
+  TARGET_BOARD_KERNEL_HEADERS := $(INTEL_PATH_COMMON)/{{{lts2020_yocto_src_path}}}/kernel-headers
+else ifeq ($(BASE_YOCTO_KERNEL), true)
+  TARGET_BOARD_KERNEL_HEADERS := $(INTEL_PATH_COMMON)/{{{yocto_src_path}}}/kernel-headers
+else
+  TARGET_BOARD_KERNEL_HEADERS := $(INTEL_PATH_COMMON)/{{{src_path}}}/kernel-headers
+endif
 
 ifneq ($(TARGET_BUILD_VARIANT),user)
 KERNEL_LOGLEVEL ?= {{{loglevel}}}


### PR DESCRIPTION
Instead of using kernel header from the respective kernel
header folder, default kernel header folder is used.

Fix the issue by setting TARGET_BOARD_KERNEL_HEADERS based
on kernel used for building CIV.

Tracked-On: OAM-100417
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>