### PR TITLE
Enable keymaster 3.0

### DIFF
--- a/groups/trusty/false/product.mk
+++ b/groups/trusty/false/product.mk
@@ -1,2 +1,3 @@
 PRODUCT_PACKAGES += \
-    android.hardware.gatekeeper@1.0-service.software
+    android.hardware.gatekeeper@1.0-service.software \
+    android.hardware.keymaster@3.0-service

--- a/groups/trusty/true/option.spec
+++ b/groups/trusty/true/option.spec
@@ -2,5 +2,4 @@
 lk_project       = sand-x86-64
 enable_hw_sec    = true
 enable_storage_proxyd = true
-keymaster_version   = 2
 ref_target =

--- a/groups/trusty/true/product.mk
+++ b/groups/trusty/true/product.mk
@@ -1,25 +1,12 @@
 {{#enable_hw_sec}}
 
-KM_VERSION := {{{keymaster_version}}}
-
-ifeq ($(KM_VERSION),2)
-PRODUCT_PACKAGES += \
-	keystore.trusty
-PRODUCT_PROPERTY_OVERRIDES += \
-	ro.hardware.keystore=trusty
-endif
-
-ifeq ($(KM_VERSION),1)
-PRODUCT_PACKAGES += \
-	keystore.${TARGET_BOARD_PLATFORM}
-endif
-
 PRODUCT_PACKAGES += \
 	libtrusty \
 	storageproxyd \
 	libinteltrustystorage \
 	libinteltrustystorageinterface \
 	android.hardware.gatekeeper@1.0-service.trusty \
+	android.hardware.keymaster@3.0-service.trusty \
 	keybox_provisioning \
 
 PRODUCT_PACKAGES_DEBUG += \
@@ -30,4 +17,5 @@ PRODUCT_PACKAGES_DEBUG += \
 
 PRODUCT_PROPERTY_OVERRIDES += \
 	ro.hardware.gatekeeper=trusty \
+	ro.hardware.keystore=trusty
 {{/enable_hw_sec}}


### PR DESCRIPTION
It will use different service binaries based on whether trusty
is enabled or disabled:
w/ trusty:
android.hardware.keymaster@3.0-service.trusty
w/o Trusty:
android.hardware.keymaster@3.0-service

Tracked-On: OAM-100659
Signed-off-by: yuxincui <yuxin.cui@intel.com>