### PR TITLE
Load proper mac80211 driver for BM/CiV

### DIFF
--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -7,10 +7,10 @@ on early-boot
 {{^iwl_upstream_drv}}
     insmod /vendor/lib/modules/compat.ko
 {{/iwl_upstream_drv}} 
-    insmod /vendor/lib/modules/cfg80211.ko
-    insmod /vendor/lib/modules/iwl7000_mac80211.ko
-    insmod /vendor/lib/modules/iwlwifi.ko
-    insmod /vendor/lib/modules/iwlmvm.ko power_scheme=1
+    chmod 0750 /system/bin/module_load.sh
+    service module_load /system/bin/module_load.sh
+    user root
+    oneshot
 
 on zygote-start
     # Create the directories used by the Wireless subsystem

--- a/groups/wlan/iwlwifi/module_load.sh
+++ b/groups/wlan/iwlwifi/module_load.sh
@@ -1,0 +1,14 @@
+#!/system/bin/sh
+
+FILE=/mnt/share/mixins.spec
+if [ ! -f "$FILE"]; then
+    insmod /vendor/lib/modules/cfg80211.ko
+    insmod /vendor/lib/modules/mac80211.ko
+    insmod /vendor/lib/modules/iwlwifi.ko
+    insmod /vendor/lib/modules/iwlmvm.ko power_scheme=1
+elif [ -f "$FILE"]; then
+    insmod /vendor/lib/modules/cfg80211.ko
+    insmod /vendor/lib/modules/iwl7000_mac80211.ko
+    insmod /vendor/lib/modules/iwlwifi.ko
+    insmod /vendor/lib/modules/iwlmvm.ko power_scheme=1
+fi 


### PR DESCRIPTION
Changes made to init.rc file to execute external script that will load
mac80211 or iwl7000_mac80211 driver separately for BM and VM.

Tracked-On: OAM-99828
Signed-off-by: Bharat B Panda <bharat.b.panda@intel.com>