### PR TITLE
Enable SOF

### DIFF
--- a/groups/audio/project-celadon/init.rc
+++ b/groups/audio/project-celadon/init.rc
@@ -1,5 +1,32 @@
-on boot
+on fs
     insmod /vendor/lib/modules/snd-dummy.ko
+    insmod /vendor/lib/modules/snd-sof.ko
+    insmod /vendor/lib/modules/snd-sof-xtensa-dsp.ko
+    insmod /vendor/lib/modules/snd-sof-pci.ko
+    insmod /vendor/lib/modules/snd-sof-intel-ipc.ko
+    insmod /vendor/lib/modules/snd-sof-acpi.ko
+    insmod /vendor/lib/modules/snd-hda-ext-core.ko
+    insmod /vendor/lib/modules/snd-sof-intel-hda.ko
+    insmod /vendor/lib/modules/snd-soc-hdac-hda.ko
+    insmod /vendor/lib/modules/snd-sof-intel-hda-common.ko
+    insmod /vendor/lib/modules/snd-sof-pci-intel-tgl.ko
+    insmod /vendor/lib/modules/snd-mixer-oss.ko
+    insmod /vendor/lib/modules/snd-seq.ko
+    insmod /vendor/lib/modules/snd-soc-dmic.ko
+    insmod /vendor/lib/modules/snd-soc-hdac-hdmi.ko
+    insmod /vendor/lib/modules/snd-soc-intel-hda-dsp-common.ko
+    insmod /vendor/lib/modules/snd-soc-skl_hda_dsp.ko
+    insmod /vendor/lib/modules/snd-soc-sst-dsp.ko
+    insmod /vendor/lib/modules/snd-soc-sst-ipc.ko
+    insmod /vendor/lib/modules/snd-sof-acpi-intel-bdw.ko
+    insmod /vendor/lib/modules/snd-sof-acpi-intel-byt.ko
+    insmod /vendor/lib/modules/snd-sof-pci-intel-apl.ko
+    insmod /vendor/lib/modules/snd-sof-pci-intel-cnl.ko
+    insmod /vendor/lib/modules/snd-sof-pci-intel-icl.ko
+    insmod /vendor/lib/modules/snd-sof-pci-intel-tng.ko
+    insmod /vendor/lib/modules/snd-usb-hiface.ko
+    insmod /vendor/lib/modules/snd-seq-midi-event.ko
+    insmod /vendor/lib/modules/snd-seq-midi.ko
 
 on property:sys.boot_completed=1 && property:ro.vendor.hdmi.audio=tgl
     stop audioserver

--- a/groups/kernel/BoardConfig.mk
+++ b/groups/kernel/BoardConfig.mk
@@ -60,6 +60,9 @@ BOARD_KERNEL_CMDLINE += \
 BOARD_KERNEL_CMDLINE += \
       snd-hda-intel.model=dell-headset-multi
 
+BOARD_KERNEL_CMDLINE += \
+      snd-intel-dspcfg.dsp_driver=3
+
 ifeq ($(BASE_YOCTO_KERNEL), true)
 BOARD_KERNEL_CMDLINE += \
       snd-intel-dspcfg.dsp_driver=1


### PR DESCRIPTION
Load Required snd and sof modules to enable sof in android
and force to load sof dsp driver.

Signed-off-by: pmandri <padmashree.mandri@intel.com>