### PR TITLE
[PM] Rearrange signal handling for sleep scenario

### DIFF
--- a/groups/device-specific/caas/guest_pm_control
+++ b/groups/device-specific/caas/guest_pm_control
@@ -100,16 +100,16 @@ def main():
                             print("VM is rebooting")
                             print("Reason: guest reset request")
                             cmdCommand = "reboot"
-                            time.sleep(3)
                             signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                            time.sleep(3)
                             process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
                             break
                         elif "host-qmp-system-reset" in json.dumps(resp["data"]):
                             print("VM is rebooting")
                             print("Reason: Reboot triggered by host")
                             cmdCommand = "reboot"
-                            time.sleep(3)
                             signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                            time.sleep(3)
                             process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
                             break
                         elif "host-qmp-quit" in json.dumps(resp["data"]):

--- a/groups/device-specific/caas_dev/guest_pm_control
+++ b/groups/device-specific/caas_dev/guest_pm_control
@@ -100,16 +100,16 @@ def main():
                             print("VM is rebooting")
                             print("Reason: guest reset request")
                             cmdCommand = "reboot"
-                            time.sleep(3)
                             signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                            time.sleep(3)
                             process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
                             break
                         elif "host-qmp-system-reset" in json.dumps(resp["data"]):
                             print("VM is rebooting")
                             print("Reason: Reboot triggered by host")
                             cmdCommand = "reboot"
-                            time.sleep(3)
                             signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                            time.sleep(3)
                             process = subprocess.Popen(cmdCommand.split(), stdout=subprocess.PIPE)
                             break
                         elif "host-qmp-quit" in json.dumps(resp["data"]):


### PR DESCRIPTION
SIGTERM catch has to be carried out before
the sleep delay for the reboot scenario.

Tracked-On: OAM-101010
Signed-off-by: Shwetha B <shwetha.b@intel.com>