### PR TITLE
Switch civ software rendering from softpipe to swiftshader

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -33,7 +33,7 @@ case "$(cat /proc/fb)" in
                 ;;
         *)
                 echo "sw rendering"
-                setprop vendor.egl.set softpipe
+                setprop vendor.egl.set swiftshader
                 setprop vendor.hwcomposer.set drm_minigbm
                 setprop vendor.gralloc.set intel
                 ;;


### PR DESCRIPTION
Switch civ software rendering from softpipe to swiftshader

Tracked-On: OAM-101055
Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>