### PR TITLE
Deprecate OMX

### DIFF
--- a/exempt_groups.txt
+++ b/exempt_groups.txt
@@ -27,6 +27,7 @@ charger
 charger-usb
 chrome
 codecs
+codec2
 compatibility-enhancement
 compiler
 config-partition

--- a/groups/codec2/true/files.spec
+++ b/groups/codec2/true/files.spec
@@ -1,0 +1,7 @@
+[extrafiles]
+media_codecs_performance_c2_{{platform}}.xml: "Media codec2.0 performance file for specific platform"
+media_codecs_performance_c2_tgl.xml: "Media codec2.0 performance file for tigerlake"
+media_codecs_performance_c2_adl.xml: "Media codec2.0 performance file for alderlake"
+mfx_c2_store.conf: "MSDK configuration for video codec2.0"
+media_codecs_c2.xml: "Specific configuration for audio and video codec2.0"
+media_codecs_intel_c2_video.xml: "Specific configuration for intel video codec2.0"

--- a/groups/codec2/true/media_codecs_c2.xml
+++ b/groups/codec2/true/media_codecs_c2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2018 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<MediaCodecs>
+    <Include href="media_codecs_intel_c2_video.xml" />
+</MediaCodecs>

--- a/groups/codec2/true/media_codecs_intel_c2_video.xml
+++ b/groups/codec2/true/media_codecs_intel_c2_video.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- The contents of this file was copied
+from AOSP frameworks/av/media/libstagefright/data/media_codecs_google_c2_video.xml
+and updated to vendor media codecs.
+-->
+<Included>
+    <Decoders>
+{{#hw_vd_h264}}
+        <MediaCodec name="c2.intel.avc.decoder" type="video/avc">
+            <!-- profiles and levels:  ProfileHigh : Level52 -->
+            <Limit name="size" min="64x64" max="4096x4096" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="block-count" range="1-32768" /> <!-- max 4096x2048 equivalent -->
+            <Limit name="blocks-per-second" range="1-1966080" />
+            <Limit name="bitrate" range="1-48000000" />
+            <Limit name="performance-point-3840x2160" value="30" />
+            <Feature name="adaptive-playback" />
+        </MediaCodec>
+{{/hw_vd_h264}}
+
+{{#hw_vd_h265}}
+        <MediaCodec name="c2.intel.hevc.decoder" type="video/hevc">
+            <!-- profiles and levels:  ProfileMain : MainTierLevel51 -->
+            <Limit name="size" min="64x64" max="8192x8192" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="8x8" />
+            <Limit name="block-count" range="1-196608" /> <!-- max 4096x3072 -->
+            <Limit name="blocks-per-second" range="1-2000000" />
+            <Limit name="bitrate" range="1-10000000" />
+            <Limit name="performance-point-3840x2160" value="30" />
+            <Feature name="adaptive-playback" />
+        </MediaCodec>
+{{/hw_vd_h265}}
+
+{{#hw_vd_vp9}}
+        <MediaCodec name="c2.intel.vp9.decoder" type="video/x-vnd.on2.vp9">
+            <Limit name="size" min="64x64" max="8192x8192" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="block-count" range="1-16384" />
+            <Limit name="blocks-per-second" range="1-500000" />
+            <Limit name="bitrate" range="1-40000000" />
+            <Limit name="performance-point-3840x2160" value="30" />
+            <Feature name="adaptive-playback" />
+        </MediaCodec>
+{{/hw_vd_vp9}}
+
+{{#hw_vd_vp8}}
+        <MediaCodec name="c2.intel.vp8.decoder" type="video/x-vnd.on2.vp8">
+            <Limit name="size" min="64x64" max="4096x4096" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="block-count" range="1-16384" />
+            <Limit name="blocks-per-second" range="1-500000" />
+            <Limit name="bitrate" range="1-40000000" />
+            <Limit name="performance-point-3840x2160" value="30" />
+            <Feature name="adaptive-playback" />
+        </MediaCodec>
+{{/hw_vd_vp8}}
+
+{{#hw_vd_mp2}}
+        <MediaCodec name="c2.intel.mp2.decoder" type="video/mpeg2">
+            <Limit name="size" min="64x64" max="2048x2048" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="block-count" range="1-16384" />
+            <Limit name="blocks-per-second" range="1-500000" />
+            <Limit name="bitrate" range="1-40000000" />
+            <Limit name="performance-point-1920x1080" value="30" />
+            <Feature name="adaptive-playback" />
+        </MediaCodec>
+{{/hw_vd_mp2}}
+
+{{#hw_vd_av1}}
+        <MediaCodec name="c2.intel.av1.decoder" type="video/av01">
+            <Limit name="size" min="64x64" max="4096x4096" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="block-count" range="1-16384" />
+            <Limit name="blocks-per-second" range="1-500000" />
+            <Limit name="bitrate" range="1-40000000" />
+            <Limit name="performance-point-3840x2160" value="30" />
+            <Feature name="adaptive-playback" />
+        </MediaCodec>
+{{/hw_vd_av1}}
+    </Decoders>
+
+    <Encoders>
+{{#hw_ve_h264}}
+        <MediaCodec name="c2.intel.avc.encoder" type="video/avc">
+            <!-- profiles and levels:  ProfileBaseline : Level41 -->
+            <Limit name="size" min="176x144" max="4096x4096" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="block-count" range="1-8192" /> <!-- max 2048x1024 -->
+            <Limit name="blocks-per-second" range="1-245760" />
+            <Limit name="bitrate" range="1-12000000" />
+            <Limit name="performance-point-3840x2160" value="30" />
+            <!--Feature name="intra-refresh" /-->
+            <Diagnostics dumpOutput="false" />
+        </MediaCodec>
+{{/hw_ve_h264}}
+
+{{#hw_ve_h265}}
+        <MediaCodec name="c2.intel.hevc.encoder" type="video/hevc" >
+            <Limit name="size" min="176x144" max="8192x8192" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="blocks-per-second" range="1-972000" />
+            <Limit name="bitrate" range="1-40000000" />
+            <Limit name="performance-point-3840x2160" value="30" />
+        </MediaCodec>
+{{/hw_ve_h265}}
+
+{{#hw_ve_vp9}}
+	    <MediaCodec name="c2.intel.vp9.encoder" type="video/x-vnd.on2.vp9" >
+            <Limit name="size" min="128x96" max="8192x8192" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="block-count" range="1-245760" />
+            <Limit name="blocks-per-second" range="1-972000" />
+            <Limit name="bitrate" range="1-40000000" />
+            <Limit name="performance-point-3840x2160" value="30" />
+        </MediaCodec>
+{{/hw_ve_vp9}}
+    </Encoders>
+</Included>

--- a/groups/codec2/true/media_codecs_performance_c2_adl.xml
+++ b/groups/codec2/true/media_codecs_performance_c2_adl.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2015 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<MediaCodecs>
+    <Decoders>
+        <MediaCodec name="c2.android.h263.decoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="1972-3864" />
+            <Limit name="measured-frame-rate-352x288" range="1386-2648" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.avc.decoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="336-760" />
+            <Limit name="measured-frame-rate-720x480" range="448-720" />
+            <Limit name="measured-frame-rate-1280x720" range="152-240" />
+            <Limit name="measured-frame-rate-1920x1080" range="68-106" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.hevc.decoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-352x288" range="324-998" />
+            <Limit name="measured-frame-rate-640x360" range="634-978" />
+            <Limit name="measured-frame-rate-720x480" range="584-930" />
+            <Limit name="measured-frame-rate-1280x720" range="288-462" />
+            <Limit name="measured-frame-rate-1920x1080" range="158-360" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.mpeg4.decoder" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="2246-4372" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.vp8.decoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="860-930" />
+            <Limit name="measured-frame-rate-640x360" range="652-1002" />
+            <Limit name="measured-frame-rate-1280x720" range="132-284" />
+            <Limit name="measured-frame-rate-1920x1080" range="64-114" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.vp9.decoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x180" range="404-722" />
+            <Limit name="measured-frame-rate-640x360" range="632-998" />
+            <Limit name="measured-frame-rate-1280x720" range="308-492" />
+            <Limit name="measured-frame-rate-1920x1080" range="214-334" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.avc.decoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="3864-6146" />
+            <Limit name="measured-frame-rate-720x480" range="3526-5368" />
+            <Limit name="measured-frame-rate-1280x720" range="1585-2378" />
+            <Limit name="measured-frame-rate-1920x1088" range="632-1172" />
+            <Limit name="measured-frame-rate-3840x2160" range="272-492" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.hevc.decoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-352x288" range="2936-4562" />
+            <Limit name="measured-frame-rate-640x360" range="2402-3852" />
+            <Limit name="measured-frame-rate-720x480" range="2216-3484" />
+            <Limit name="measured-frame-rate-1280x720" range="1448-2286" />
+            <Limit name="measured-frame-rate-1920x1080" range="718-1584" />
+            <Limit name="measured-frame-rate-3840x2160" range="272-492" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.mp2.decoder" type="video/mpeg2" update="true">
+            <Limit name="measured-frame-rate-320x180" range="3228-5688" />
+            <Limit name="measured-frame-rate-640x360" range="2916-4582" />
+            <Limit name="measured-frame-rate-1280x720" range="1498-2374" />
+            <Limit name="measured-frame-rate-1920x1080" range="1108-1700" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.vp9.decoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x180" range="3228-5688" />
+            <Limit name="measured-frame-rate-640x360" range="2916-4582" />
+            <Limit name="measured-frame-rate-1280x720" range="1498-2374" />
+            <Limit name="measured-frame-rate-1920x1080" range="1108-1700" />
+            <Limit name="measured-frame-rate-3840x2160" range="303-492" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.av1.decoder" type="video/av01" update="true">
+            <Limit name="measured-frame-rate-320x180" range="3228-5688" />
+            <Limit name="measured-frame-rate-640x360" range="2916-4582" />
+            <Limit name="measured-frame-rate-1280x720" range="1498-2374" />
+            <Limit name="measured-frame-rate-1920x1080" range="1108-1700" />
+            <Limit name="measured-frame-rate-3840x2160" range="303-492" />
+        </MediaCodec>
+    </Decoders>
+    <Encoders>
+        <MediaCodec name="c2.android.avc.encoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="635-2624" />
+            <Limit name="measured-frame-rate-720x480" range="348-597" />
+            <Limit name="measured-frame-rate-1280x720" range="276-489" />
+            <Limit name="measured-frame-rate-1920x1080" range="156-276" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.hevc.encoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="86-204" />
+            <Limit name="measured-frame-rate-720x480" range="28-68" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.h263.encoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="878-3682" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.mpeg4.encoder" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="964-3380" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.vp8.encoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="150-1124" />
+            <Limit name="measured-frame-rate-640x360" range="95-662" />
+            <Limit name="measured-frame-rate-1280x720" range="60-142" />
+            <Limit name="measured-frame-rate-1920x1080" range="22-25" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.vp9.encoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x180" range="96-106" />
+            <Limit name="measured-frame-rate-640x360" range="39-39" />
+            <Limit name="measured-frame-rate-1280x720" range="7-9" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.avc.encoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="942-1540" />
+            <Limit name="measured-frame-rate-720x480" range="454-685" />
+            <Limit name="measured-frame-rate-1280x720" range="234-428" />
+            <Limit name="measured-frame-rate-1920x1080" range="96-208" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.hevc.encoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="806-1432" />
+            <Limit name="measured-frame-rate-720x480" range="394-606" />
+            <Limit name="measured-frame-rate-1280x720" range="204-306" />
+            <Limit name="measured-frame-rate-1920x1080" range="98-147" />
+            <Limit name="measured-frame-rate-3840x2160" range="28-42" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.vp9.encoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x240" range="806-1432" />
+            <Limit name="measured-frame-rate-720x480" range="394-606" />
+            <Limit name="measured-frame-rate-1280x720" range="204-306" />
+            <Limit name="measured-frame-rate-1920x1080" range="98-147" />
+            <Limit name="measured-frame-rate-3840x2160" range="28-42" />
+        </MediaCodec>
+    </Encoders>
+</MediaCodecs>

--- a/groups/codec2/true/media_codecs_performance_c2_tgl.xml
+++ b/groups/codec2/true/media_codecs_performance_c2_tgl.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2015 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<MediaCodecs>
+    <Decoders>
+        <MediaCodec name="c2.android.h263.decoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="1972-3864" />
+            <Limit name="measured-frame-rate-352x288" range="1386-2648" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.avc.decoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="336-760" />
+            <Limit name="measured-frame-rate-720x480" range="448-720" />
+            <Limit name="measured-frame-rate-1280x720" range="152-240" />
+            <Limit name="measured-frame-rate-1920x1080" range="68-106" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.hevc.decoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-352x288" range="324-998" />
+            <Limit name="measured-frame-rate-640x360" range="634-978" />
+            <Limit name="measured-frame-rate-720x480" range="584-930" />
+            <Limit name="measured-frame-rate-1280x720" range="288-462" />
+            <Limit name="measured-frame-rate-1920x1080" range="158-360" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.mpeg4.decoder" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="2246-4372" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.vp8.decoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="860-930" />
+            <Limit name="measured-frame-rate-640x360" range="652-1002" />
+            <Limit name="measured-frame-rate-1280x720" range="132-284" />
+            <Limit name="measured-frame-rate-1920x1080" range="64-114" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.vp9.decoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x180" range="404-722" />
+            <Limit name="measured-frame-rate-640x360" range="632-998" />
+            <Limit name="measured-frame-rate-1280x720" range="308-492" />
+            <Limit name="measured-frame-rate-1920x1080" range="214-334" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.avc.decoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="3864-6146" />
+            <Limit name="measured-frame-rate-720x480" range="3526-5368" />
+            <Limit name="measured-frame-rate-1280x720" range="1585-2378" />
+            <Limit name="measured-frame-rate-1920x1088" range="632-1172" />
+            <Limit name="measured-frame-rate-3840x2160" range="272-492" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.hevc.decoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-352x288" range="2936-4562" />
+            <Limit name="measured-frame-rate-640x360" range="2402-3852" />
+            <Limit name="measured-frame-rate-720x480" range="2216-3484" />
+            <Limit name="measured-frame-rate-1280x720" range="1448-2286" />
+            <Limit name="measured-frame-rate-1920x1080" range="718-1584" />
+            <Limit name="measured-frame-rate-3840x2160" range="272-492" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.mp2.decoder" type="video/mpeg2" update="true">
+            <Limit name="measured-frame-rate-320x180" range="3228-5688" />
+            <Limit name="measured-frame-rate-640x360" range="2916-4582" />
+            <Limit name="measured-frame-rate-1280x720" range="1498-2374" />
+            <Limit name="measured-frame-rate-1920x1080" range="1108-1700" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.vp8.decoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="3228-5688" />
+            <Limit name="measured-frame-rate-640x360" range="2916-4582" />
+            <Limit name="measured-frame-rate-1280x720" range="1498-2374" />
+            <Limit name="measured-frame-rate-1920x1080" range="1108-1700" />
+            <Limit name="measured-frame-rate-3840x2160" range="303-492" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.vp9.decoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x180" range="3228-5688" />
+            <Limit name="measured-frame-rate-640x360" range="2916-4582" />
+            <Limit name="measured-frame-rate-1280x720" range="1498-2374" />
+            <Limit name="measured-frame-rate-1920x1080" range="1108-1700" />
+            <Limit name="measured-frame-rate-3840x2160" range="303-492" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.av1.decoder" type="video/av01" update="true">
+            <Limit name="measured-frame-rate-320x180" range="3228-5688" />
+            <Limit name="measured-frame-rate-640x360" range="2916-4582" />
+            <Limit name="measured-frame-rate-1280x720" range="1498-2374" />
+            <Limit name="measured-frame-rate-1920x1080" range="1108-1700" />
+            <Limit name="measured-frame-rate-3840x2160" range="303-492" />
+        </MediaCodec>
+    </Decoders>
+    <Encoders>
+        <MediaCodec name="c2.android.avc.encoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="635-2624" />
+            <Limit name="measured-frame-rate-720x480" range="348-597" />
+            <Limit name="measured-frame-rate-1280x720" range="276-489" />
+            <Limit name="measured-frame-rate-1920x1080" range="156-276" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.hevc.encoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="86-204" />
+            <Limit name="measured-frame-rate-720x480" range="28-68" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.h263.encoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="878-3682" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.mpeg4.encoder" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="964-3380" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.vp8.encoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="150-1124" />
+            <Limit name="measured-frame-rate-640x360" range="95-662" />
+            <Limit name="measured-frame-rate-1280x720" range="60-142" />
+            <Limit name="measured-frame-rate-1920x1080" range="22-25" />
+        </MediaCodec>
+        <MediaCodec name="c2.android.vp9.encoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x180" range="96-106" />
+            <Limit name="measured-frame-rate-640x360" range="39-39" />
+            <Limit name="measured-frame-rate-1280x720" range="7-9" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.avc.encoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="942-1540" />
+            <Limit name="measured-frame-rate-720x480" range="454-685" />
+            <Limit name="measured-frame-rate-1280x720" range="234-428" />
+            <Limit name="measured-frame-rate-1920x1080" range="96-208" />
+        </MediaCodec>
+        <MediaCodec name="c2.intel.hevc.encoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="806-1432" />
+            <Limit name="measured-frame-rate-720x480" range="394-606" />
+            <Limit name="measured-frame-rate-1280x720" range="204-306" />
+            <Limit name="measured-frame-rate-1920x1080" range="98-147" />
+            <Limit name="measured-frame-rate-3840x2160" range="28-42" />
+        </MediaCodec>
+    </Encoders>
+</MediaCodecs>

--- a/groups/codec2/true/mfx_c2_store.conf
+++ b/groups/codec2/true/mfx_c2_store.conf
@@ -1,0 +1,35 @@
+{{#hw_vd_h264}}
+c2.intel.avc.decoder : libmfx_c2_components_hw.so
+{{/hw_vd_h264}}
+
+{{#hw_ve_h264}}
+c2.intel.avc.encoder : libmfx_c2_components_hw.so
+{{/hw_ve_h264}}
+
+{{#hw_vd_h265}}
+c2.intel.hevc.decoder : libmfx_c2_components_hw.so
+{{/hw_vd_h265}}
+
+{{#hw_ve_h265}}
+c2.intel.hevc.encoder : libmfx_c2_components_hw.so
+{{/hw_ve_h265}}
+
+{{#hw_ve_vp9}}
+c2.intel.vp9.encoder : libmfx_c2_components_hw.so
+{{/hw_ve_vp9}}
+
+{{#hw_vd_vp9}}
+c2.intel.vp9.decoder : libmfx_c2_components_hw.so
+{{/hw_vd_vp9}}
+
+{{#hw_vd_vp8}}
+c2.intel.vp8.decoder : libmfx_c2_components_hw.so
+{{/hw_vd_vp8}}
+
+{{#hw_vd_mp2}}
+c2.intel.mp2.decoder : libmfx_c2_components_hw.so
+{{/hw_vd_mp2}}
+
+{{#hw_vd_av1}}
+c2.intel.av1.decoder : libmfx_c2_components_hw.so
+{{/hw_vd_av1}}

--- a/groups/codec2/true/option.spec
+++ b/groups/codec2/true/option.spec
@@ -1,3 +1,16 @@
 [defaults]
+hw_vd_vc1 = false
+hw_vd_vp9 = true
+hw_vd_vp8 = true
+hw_vd_mp2 = true
+hw_vd_h264 = true
+hw_vd_h265 = true
+hw_vd_av1 = true
+hw_ve_vp8 = false
+hw_ve_vp9 = false
+hw_ve_h265 = true
+hw_ve_h264 = true
+gpu = gen12
+platform = adl
 enable_msdk_c2 = true
 use_onevpl = true

--- a/groups/codec2/true/product.mk
+++ b/groups/codec2/true/product.mk
@@ -2,9 +2,12 @@
 
 {{#enable_msdk_c2}}
 PRODUCT_COPY_FILES += \
-    vendor/intel/mediasdk_c2/c2_store/data/mfx_c2_store.conf:vendor/etc/mfx_c2_store.conf \
-    vendor/intel/mediasdk_c2/c2_store/data/media_codecs_c2.xml:vendor/etc/media_codecs_c2.xml \
-    vendor/intel/mediasdk_c2/c2_store/data/media_codecs_intel_c2_video.xml:vendor/etc/media_codecs_intel_c2_video.xml
+    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_c2_{{platform}}.xml:vendor/etc/media_codecs_performance_c2.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_c2_tgl.xml:vendor/etc/media_codecs_performance_tgl.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_c2_adl.xml:vendor/etc/media_codecs_performance_adl.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/mfx_c2_store.conf:vendor/etc/mfx_c2_store.conf \
+    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_c2.xml:vendor/etc/media_codecs_c2.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_intel_c2_video.xml:vendor/etc/media_codecs_intel_c2_video.xml
 
 PRODUCT_PACKAGES += \
     libmfx_c2_components_hw \

--- a/groups/codecs/configurable/option.spec
+++ b/groups/codecs/configurable/option.spec
@@ -1,19 +1,20 @@
 [defaults]
 hw_vd_vc1 = false
 hw_vd_vp9 = false
-hw_vd_vp8 = true
+hw_vd_vp8 = false
 sw_vd_h265 = false
-hw_vd_h265 = true
+hw_vd_h265 = false
 hw_vd_h265_secure = false
 hw_ve_vp8 = false
 hw_ve_vp9 = false
 hw_ve_h265 = false
-hw_ve_h264 = true
+hw_ve_h264 = false
 sw_vd_h264 = false
-hw_vd_h264 = true
+hw_vd_h264 = false
 hw_vd_h264_secure = false
 hw_vd_mp2 = false
 sw_omx_video = false
+hw_omx_video = false
 codec_perf_xen = false
 profile_file = media_profiles.xml
 gpu = gen12

--- a/groups/codecs/configurable/product.mk
+++ b/groups/codecs/configurable/product.mk
@@ -14,19 +14,28 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/{{_extra_dir}}/mfx_omxil_core_vp9.conf:vendor/etc/mfx_omxil_core.conf
 else
 PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_{{gpu}}.xml:vendor/etc/media_codecs.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_{{gpu}}.xml:vendor/etc/media_codecs.xml
+
+{{#hw_omx_video}}
+PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_gen9.xml:vendor/etc/media_codecs_gen9.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_gen12.xml:vendor/etc/media_codecs_gen12.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/mfx_omxil_core.conf:vendor/etc/mfx_omxil_core.conf
+{{/hw_omx_video}}
 endif
 
 {{^codec_perf_xen}}
+{{#hw_omx_video}}
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_{{platform}}.xml:vendor/etc/media_codecs_performance.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_cml.xml:vendor/etc/media_codecs_performance_cml.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_tgl.xml:vendor/etc/media_codecs_performance_tgl.xml
+{{/hw_omx_video}}
 {{/codec_perf_xen}}
+
 {{#codec_perf_xen}}
+{{#hw_omx_video}}
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_{{platform}}_xen.xml:vendor/etc/media_codecs_performance.xml
+{{/hw_omx_video}}
 {{/codec_perf_xen}}

--- a/groups/media/auto/BoardConfig.mk
+++ b/groups/media/auto/BoardConfig.mk
@@ -1,5 +1,8 @@
+{{#enable_msdk_omx}}
 INTEL_STAGEFRIGHT := true
 
 # Settings for the Media SDK library and plug-ins:
 # - USE_MEDIASDK: use Media SDK support or not
+# Used for mediasdk_release only
 USE_MEDIASDK := true
+{{/enable_msdk_omx}}

--- a/groups/media/auto/option.spec
+++ b/groups/media/auto/option.spec
@@ -1,4 +1,5 @@
 [defaults]
+enable_msdk_omx = true
 add_sw_msdk = false
 opensource_msdk = true
 opensource_msdk_omx_il = true

--- a/groups/media/auto/product.mk
+++ b/groups/media/auto/product.mk
@@ -1,20 +1,17 @@
+{{#enable_msdk_omx}}
 # libstagefrighthw
 PRODUCT_PACKAGES += \
     libstagefrighthw
 
 # Media SDK and OMX IL components
 PRODUCT_PACKAGES += \
-    libmfxhw32 \
     libmfx_omx_core \
     libmfx_omx_components_hw
+{{/enable_msdk_omx}}
 
-# Open source media_driver
-PRODUCT_PACKAGES += i965_drv_video
-PRODUCT_PACKAGES += libigfxcmrt
-
-# Open source hdcp
-PRODUCT_PACKAGES += libhdcpsdk
-PRODUCT_PACKAGES += lihdcpcommon
+# MediaSDK library
+PRODUCT_PACKAGES += \
+    libmfxhw32
 
 ifeq ($(BOARD_USE_64BIT_USERSPACE),true)
 PRODUCT_PACKAGES += \
@@ -40,6 +37,14 @@ BOARD_HAVE_MEDIASDK_OPEN_SOURCE := true
 {{#opensource_msdk_omx_il}}
 BOARD_HAVE_OMX_SRC := true
 {{/opensource_msdk_omx_il}}
+
+# Open source media_driver
+PRODUCT_PACKAGES += i965_drv_video
+PRODUCT_PACKAGES += libigfxcmrt
+
+# Open source hdcp
+PRODUCT_PACKAGES += libhdcpsdk
+PRODUCT_PACKAGES += lihdcpcommon
 
 PRODUCT_PACKAGES += \
     libpciaccess

--- a/groups/media/mesa/BoardConfig.mk
+++ b/groups/media/mesa/BoardConfig.mk
@@ -1,5 +1,8 @@
+{{#enable_msdk_omx}}
 INTEL_STAGEFRIGHT := true
 
 # Settings for the Media SDK library and plug-ins:
 # - USE_MEDIASDK: use Media SDK support or not
+# Used for mediasdk_release only
 USE_MEDIASDK := true
+{{/enable_msdk_omx}}

--- a/groups/media/mesa/option.spec
+++ b/groups/media/mesa/option.spec
@@ -1,4 +1,5 @@
 [defaults]
+enable_msdk_omx = true
 add_sw_msdk = false
 opensource_msdk = true
 opensource_msdk_omx_il = true

--- a/groups/media/mesa/product.mk
+++ b/groups/media/mesa/product.mk
@@ -1,21 +1,17 @@
+{{#enable_msdk_omx}}
 # libstagefrighthw
 PRODUCT_PACKAGES += \
     libstagefrighthw
 
-# Media SDK and OMX IL components
+# MSDK OMX IL components
 PRODUCT_PACKAGES += \
-    libmfxhw32 \
     libmfx_omx_core \
     libmfx_omx_components_hw
+{{/enable_msdk_omx}}
 
-# Open source media_driver
-PRODUCT_PACKAGES += i965_drv_video
-PRODUCT_PACKAGES += libgmm_umd
-PRODUCT_PACKAGES += libigfxcmrt
-
-# Open source hdcp
-PRODUCT_PACKAGES += libhdcpsdk
-PRODUCT_PACKAGES += lihdcpcommon
+# Media SDK libraries
+PRODUCT_PACKAGES += \
+    libmfxhw32
 
 ifeq ($(BOARD_USE_64BIT_USERSPACE),true)
 PRODUCT_PACKAGES += \
@@ -41,6 +37,14 @@ BOARD_HAVE_MEDIASDK_OPEN_SOURCE := true
 {{#opensource_msdk_omx_il}}
 BOARD_HAVE_OMX_SRC := true
 {{/opensource_msdk_omx_il}}
+
+# Open source media_driver
+PRODUCT_PACKAGES += i965_drv_video
+PRODUCT_PACKAGES += libigfxcmrt
+
+# Open source hdcp
+PRODUCT_PACKAGES += libhdcpsdk
+PRODUCT_PACKAGES += lihdcpcommon
 
 PRODUCT_PACKAGES += \
     libpciaccess


### PR DESCRIPTION
Disable OMX plugin as OMX is marked deprecated
in Android 12

Tracked-On: OAM-101087
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>