### PR TITLE
Add vulkan sw support for virtio-gpu

### DIFF
--- a/groups/aaf/true/init.rc
+++ b/groups/aaf/true/init.rc
@@ -4,6 +4,8 @@ on fs
     exec - system system -- /vendor/bin/logwrapper /vendor/bin/sh /vendor/bin/auto_detection.sh
     setprop ro.hardware.hwcomposer ${vendor.hwcomposer.set}
     setprop ro.hardware.gralloc ${vendor.gralloc.set}
+    setprop ro.hardware.egl ${vendor.egl.set}
+    setprop ro.hardware.vulkan ${vendor.vulkan.set}
     setprop ro.power.fixed_performance_scale_factor ${vendor.power.fixed_performance_scale_factor}
     setprop ro.media.xml_variant.codecs ${ro.vendor.media.target_variant}
     setprop ro.media.xml_variant.codecs_performance ${ro.vendor.media.target_variant_platform}

--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -2,40 +2,37 @@ update_graphics() {
 case "$(cat /proc/fb)" in
         *i915)
                 echo "intel"
-                setprop vendor.hwcomposer.set drm_minigbm
-                setprop vendor.gralloc.set intel
                 setprop vendor.hwcomposer.edid.all 0
+                setprop vendor.vulkan.set celadon
                 ;;
         *i915drmfb)
                 echo "intel"
-                setprop vendor.hwcomposer.set drm_minigbm
-                setprop vendor.gralloc.set intel
                 setprop vendor.hwcomposer.edid.all 0
+                setprop vendor.vulkan.set celadon
                 ;;
         *inteldrmfb)
                 echo "intel"
-                setprop vendor.hwcomposer.set drm_minigbm
-                setprop vendor.gralloc.set intel
                 setprop vendor.hwcomposer.edid.all 0
+                setprop vendor.vulkan.set celadon
                 ;;
         *virtiodrmfb)
                 echo "virtio-gpu"
-                setprop vendor.hwcomposer.set drm_minigbm
-                setprop vendor.gralloc.set intel
+                setprop vendor.vulkan.set pastel
                 ;;
 	*virtio_gpudrmfb)
                 echo "virtio-gpu"
-                setprop vendor.hwcomposer.set drm_minigbm
-                setprop vendor.gralloc.set intel
                 if [ "$(cat /sys/kernel/debug/dri/0/virtio-gpu-features |grep virgl |awk '{print $3}')" = "no" ];then
-                        setprop vendor.gles.set softpipe
+                        echo "swiftshader display"
+                        setprop vendor.egl.set swiftshader
+                        setprop vendor.vulkan.set pastel
+                else
+                        setprop vendor.vulkan.set celadon
                 fi
                 ;;
         *)
                 echo "sw rendering"
                 setprop vendor.egl.set swiftshader
-                setprop vendor.hwcomposer.set drm_minigbm
-                setprop vendor.gralloc.set intel
+                setprop vendor.vulkan.set pastel
                 ;;
 esac
 }

--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -40,11 +40,14 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     hwcomposer.drm_minigbm
 
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hardware.hwcomposer=drm_minigbm
 {{#minigbm}}
 # Mini gbm
-
 PRODUCT_PACKAGES += \
     gralloc.$(TARGET_GFX_INTEL)
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hardware.gralloc=$(TARGET_GFX_INTEL)
 {{/minigbm}}
 
 {{^minigbm}}
@@ -95,8 +98,5 @@ PRODUCT_COPY_FILES += \
 
 PRODUCT_PACKAGES += \
     vulkan.$(TARGET_BOARD_PLATFORM) \
-    libvulkan_intel
-
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.hardware.vulkan=$(TARGET_BOARD_PLATFORM)
+    vulkan.pastel
 {{/vulkan}}


### PR DESCRIPTION
In general, we use vulkan celadon.
For virtio2d, we need to provide vulkan.pastel for SW support.

Tracked-On: OAM-101217
Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>