### PR TITLE
i915/drm: add i915.enable_fbc=1

### DIFF
--- a/groups/graphics/auto/BoardConfig.mk
+++ b/groups/graphics/auto/BoardConfig.mk
@@ -2,7 +2,7 @@
 TARGET_USE_PRIVATE_LIBDRM := true
 LIBDRM_VER ?= intel
 
-BOARD_KERNEL_CMDLINE += vga=current i915.modeset=1 drm.atomic=1 i915.nuclear_pageflip=1 drm.vblankoffdelay=1 i915.fastboot=1
+BOARD_KERNEL_CMDLINE += vga=current i915.modeset=1 drm.atomic=1 i915.nuclear_pageflip=1 drm.vblankoffdelay=1 i915.fastboot=1 i915.enable_fbc=1
 {{^acrn-guest}}
 {{#enable_guc}}
 BOARD_KERNEL_CMDLINE += i915.enable_guc=2


### PR DESCRIPTION
Framebuffer compression (enable_fbc)
Making use of Framebuffer compression (FBC) can reduce power consumption while reducing memory bandwidth needed for screen refreshes.

To enable FBC, use i915.enable_fbc=1 as kernel parameter

Tracked-On: OAM-99951
Signed-off-by: Kanli Hu <kanli.hu@intel.com>