### PR TITLE
Unify one caas image for BM, Gvt-d, VirtIO and SRIOV

### DIFF
--- a/groups/graphics/auto/BoardConfig.mk
+++ b/groups/graphics/auto/BoardConfig.mk
@@ -15,7 +15,6 @@ endif
 
 ifeq ($(BASE_LTS2020_YOCTO_KERNEL),true)
 BOARD_KERNEL_CMDLINE += i915.enable_guc=1
-BOARD_KERNEL_CMDLINE += i915.disable_display=1
 endif
 
 USE_OPENGL_RENDERER := true


### PR DESCRIPTION
So far the SRIOV and BM/Gvt-d/VirtIO need use two caas image to boot.
This patch could use a unify build for all gfx config by removing
the disable i915 display config in kernel.

The i915.disable_display is for the kmsro. In kmsro, there are
two backend drivers: i915 and virtio. The i915 is for render buffer,
the virtio is for scanout(display) buffer, so at beginning we disable
i915 display to only let virtio for display.
Now the minigbm have merged one patch that scanout(display) buffer
using virtio to allocate, other buffers using i915 to allocate.
Also in qemu, we pass the -device virtio-vga to emulate the display.
The i915.disable_display is not needed anymore.

Tracked-On: OAM-101681
Signed-off-by: HeYue <yue.he@intel.com>