### PR TITLE
Fix low volume on USB Headset in Passthrough mode

### DIFF
--- a/groups/audio/project-celadon/default/mixer_paths_usb.xml
+++ b/groups/audio/project-celadon/default/mixer_paths_usb.xml
@@ -1,7 +1,5 @@
 <mixer>
   <!-- These are the initial mixer settings -->
+  <ctl name="PCM Playback Volume" value="44 44" />
   <ctl name="Headset Playback Volume" value="24 24" />
-  <path name="usb_headset">
-    <ctl name="Headset Playback Volume" value="24 24" />
-  </path>
 </mixer>

--- a/groups/audio/project-celadon/product.mk
+++ b/groups/audio/project-celadon/product.mk
@@ -56,7 +56,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PROPERTY_OVERRIDES += ro.vendor.hdmi.audio=ehl
 else
 PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/audio/default/mixer_paths_0.xml:vendor/etc/mixer_paths_0.xml
+    $(LOCAL_PATH)/audio/default/mixer_paths_0.xml:vendor/etc/mixer_paths_0.xml \
+    $(LOCAL_PATH)/audio/default/mixer_paths_usb.xml:vendor/etc/mixer_paths_usb.xml
 endif
 
 #fallback


### PR DESCRIPTION
Touch tones are not heard via USB Headset in Passthrough mode.
Increase volume gain to the highest value for the mixer control.

Tracked-On: OAM-101861
Signed-off-by: pmandri <padmashree.mandri@intel.com>