### PR TITLE
Thermal configuration for Alder Lake

### DIFF
--- a/groups/device-specific/caas/intel-thermal-conf.xml
+++ b/groups/device-specific/caas/intel-thermal-conf.xml
@@ -224,6 +224,13 @@
 						</CoolingDevice>
 					</TripPoint>
 				</TripPoints>
+				<TripPoints>
+					<TripPoint>
+						<SensorType>x86_pkg_temp</SensorType>
+						<Temperature>100000</Temperature>
+						<Type>Critical</Type>
+					</TripPoint>
+				</TripPoints>
 			</ThermalZone>
 		</ThermalZones>
 		<CoolingDevices>


### PR DESCRIPTION
This change will add critical temperature
customisations for Alderlake.

When the machine temperature reaches 100C,
device will go for shutdown.

Tracked-On: OAM-102063
Signed-off-by: Vilas R K <vilas.r.k@intel.com>