### PR TITLE
Use adl as default C2 performance setting

### DIFF
--- a/groups/codec2/true/files.spec
+++ b/groups/codec2/true/files.spec
@@ -1,5 +1,4 @@
 [extrafiles]
-media_codecs_performance_c2_{{platform}}.xml: "Media codec2.0 performance file for specific platform"
 media_codecs_performance_c2_tgl.xml: "Media codec2.0 performance file for tigerlake"
 media_codecs_performance_c2_adl.xml: "Media codec2.0 performance file for alderlake"
 mfx_c2_store.conf: "MSDK configuration for video codec2.0"

--- a/groups/codec2/true/product.mk
+++ b/groups/codec2/true/product.mk
@@ -2,7 +2,7 @@
 
 {{#enable_msdk_c2}}
 PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_c2_{{platform}}.xml:vendor/etc/media_codecs_performance_c2.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_c2_adl.xml:vendor/etc/media_codecs_performance_c2.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_c2_tgl.xml:vendor/etc/media_codecs_performance_tgl.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_c2_adl.xml:vendor/etc/media_codecs_performance_adl.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/mfx_c2_store.conf:vendor/etc/mfx_c2_store.conf \

--- a/groups/codecs/configurable/auto_hal.in
+++ b/groups/codecs/configurable/auto_hal.in
@@ -9,6 +9,9 @@ if [ $value_model == 166 ]; then
 elif [ $value_model == 141 ]; then
     setprop ro.vendor.media.target_variant "_gen12"
     setprop ro.vendor.media.target_variant_platform "_tgl"
+elif [ $value_model == 154 ]; then
+    setprop ro.vendor.media.target_variant "_gen12"
+    setprop ro.vendor.media.target_variant_platform "_adl"
 else
     :
 fi


### PR DESCRIPTION
Use adl as default C2 performance setting

    media_codecs_performance_c2_adl.xml is copied as default
    and auto_hal.in is updated for applying adl.


Tracked-On: OAM-102384
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>