### PR TITLE
Resolve issue of usb card listing as sdcard

### DIFF
--- a/groups/storage/sdcard-v-usb-only/fstab.recovery
+++ b/groups/storage/sdcard-v-usb-only/fstab.recovery
@@ -1,2 +1,2 @@
 /dev/block/sdb1                         /udiskb          vfat    defaults                                   voldmanaged=udiskb:auto
-/dev/block/sda1                    /sdcard          vfat    defaults                                   voldmanaged=sdcard:auto
+/dev/block/sda1                    /udiska          vfat    defaults                                   voldmanaged=udiska:auto


### PR DESCRIPTION
This changes resolves issue of usb getting detected
as sdcard in recovery mode.

Signed-off-by: pmandri <padmashree.mandri@intel.com>