### PR TITLE
Add the supported vendor-ndk level

### DIFF
--- a/groups/device-specific/caas/compatibility_matrix.xml
+++ b/groups/device-specific/caas/compatibility_matrix.xml
@@ -55,4 +55,7 @@
             <instance>default</instance>
         </interface>
     </hal>
+    <vendor-ndk>
+        <version>31</version>
+    </vendor-ndk>
 </compatibility-matrix>

--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -198,5 +198,7 @@
             <instance>default</instance>
         </interface>
     </hal>
-
+    <vendor-ndk>
+        <version>31</version>
+    </vendor-ndk>
 </manifest>


### PR DESCRIPTION
This patch will add the supported vendor-ndk level in
framework manifest and compatibilty matrix to solve the
compatibility check failure while building OTA package.

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>