### PR TITLE
Incorporate bootctrl HAL module into recovery image

### DIFF
--- a/groups/slot-ab/true/product.mk
+++ b/groups/slot-ab/true/product.mk
@@ -8,7 +8,8 @@ PRODUCT_PACKAGES += \
     android.hardware.boot@1.2-impl-intel \
     android.hardware.boot@1.2-impl-intel.recovery \
     android.hardware.boot@1.2-service \
-    bootctrl.intel
+    bootctrl.intel \
+    bootctrl.intel.recovery
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.bootctrl=intel


### PR DESCRIPTION
Currently OTA cannot pass in recovery mode since bootctrl
HAL module is not included in the recovery image.

Tracked-On: OAM-102639
Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>