### PR TITLE
Shift storageproxyd to a very early stage

### DIFF
--- a/groups/trusty/true/init.rc
+++ b/groups/trusty/true/init.rc
@@ -1,6 +1,8 @@
 on post-fs-data
     mkdir /data/vendor/securestorage 0700 system system
     chmod 666 /dev/rpmb0
+
+on early-fs
     start storageproxyd
 
 service storageproxyd /vendor/bin/storageproxyd -d /dev/trusty-ipc-dev0 -p /data/vendor/securestorage -r /dev/vport0p1 -t virt


### PR DESCRIPTION
Gatekeeper or Keymaster may call SecureStorage before /data
are fully decrypted or mounted. In some conditions, it may
cause to deadlock. Shift storageproxyd booting as earlier
as possible can break the deadlock.

Tested with:
run cts -m CtsAppSecurityHostTestCases -t
"android.appsecurity.cts.ResumeOnRebootHostTest#resumeOnReboot_SingleUser_MultiClient_ClientASuccess"

Tracked-On: OAM-102823
Signed-off-by: Yang Huang <yang.huang@intel.com>