### PR TITLE
Remove kernel target-level from manifest.xml

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -155,7 +155,6 @@
             <instance>default</instance>
         </interface>
     </hal>
-    <kernel target-level="5"/>
     <sepolicy>
         <version>31.0</version>
     </sepolicy>


### PR DESCRIPTION
Setting kernel target-level in manifest requires enabling all android-base configs. As x86 does not support GKI, kernel config CONFIG_TRACE_GPU_MEM can not be enabled.
Also, in celadon to dynamically switch between legacy-hda and sof, CONFIG_SND has to be configured as module instead of static kernel driver.
Since kernel target-level is optional, it is removed from manifest.

Tracked-On: OAM-102829
Signed-off-by: Lakshmishree C <lakshmishree.c@intel.com>