### PR TITLE
Add property to control nonblock

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -15,6 +15,7 @@ case "$(cat /proc/fb)" in
                         echo "sriov rendering"
                         setprop vendor.egl.set mesa
                         setprop vendor.vulkan.set intel
+                        setprop drm.nonblock_commit.on 0
                 else
                         if [ "$(cat /sys/kernel/debug/dri/0/virtio-gpu-features |grep virgl |awk '{print $3}')" = "no" ];then
                                 echo "swiftshader rendering"

--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -59,6 +59,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.hwcomposer=drm_minigbm
 
+# DRM nonblock commit
+PRODUCT_PROPERTY_OVERRIDES += \
+    drm.nonblock_commit.on=1
+
 {{#minigbm}}
 # Mini gbm
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
When SRIOV is started, the current blocking state is controlled according to the property

Tracked-On: OAM-103400
Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>