### PR TITLE
Add property for SRIOV to disable nonblock

### DIFF
--- a/groups/aaf/true/init.rc
+++ b/groups/aaf/true/init.rc
@@ -6,6 +6,7 @@ on fs
     setprop ro.hardware.gralloc ${vendor.gralloc.set}
     setprop ro.hardware.egl ${vendor.egl.set}
     setprop ro.hardware.vulkan ${vendor.vulkan.set}
+    setprop ro.vendor.drm.nonblock_commit.on ${vendor.nonblock_commit.set}
     setprop ro.power.fixed_performance_scale_factor ${vendor.power.fixed_performance_scale_factor}
     setprop ro.media.xml_variant.codecs ${ro.vendor.media.target_variant}
     setprop ro.media.xml_variant.codecs_performance ${ro.vendor.media.target_variant_platform}

--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -15,6 +15,7 @@ case "$(cat /proc/fb)" in
                         echo "sriov rendering"
                         setprop vendor.egl.set mesa
                         setprop vendor.vulkan.set intel
+                        setprop vendor.nonblock_commit.set 0
                 else
                         if [ "$(cat /sys/kernel/debug/dri/0/virtio-gpu-features |grep virgl |awk '{print $3}')" = "no" ];then
                                 echo "swiftshader rendering"


### PR DESCRIPTION
When starting sriov, execute "setprop drm.nonblock.on 0" to switch nonblock to blocking

Tracked-On: OAM-103400
Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>