### PR TITLE
Add property for SRIOV to disable nonblock

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -15,6 +15,7 @@ case "$(cat /proc/fb)" in
                         echo "sriov rendering"
                         setprop vendor.egl.set mesa
                         setprop vendor.vulkan.set intel
+                        setprop ro.vendor.drm.nonblock_commit.on 0
                 else
                         if [ "$(cat /sys/kernel/debug/dri/0/virtio-gpu-features |grep virgl |awk '{print $3}')" = "no" ];then
                                 echo "swiftshader rendering"


### PR DESCRIPTION
When starting sriov, execute "setprop drm.nonblock.on 0" to switch nonblock to blocking

Tracked-On: OAM-103400
Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>