### PR TITLE
[S-MR0-CELADON-MASTER][ADL-CIV-S] CTS module CtsWindowManagerDeviceTe…

### DIFF
--- a/groups/device-type/tablet/product.mk
+++ b/groups/device-type/tablet/product.mk
@@ -3,6 +3,3 @@ PRODUCT_CHARACTERISTICS := tablet
 PRODUCT_COPY_FILES += \
         {{{tablet_core_hardware_path}}}/tablet_core_hardware.xml:vendor/etc/permissions/tablet_core_hardware.xml
 
-PRODUCT_COPY_FILES += \
-    frameworks/native/data/etc/android.software.freeform_window_management.xml:vendor/etc/permissions/android.software.freeform_window_management.xml
-


### PR DESCRIPTION
…stCases failed with 24 tests.

I have verified in Pixel A12 device. These test case are passing there.
Actually in pixel device, FEATURE_FREEFORM_WINDOW_MANAGEMENT feature is not enabled.
So this CTS test case is running in Split Mode instead of Free Form Mode.
In Pixel Tablet (large screen) Emulator of A12 also, this feature is not enabled.
So I have disabled Free Form Feature in our CIV build and run this test case. After that CTS is passing.

Tracked-On:OAM-103542
Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>