### PR TITLE
Fix ivi software cannot boot up on ADL platform

### DIFF
--- a/groups/device-specific/celadon_ivi/overlay/packages/Car/service/res/values/config.xml
+++ b/groups/device-specific/celadon_ivi/overlay/packages/Car/service/res/values/config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009-2012 Broadcom Corporation
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<resources>
+    <bool name="config_enableCarLocationServiceGnssControlsForPowerManagement">false</bool>
+</resources>


### PR DESCRIPTION
 As GNSS HAL is not yet implemented, GNSS service is not created.
 However, the power management function for gnss is enabled currently.
 When power state changes, the suspend callback will
 be called on gnss service resulting in null pointer dereference.

 As GNSS HAL is not implemented, power management for gnss is disabled.

Tracked-On: OAM-103707
Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>