### PR TITLE
Remove trusty driver in kernel config when trusty is disabled

### DIFF
--- a/groups/kernel/gmin64/config-lts/lts2019-chromium/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/lts2019-chromium/x86_64_defconfig
@@ -3233,6 +3233,7 @@ CONFIG_PROC_THERMAL_MMIO_RAPL=y
 #
 # Trusty
 #
+{{#trusty_driver}}
 CONFIG_TRUSTY=y
 CONFIG_TRUSTY_BACKUP_TIMER=y
 CONFIG_TRUSTY_IRQ=n
@@ -3241,6 +3242,10 @@ CONFIG_TRUSTY_TEST=n
 CONFIG_TRUSTY_VIRTIO=y
 CONFIG_TRUSTY_VIRTIO_IPC=y
 CONFIG_TRUSTY_X86_64=y
+{{/trusty_driver}}
+{{^trusty_driver}}
+# CONFIG_TRUSTY is not set
+{{/trusty_driver}}
 # end of Trusty
 
 CONFIG_WATCHDOG=y

--- a/groups/kernel/gmin64/config-lts/lts2019-yocto/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/lts2019-yocto/x86_64_defconfig
@@ -3258,11 +3258,16 @@ CONFIG_PROC_THERMAL_MMIO_RAPL=y
 #
 # Trusty
 #
+{{#trusty_driver}}
 CONFIG_TRUSTY=m
 CONFIG_TRUSTY_LOG=m
 CONFIG_TRUSTY_VIRTIO=m
 CONFIG_TRUSTY_VIRTIO_IPC=m
 CONFIG_TRUSTY_BACKUP_TIMER=m
+{{/trusty_driver}}
+{{^trusty_driver}}
+# CONFIG_TRUSTY is not set
+{{/trusty_driver}}
 # end of Trusty
 
 CONFIG_WATCHDOG=y

--- a/groups/kernel/gmin64/config-lts/lts2020-chromium/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/lts2020-chromium/x86_64_defconfig
@@ -3341,6 +3341,7 @@ CONFIG_PROC_THERMAL_MMIO_RAPL=y
 #
 # Trusty driver
 #
+{{#trusty_driver}}
 CONFIG_TRUSTY=y
 # CONFIG_TRUSTY_IRQ is not set
 CONFIG_TRUSTY_LOG=y
@@ -3351,6 +3352,10 @@ CONFIG_TRUSTY_VIRTIO_IPC=y
 # CONFIG_TRUSTY_CRASH_IS_PANIC is not set
 CONFIG_TRUSTY_X86_64=y
 CONFIG_TRUSTY_BACKUP_TIMER=y
+{{/trusty_driver}}
+{{^trusty_driver}}
+# CONFIG_TRUSTY is not set
+{{/trusty_driver}}
 # end of Trusty driver
 
 CONFIG_WATCHDOG=y

--- a/groups/kernel/gmin64/config-lts/lts2020-yocto/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/lts2020-yocto/x86_64_defconfig
@@ -3333,6 +3333,7 @@ CONFIG_PROC_THERMAL_MMIO_RAPL=y
 #
 # Trusty driver
 #
+{{#trusty_driver}}
 CONFIG_TRUSTY=y
 # CONFIG_TRUSTY_IRQ is not set
 CONFIG_TRUSTY_LOG=y
@@ -3341,6 +3342,10 @@ CONFIG_TRUSTY_VIRTIO=y
 CONFIG_TRUSTY_VIRTIO_IPC=y
 CONFIG_TRUSTY_X86_64=y
 CONFIG_TRUSTY_BACKUP_TIMER=y
+{{/trusty_driver}}
+{{^trusty_driver}}
+# CONFIG_TRUSTY is not set
+{{/trusty_driver}}
 # end of Trusty driver
 
 CONFIG_WATCHDOG=y

--- a/groups/kernel/option.spec-gmin
+++ b/groups/kernel/option.spec-gmin
@@ -33,3 +33,4 @@ lts2020_yocto_cfg_path =
 lts2020_chromium_src_path =
 lts2020_chromium_cfg_path =
 more_modules = false
+trusty_driver = true


### PR DESCRIPTION
Remove trusty driver in kernel config when trusty is disabled.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>