### PR TITLE
"Set file context for

### DIFF
--- a/groups/device-type/tv/BoardConfig.mk
+++ b/groups/device-type/tv/BoardConfig.mk
@@ -1,1 +1,4 @@
 DEVICE_PACKAGE_OVERLAYS += device/google/cuttlefish/shared/tv/overlay
+
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/tv
+


### PR DESCRIPTION
android.hardware.tv.cec@1.0-service.mock"

Tracked-On: OAM-103991
Signed-off-by: swaroopb <swaroop.balan@intel.com>