### PR TITLE
Configure rro overlay for connectivity to fix CTS issue

### DIFF
--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -7,7 +7,8 @@ PRODUCT_PACKAGES += \
     wpa_cli \
     iw \
     TetheringConfigOverlay \
-    TetheringConfigOverlayGsi
+    TetheringConfigOverlayGsi \
+    ServiceConnectivityResourcesConfigOverlay
 
 PRODUCT_PACKAGES += \
     android.hardware.wifi@1.0-service


### PR DESCRIPTION
Keepalive packet offloading is enabled by default. CTS test cases
are failing as the keepalive offloading event is not received.

As Keepalive is not supported, configure the rro overlay for
ServiceConnectivityResource to disable the
networkSupportedKeepaliveCount to fix the Cts Net TC module issue.

Tracked-On: OAM-104109
Signed-off-by: gollarx <ratnakumarix.golla@intel.com>