### PR TITLE
Enable Basic Android TV UI

### DIFF
--- a/groups/device-specific/celadon_tv/manifest.xml
+++ b/groups/device-specific/celadon_tv/manifest.xml
@@ -81,7 +81,7 @@
     <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
-        <version>2.4</version>
+        <version>2.1</version>
         <interface>
             <name>IComposer</name>
             <instance>default</instance>

--- a/groups/device-specific/celadon_tv/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/groups/device-specific/celadon_tv/overlay/frameworks/base/core/res/res/values/config.xml
@@ -197,4 +197,7 @@
         <item>bugreport</item>
         <item>users</item>
     </string-array>
+    <!-- Launcher customization requires AppWidgetService, but otherwise
+         home screen widgets are not supported on TV -->
+    <bool name="config_enableAppWidgetService">true</bool>
 </resources>

--- a/groups/device-specific/celadon_tv/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/groups/device-specific/celadon_tv/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -17,6 +17,8 @@
  */
 -->
 <resources>
+    <!-- Disable the lockscreen -->
+    <bool name="def_lockscreen_disabled">true</bool>
 
     <!-- Default for Settings.Secure.WAKE_GESTURE_ENABLED -->
     <bool name="def_wake_gesture_enabled">false</bool>

--- a/groups/device-specific/celadon_tv/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/groups/device-specific/celadon_tv/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -22,6 +22,9 @@
     <!-- Whether to show a warning notification when the device reaches a certain temperature. -->
     <integer name="config_showTemperatureWarning">1</integer>
 
+    <!-- Disable KeyguardSerivce -->
+    <bool name="config_enableKeyguardService">false</bool>
+
     <!-- Temp at which to show a warning notification if config_showTemperatureWarning is true.
          If < 0, uses the value from
          HardwarePropertiesManager#getDeviceTemperatures - config_warningTemperatureTolerance. -->

--- a/groups/device-specific/celadon_tv/product.mk
+++ b/groups/device-specific/celadon_tv/product.mk
@@ -24,7 +24,7 @@ PRODUCT_PACKAGES += android.hardware.usb@1.0-impl \
                     android.hardware.graphics.mapper@4.0-impl.minigbm \
                     android.hardware.graphics.allocator@4.0-service.minigbm \
                     android.hardware.renderscript@1.0-impl \
-                    android.hardware.graphics.composer@2.4-service
+                    android.hardware.graphics.composer@2.1-service
 
 PRODUCT_PACKAGES += \
     LatinIMEGoogleTvPrebuilt \

--- a/groups/device-specific/celadon_tv/product.mk
+++ b/groups/device-specific/celadon_tv/product.mk
@@ -26,6 +26,9 @@ PRODUCT_PACKAGES += android.hardware.usb@1.0-impl \
                     android.hardware.renderscript@1.0-impl \
                     android.hardware.graphics.composer@2.4-service
 
+PRODUCT_PACKAGES += \
+    LatinIMEGoogleTvPrebuilt \
+    TvSampleLeanbackLauncher
 
 PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce
 PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.useautofastjni=true

--- a/groups/device-specific/celadon_tv/product.mk
+++ b/groups/device-specific/celadon_tv/product.mk
@@ -28,7 +28,8 @@ PRODUCT_PACKAGES += android.hardware.usb@1.0-impl \
 
 PRODUCT_PACKAGES += \
     LatinIMEGoogleTvPrebuilt \
-    TvSampleLeanbackLauncher
+    TvSampleLeanbackLauncher \
+    TvSettings
 
 PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce
 PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.useautofastjni=true


### PR DESCRIPTION
Andrdoid TV doesn't need lockscreen and needs
appWidgets enabled to work.

Tracked-On: OAM-104028
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>