### PR TITLE
guest_pm_control: Remove hardcoding of sendkey binary call

### DIFF
--- a/groups/device-specific/caas/guest_pm_control
+++ b/groups/device-specific/caas/guest_pm_control
@@ -172,8 +172,8 @@ def main():
                     elif val == "WAKEUP":
                         if rtc_wakeup == 0:
                             time.sleep(1)
-                            cmdCommand = "./sendkey --vm 0 --power 0"
-                            process = subprocess.call(cmdCommand.split(), stdout=subprocess.PIPE)
+                            # send power button event using sendkey binary
+                            process = subprocess.run([argv[2], '--vm', '0', '--power', '0'])
 
         except KeyboardInterrupt:
             print('interrupted!')


### PR DESCRIPTION
Remove hardcoding of sendkey binary call. With latest vm-manager sendkey binary path is getting passed as argument.

Tracked-On: OAM-104061
Signed-off-by: kaushlendra <kaushlendra.kumar@intel.com>