### PR TITLE
Addition of atrace in framework manifest file

### DIFF
--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -4,6 +4,15 @@
 {{#ota-update}}
 <manifest version="1.0" type="framework">
 {{/ota-update}}
+    <hal format="hidl">
+        <name>android.hardware.atrace</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IAtraceDevice</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
     <hal format="aidl">
         <name>android.hardware.security.keymint</name>
         <version>1</version>


### PR DESCRIPTION
This patch will add atrace HAL to the framework manifest file to enable the atrace service.

Tracked-On: OAM-104085
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>