### PR TITLE
Gptimage will not be built by command "make flashfiles publish_ci"

### DIFF
--- a/groups/gptbuild/true/BoardConfig.mk
+++ b/groups/gptbuild/true/BoardConfig.mk
@@ -7,7 +7,7 @@ GPTIMAGE_BIN = $(PRODUCT_OUT)/$(TARGET_PRODUCT).img
 CRAFFIMAGE_BIN = $(PRODUCT_OUT)/$(TARGET_PRODUCT).craff
 {{/generate_craff}}
 
-{{^gen_gptimage_when_pub}}
+{{#gen_gptimage_when_pub}}
 BOARD_FLASHFILES += $(GPTIMAGE_BIN):$(TARGET_PRODUCT).img
 {{/gen_gptimage_when_pub}}
 


### PR DESCRIPTION
Remove caas.img from the CIV build and create new
make command for Users in need.

Right now each and every build generates caas.img as part of build process and it is uploaded to artifactory, consuming space and processing time. Since not all users need it, we can allow it to be created only as part of additional make commands that user can pass while running an engineering build. This should improve build time in CI and friendly to developer.

Developer can use "make publish_gptimage" to generate caas.img.gz or "make gptimage" to generate caas.img

Tracked-On: OAM-102849
Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>