### PR TITLE
Fix for ethernet driver not loaded in ADL NUC

### DIFF
--- a/groups/kernel/gmin64/config-lts/lts2020-yocto/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/lts2020-yocto/x86_64_defconfig
@@ -2129,7 +2129,7 @@ CONFIG_E1000E_HWTS=y
 # CONFIG_I40EVF is not set
 # CONFIG_ICE is not set
 # CONFIG_FM10K is not set
-# CONFIG_IGC is not set
+CONFIG_IGC=y
 # CONFIG_JME is not set
 # CONFIG_NET_VENDOR_MARVELL is not set
 # CONFIG_NET_VENDOR_MELLANOX is not set


### PR DESCRIPTION
Ethernet driver for ethernet controller I225-LM/I225-V is not loaded.

Driver corresponding to ethernet controller I225-LM/I225-V in ADL NUC is igc and it is not enabled in kernel config causing ethernet not working in ADL NUC.

Fix the issue by enabling ethernet driver for ethernet controller I225-LM/I225-V.

Tracked-On: OAM-104133
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>