### PR TITLE
Fix boot.img creation failue due to size limit

### DIFF
--- a/groups/graphics/auto/AndroidBoard.mk
+++ b/groups/graphics/auto/AndroidBoard.mk
@@ -3,7 +3,13 @@
 I915_FW_PATH := vendor/linux/firmware/i915
 
 #list of i915/huc_xxx.bin i915/dmc_xxx.bin i915/guc_xxx.bin
-$(foreach t, $(patsubst $(I915_FW_PATH)/%,%,$(wildcard $(I915_FW_PATH)/*)) ,$(eval I915_FW += i915/$(t)) $(eval $(LOCAL_KERNEL) : $(PRODUCT_OUT)/vendor/firmware/i915/$(t)))
+$(foreach t, $(patsubst $(I915_FW_PATH)/%,%,$(wildcard $(I915_FW_PATH)/kbl*)) ,$(eval I915_FW += i915/$(t)) $(eval $(LOCAL_KERNEL) : $(PRODUCT_OUT)/vendor/firmware/i915/$(t)))
+$(foreach t, $(patsubst $(I915_FW_PATH)/%,%,$(wildcard $(I915_FW_PATH)/bxt*)) ,$(eval I915_FW += i915/$(t)) $(eval $(LOCAL_KERNEL) : $(PRODUCT_OUT)/vendor/firmware/i915/$(t)))
+$(foreach t, $(patsubst $(I915_FW_PATH)/%,%,$(wildcard $(I915_FW_PATH)/cml*)) ,$(eval I915_FW += i915/$(t)) $(eval $(LOCAL_KERNEL) : $(PRODUCT_OUT)/vendor/firmware/i915/$(t)))
+$(foreach t, $(patsubst $(I915_FW_PATH)/%,%,$(wildcard $(I915_FW_PATH)/ehl*)) ,$(eval I915_FW += i915/$(t)) $(eval $(LOCAL_KERNEL) : $(PRODUCT_OUT)/vendor/firmware/i915/$(t)))
+$(foreach t, $(patsubst $(I915_FW_PATH)/%,%,$(wildcard $(I915_FW_PATH)/tgl*)) ,$(eval I915_FW += i915/$(t)) $(eval $(LOCAL_KERNEL) : $(PRODUCT_OUT)/vendor/firmware/i915/$(t)))
+$(foreach t, $(patsubst $(I915_FW_PATH)/%,%,$(wildcard $(I915_FW_PATH)/adl*)) ,$(eval I915_FW += i915/$(t)) $(eval $(LOCAL_KERNEL) : $(PRODUCT_OUT)/vendor/firmware/i915/$(t)))
+$(foreach t, $(patsubst $(I915_FW_PATH)/%,%,$(wildcard $(I915_FW_PATH)/dg2*)) ,$(eval I915_FW += i915/$(t)) $(eval $(LOCAL_KERNEL) : $(PRODUCT_OUT)/vendor/firmware/i915/$(t)))
 
 _EXTRA_FW_ += $(I915_FW)
 


### PR DESCRIPTION
Creation of boot.img fails due to size exceeding maximum size limit of 40MB.

When all guc and huc files are included, boot.img size is exceeding the max size of 40MB.

Copy GuC and HuC files of supported platforms to avoid boot image size exceeding set maximum size limit.

Change-Id: Ice350188cb7acad12f1c0edcf05e59c3c53c6db6
Tracked-On: OAM-104210
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Sundar Gnanasekaran <sundar.gnanasekaran@intel.com>