### PR TITLE
Enable persist.sys.fuse.bpf.enable property

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -31,6 +31,7 @@ PRODUCT_PACKAGES +=  \
 PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce
 PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.useautofastjni=true
 PRODUCT_PRODUCT_PROPERTIES += persist.adb.tcp.port=5555
+PRODUCT_PRODUCT_PROPERTIES += persist.sys.fuse.bpf.enable=true
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.crypto.volume.metadata.method=dm-default-key \


### PR DESCRIPTION
This property is needed for Android 13.

Tracked-On: OAM-104316
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>