### PR TITLE
Add libmd back to pass CTS test

### DIFF
--- a/groups/public-libraries/true/public.libraries.txt
+++ b/groups/public-libraries/true/public.libraries.txt
@@ -1,3 +1,2 @@
 # Specify additional native libraries
 # So that Apps can use Intel proprietary libraries
-libmd.so


### PR DESCRIPTION
Fix CTS CtsUsesNativeLibraryTest sub cases by adding libmd back.

Tracked-On: OAM-104325
Signed-off-by: lyintel <yang.a.lu@intel.com>