### PR TITLE
Remove libmd.so from additional native libraries

### DIFF
--- a/groups/public-libraries/true/public.libraries.txt
+++ b/groups/public-libraries/true/public.libraries.txt
@@ -1,3 +1,2 @@
 # Specify additional native libraries
 # So that Apps can use Intel proprietary libraries
-libmd.so


### PR DESCRIPTION
Remove libmd.so from additional native libraries for CTS tests as libmd is disabled.

Tracked-On: OAM-104325
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>