### PR TITLE
Migrate Bluetooth Audio HAL to AIDL

### DIFF
--- a/groups/bluetooth/btusb/product.mk
+++ b/groups/bluetooth/btusb/product.mk
@@ -8,7 +8,7 @@ PRODUCT_PROPERTY_OVERRIDES += bluetooth.rfkill=1
 PRODUCT_PACKAGES += \
     android.hardware.bluetooth@1.0-service.vbt \
     libbt-vendor \
-    android.hardware.bluetooth.audio@2.1-impl \
+    android.hardware.bluetooth.audio-impl \
 
 {{#ivi}}
 PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/bluetooth/overlay-car

--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -112,12 +112,11 @@
            <instance>default</instance>
        </interface>
    </hal>
-    <hal format="hidl">
+    <hal format="aidl" optional="true">
         <name>android.hardware.bluetooth.audio</name>
-        <transport>hwbinder</transport>
-        <version>2.1</version>
+        <version>2</version>
         <interface>
-            <name>IBluetoothAudioProvidersFactory</name>
+            <name>IBluetoothAudioProviderFactory</name>
             <instance>default</instance>
         </interface>
     </hal>


### PR DESCRIPTION
From Android T onwards, its mandatory to use
AIDL for Bluetooth Audio HAL. So migrating it
from HIDL to AIDL.

Verified the music streaming and logcat logs
for AIDL.

Tracked-On: OAM-104808
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>