### PR TITLE
disable intel_lmce which not supported by virtual machines

### DIFF
--- a/groups/kernel/BoardConfig.mk
+++ b/groups/kernel/BoardConfig.mk
@@ -62,11 +62,10 @@ BOARD_KERNEL_CMDLINE += \
       snd-intel-dspcfg.dsp_driver=1
 endif
 
-ifeq ($(BASE_LTS2020_YOCTO_KERNEL), true)
 BOARD_KERNEL_CMDLINE += \
       clearcpuid=517 \
-      mce=no_lmce
-endif
+      mce=no_lmce \
+      mce=ignore_ce
 
 BOARD_SEPOLICY_M4DEFS += module_kernel=true
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/kernel


### PR DESCRIPTION
unsupported lmce/mce causing crash-dump during virtual machine boot as well reboot and shutdown scenarios. since lmce is not exposed to guest-os. hence disabled using kernel command line option.

Updated kernel command line to disable local machine check exception
and WAITPKG feature to address civ boot issue. applicable to all.	

crashdump:
=========
[    0.205755] ------------[ cut here ]------------
[    0.206454] WARNING: CPU: 0 PID: 0 at arch/x86/kernel/cpu/mce/intel.c:124 intel_init_lmce+0xe9/0xf0
[    0.207454] Modules linked in:
[    0.208454] CPU: 0 PID: 0 Comm: swapper/0 Tainted: G     U            5.15.74-ga0db5462ba8a-dirty #1
[    0.209454] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 0.0.0 02/06/2015
[    0.210454] RIP: 0010:intel_init_lmce+0xe9/0xf0
[    0.211057] Code: 48 c1 eb 20 b9 d0 04 00 00 89 da 0f 30 83 3d 45 5f 5b 03 00 7e 0f bf d0 04 00 00 48 89 c6 31 d2 b
[    0.211454] RSP: 0000:ffffffff8c403dd0 EFLAGS: 00010246
[    0.212454] RAX: 0000000000000000 RBX: 0000000000000000 RCX: 000000000000003a
[    0.213454] RDX: 0000000000000000 RSI: ffffffff89122d28 RDI: 0000000000000030
[    0.214454] RBP: ffffffff8c403de0 R08: ffffffff8c4149a8 R09: ffff9a738044cfff
[    0.215416] R10: ffff8bcf401c4018 R11: ffffffff8a35b480 R12: 000000000000000a
[    0.215454] R13: ffffffff8c6e5210 R14: ffffffff8c6e5198 R15: ffffffff8c6e5198
[    0.216454] FS:  0000000000000000(0000) GS:ffff8bcfbbc00000(0000) knlGS:0000000000000000
[    0.217454] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[    0.218454] CR2: ffff8bcfa9001000 CR3: 0000000168414001 CR4: 0000000000770ef0
[    0.219455] PKRU: 55555554
[    0.220454] Call Trace:
[    0.220787]  <TASK>
[    0.221073]  mce_intel_feature_init+0x1d/0x190
[    0.221454]  __mcheck_cpu_init_vendor+0x24/0xb0
[    0.222061]  mcheck_cpu_init+0x380/0x4d0
[    0.222454]  ? bsp_init_amd.a37caec6941172bae46ab451b1d4de9c.cfi_jt+0x8/0x8
[    0.223454]  identify_cpu+0x67f/0x740
[    0.223948]  identify_boot_cpu+0x11/0xbc
[    0.224454]  check_bugs+0x20/0xfe
[    0.224902]  start_kernel+0x454/0x4f9
[    0.225454]  x86_64_start_reservations+0x24/0x26
[    0.226454]  x86_64_start_kernel+0x58/0x5b
[    0.227007]  secondary_startup_64_no_verify+0xb1/0xbb
[    0.227454]  </TASK>
[    0.227752] ---[ end trace d412e29ab214f46e ]---

Tracked-On: OAM-104891
Signed-off-by: rajucm <raju.mallikarjun.chegraddi@intel.com>
Signed-off-by: rajucm <raju.mallikarjun.chegaraddi@intel.com>