### PR TITLE
Set hashbang to python3

### DIFF
--- a/mixin-update
+++ b/mixin-update
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 from six.moves import configparser


### PR DESCRIPTION
Python2 is already end-of-life and newer pystache versions also do not support Python2 anymore.
As other scripts also already rely on python3, it makes sense (in my opinion) to require python3 here.