### PR TITLE
Update hardware vulkan version

### DIFF
--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -112,7 +112,7 @@ PRODUCT_COPY_FILES += \
 
 {{#vulkan}}
 PRODUCT_COPY_FILES += \
-    frameworks/native/data/etc/android.hardware.vulkan.version-1_3.xml:vendor/etc/permissions/android.hardware.vulkan.version.xml
+    frameworks/native/data/etc/android.hardware.vulkan.version-1_1.xml:vendor/etc/permissions/android.hardware.vulkan.version.xml
 
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.vulkan.deqp.level-2022-03-01.xml:vendor/etc/permissions/android.software.vulkan.deqp.level.xml


### PR DESCRIPTION
Based on cts report, hardware vulkan version is forward to the required version. Change android.hardware.vulkan.version from 1.3 to 1.1

Tracked-On: OAM-104978
Signed-off-by: Chengrui Liu <chengrui.liu@intel.com>