### PR TITLE
Fix android not booting in sriov mode

### DIFF
--- a/groups/graphics/auto/BoardConfig.mk
+++ b/groups/graphics/auto/BoardConfig.mk
@@ -5,7 +5,7 @@ LIBDRM_VER ?= intel
 BOARD_KERNEL_CMDLINE += vga=current i915.modeset=1 drm.atomic=1 i915.nuclear_pageflip=1 drm.vblankoffdelay=1 i915.fastboot=1
 {{^acrn-guest}}
 {{#enable_guc}}
-BOARD_KERNEL_CMDLINE += i915.enable_guc=2
+BOARD_KERNEL_CMDLINE += i915.enable_guc=1
 {{/enable_guc}}
 {{/acrn-guest}}
 


### PR DESCRIPTION
For Guc Submission only, enable_guc is not set resulting in Android boot failure in sriov mode.

Fix the issue by setting the enable_guc to 1.

Tracked-On: OAM-105036
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>