### PR TITLE
Refine the fastboot format command for installer

### DIFF
--- a/groups/flashfiles/ini/flashfiles.ini
+++ b/groups/flashfiles/ini/flashfiles.ini
@@ -327,7 +327,7 @@ description = Set OEM variables
 
 [command.format.data]
 tool = fastboot
-args = format{{#data_use_f2fs}}:f2fs{{/data_use_f2fs}} {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}}
+args = format {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}}
 description = Format {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}} partition
 {{/mfgos}}
 


### PR DESCRIPTION
Currently Celadon installer doesn't support such format command form:
	format:f2fs userdata
It only supports this command form:
	format userdata

Remove f2fs option from format command, since Installer doesn't need to create a filesystem in the relevant partition. Android fs_mgr will do this by the relevant fstab options during the first boot.

Tracked-On: OAM-104811
Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>