### PR TITLE
Change judgment condition for SRIOV codec type

### DIFF
--- a/groups/media/auto/auto_hal.in
+++ b/groups/media/auto/auto_hal.in
@@ -13,7 +13,7 @@ case "$(cat /proc/fb)" in
                 setprop vendor.intel.video.codec hardware
                 ;;
         *)
-                if [ "$(cat /sys/kernel/debug/dri/0/i915_sriov_info |grep virtualization |awk '{print $2}')" = "enabled" ];then
+                if [ -d "/sys/class/drm/card0/engine" ];then
                        echo "Intel SRIOV"
                        setprop vendor.intel.video.codec hardware
                 else


### PR DESCRIPTION
There's no i915_sriov_info file under debugfs. Try to not depend on debugfs.

Signed-off-by: chenyanxzhu <chenyanx.zhu@intel.com>