### PR TITLE
HIDL to AIDL support for USB

### DIFF
--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -165,10 +165,9 @@
         <fqname>@1.4::ICryptoFactory/clearkey</fqname>
         <fqname>@1.4::IDrmFactory/clearkey</fqname>
     </hal>
-    <hal format="hidl">
+    <hal format="aidl">
         <name>android.hardware.usb</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
+        <version>1</version>
         <interface>
             <name>IUsb</name>
             <instance>default</instance>

--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -20,8 +20,7 @@ PRODUCT_PACKAGES += vndservicemanager
 PRODUCT_PACKAGES += ClipboardAgent
 
 PRODUCT_PACKAGES +=  \
-                    android.hardware.usb@1.0-impl \
-                    android.hardware.usb@1.0-service \
+                    android.hardware.usb-service.example \
                     camera.device@1.0-impl \
                     android.hardware.camera.provider@2.4-impl \
                     android.hardware.graphics.mapper@4.0-impl.minigbm \


### PR DESCRIPTION
Migrate IUsb to AIDL.This change migrates
android.hardware.usb.IUsb to AIDL and adds
the default implementation.

Compared to the HIDL interface, AIDL based
interface adds transactionId argument to
each of the interface method which is used
while invoking the corresponding callback.

Tracked-On: OAM-105292
Signed-off-by: RajaniRanjan <rajani.ranjan@intel.com>