### PR TITLE
[ADL]Fix for GTS checkVulkanDeqpLevelIsHighEnough

### DIFF
--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -93,6 +93,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.opengles.aep.xml:vendor/etc/permissions/android.hardware.opengles.aep.xml
 
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.opengles.deqp.level-2021-03-01.xml:vendor/etc/permissions/android.software.opengles.deqp.level.xml
+
 # GLES version
 PRODUCT_PROPERTY_OVERRIDES += \
    ro.opengles.version=196610
@@ -112,7 +115,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.vulkan.version-1_1.xml:vendor/etc/permissions/android.hardware.vulkan.version.xml
 
 PRODUCT_COPY_FILES += \
-    frameworks/native/data/etc/android.software.vulkan.deqp.level-2020-03-01.xml:vendor/etc/permissions/android.software.vulkan.deqp.level.xml
+    frameworks/native/data/etc/android.software.vulkan.deqp.level-2021-03-01.xml:vendor/etc/permissions/android.software.vulkan.deqp.level.xml
 
 PRODUCT_PACKAGES += \
     vulkan.$(TARGET_BOARD_PLATFORM) \


### PR DESCRIPTION
 Fix for below 2TC
    VulkanTest#checkVulkanDeqpLevelIsHighEnough
    OpenGlEsTest#checkOpenGlEsDeqpLevelIsHighEnough

 TC Expected:
    feature:android.software.opengles.deqp.level>=132449025
    feature:android.software.vulkan.deqp.level>=132449025

Tracked-On: OAM-104806
Signed-off-by: vdanix <vishwanathx.dani@intel.com>