### PR TITLE
[ADL] fix GTS checkGpuProfilingRequirements

### DIFF
--- a/groups/device-specific/caas/caas.mk
+++ b/groups/device-specific/caas/caas.mk
@@ -64,6 +64,9 @@ PRODUCT_AAPT_PREF_CONFIG := mdpi
 PRODUCT_VENDOR_PROPERTIES += \
     ro.soc.manufacturer=$(PRODUCT_MANUFACTURER)
 
+PRODUCT_VENDOR_PROPERTIES += \
+    graphics.gpu.profiler.support=true
+
 PRODUCT_RESTRICT_VENDOR_FILES := false
 PRODUCT_SET_DEBUGFS_RESTRICTIONS := false
 {{^ota-update}}


### PR DESCRIPTION
TC failing Error: API level S must support GPU profiling Test checking graphics.gpu.profiler.support=true

Tracked-On: OAM-104969
Signed-off-by: vdanix <vishwanathx.dani@intel.com>