### PR TITLE
Set Verity_update_state in boot flow.

### DIFF
--- a/groups/device-specific/caas/init.rc
+++ b/groups/device-specific/caas/init.rc
@@ -8,6 +8,9 @@ on boot
     write /sys/devices/platform/INT33BB:00/power/control on
     write /sys/devices/pci0000\:00/0000\:00\:15.0/power/control auto
 
+# Update dm-verity state and set partition.*.verified properties.
+    verity_update_state
+
 on post-fs
     #Accelerometer: X & Z inverted
     setprop ro.vendor.iio.accel.x.opt_scale    -1


### PR DESCRIPTION
This is required because CtsNativeVerifiedBootTestCaese will read property "partition.${partition}.verified.hash_alg" to check that sha1 is not used.

Tracked-On: OAM-104656
Signed-off-by: sushre2x <sushreex.panda@intel.com>
Signed-off-by: vdanix <vishwanathx.dani@intel.com>