### PR TITLE
Fix android not booting in sriov mode due to GuC and HuC both enabled

### DIFF
--- a/groups/graphics/auto/BoardConfig.mk
+++ b/groups/graphics/auto/BoardConfig.mk
@@ -9,6 +9,10 @@ BOARD_KERNEL_CMDLINE += i915.enable_guc=1
 {{/enable_guc}}
 {{/acrn-guest}}
 
+ifeq ($(BASE_LINUX_INTEL_LTS2021_KERNEL),true)
+BOARD_KERNEL_CMDLINE += i915.enable_guc=1
+endif
+
 USE_OPENGL_RENDERER := true
 USE_INTEL_UFO_DRIVER := false
 BOARD_GPU_DRIVERS := i965 swrast virgl iris


### PR DESCRIPTION
when enable_guc is not overrided, GuC submission and HuC authentication is enabled which is causing Android Guest boot failure in VF mode.

Fix the issue by overriding the enable_guc to 1 only for SRIOV support enabled kernel.

Tracked-On: OAM-105298
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>