### PR TITLE
Kernel Rebase: Update x86_64_defconfig file

### DIFF
--- a/groups/kernel/gmin64/config-lts/lts2021-chromium/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/lts2021-chromium/x86_64_defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.15.74 Kernel Configuration
+# Linux/x86_64 5.15.78 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="Android (8490178, based on r450784d) clang version 14.0.6 (https://android.googlesource.com/toolchain/llvm-project 4c603efb0cca074e9238af8b4106c30add4418f6)"
 CONFIG_GCC_VERSION=0
@@ -2808,7 +2808,6 @@ CONFIG_TCG_TIS_I2C_INFINEON=m
 CONFIG_TCG_TIS_I2C_NUVOTON=m
 CONFIG_TCG_NSC=m
 CONFIG_TCG_ATMEL=m
-# CONFIG_TCG_CR50_I2C is not set
 CONFIG_TCG_INFINEON=m
 CONFIG_TCG_CRB=m
 # CONFIG_TCG_VTPM_PROXY is not set
@@ -3987,6 +3986,7 @@ CONFIG_MEDIA_TUNER_QM1D1B0004=m
 #
 # Graphics support
 #
+CONFIG_APERTURE_HELPERS=y
 CONFIG_AGP=y
 # CONFIG_AGP_AMD64 is not set
 CONFIG_AGP_INTEL=y
@@ -6683,6 +6683,7 @@ CONFIG_LSM="selinux"
 # Memory initialization
 #
 CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN=y
+CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_ENABLER=y
 CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO=y
 # CONFIG_INIT_STACK_NONE is not set
 # CONFIG_INIT_STACK_ALL_PATTERN is not set
@@ -7056,6 +7057,8 @@ CONFIG_MESSAGE_LOGLEVEL_DEFAULT=4
 CONFIG_SYMBOLIC_ERRNAME=y
 CONFIG_DEBUG_BUGVERBOSE=y
 # end of printk and dmesg options
+
+CONFIG_AS_HAS_NON_CONST_LEB128=y
 
 #
 # Compile-time checks and compiler options


### PR DESCRIPTION
Update x86_64_defconfig file as part of 5.15 kernel rebase to 5.15.78

Tracked-On: OAM-105586
Signed-off-by: tboppana <tej.kiran.boppana@intel.com>