### PR TITLE
Remove use OMX property

### DIFF
--- a/groups/device-specific/cic-cloud/system.prop
+++ b/groups/device-specific/cic-cloud/system.prop
@@ -13,7 +13,6 @@ qemu.hw.mainkeys=0
 enable.accessiblity=true
 
 debug.stagefright.c2-poolmask=0x80000
-debug.codec.use.omx=true
 
 persist.sys.disable_rescue=true
 ro.product.first_api_level=30


### PR DESCRIPTION
As Codec2 works without ION device, remove the property introduced to enable/disable OMX usage instead of Codec2.

Tracked-On: OAM-105758
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>