### PR TITLE
Fix device not booting due to multiple modules for neuralnetworks

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -167,15 +167,6 @@
             <instance>default</instance>
         </interface>
     </hal>
-    <hal format="hidl">
-        <name>android.hardware.neuralnetworks</name>
-        <transport>hwbinder</transport>
-        <version>1.3</version>
-        <interface>
-            <name>IDevice</name>
-            <instance>CPU</instance>
-        </interface>
-    </hal>
     <!--<kernel target-level="5"/>-->
     <sepolicy>
         <version>33.0</version>


### PR DESCRIPTION
Device boot fails due to multiple neuralnetworks modules providing same HAL is installed.

As the vintf fragment is already included as part of android.hardware.neuralnetworks Android.bp file remove it from manifest.xml file.

Tracked-On: OAM-105824