### PR TITLE
Enable sw rendering.

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -17,8 +17,8 @@ case "$(cat /proc/fb)" in
                         setprop vendor.vulkan.set intel
                 else
                         if [ "$(cat /sys/kernel/debug/dri/0/virtio-gpu-features |grep virgl |awk '{print $3}')" = "no" ];then
-                                echo "swiftshader rendering"
-                                setprop vendor.egl.set swiftshader
+                                echo "angle rendering"
+                                setprop vendor.egl.set angle
                                 setprop vendor.vulkan.set pastel
                         else
                                 echo "virtio rendering"
@@ -29,7 +29,7 @@ case "$(cat /proc/fb)" in
                 ;;
         *)
                 echo "sw rendering"
-                setprop vendor.egl.set swiftshader
+                setprop vendor.egl.set angle
                 setprop vendor.vulkan.set pastel
                 ;;
 esac

--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -1,7 +1,4 @@
 PRODUCT_PACKAGES += \
-    libEGL_swiftshader \
-    libGLESv1_CM_swiftshader \
-    libGLESv2_swiftshader \
     libGLES_android \
     libigdrcl \
     libOpenCL \
@@ -121,3 +118,9 @@ PRODUCT_PACKAGES += \
     vulkan.$(TARGET_BOARD_PLATFORM) \
     vulkan.pastel
 {{/vulkan}}
+
+PRODUCT_PACKAGES += \
+    libEGL_angle \
+    libGLESv1_CM_angle \
+    libGLESv2_angle
+


### PR DESCRIPTION
SwiftShader's GL libraries are getting deprecated in andriod T, and to be replaced with ANGLE on top of SwiftShader's Vulkan library.

Setprop vendor.egl.set angle in auto_hal.in

Add angle`s libs to product.mk

Tracked-On: OAM-104193