### PR TITLE
Fix for build failing with KernelCompatibility check enabled flag

### DIFF
--- a/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
@@ -7300,7 +7300,7 @@ CONFIG_STACKTRACE=y
 #
 # Debug kernel data structures
 #
-# CONFIG_DEBUG_LIST is not set
+CONFIG_DEBUG_LIST=y
 # CONFIG_DEBUG_PLIST is not set
 # CONFIG_DEBUG_SG is not set
 # CONFIG_DEBUG_NOTIFIERS is not set


### PR DESCRIPTION
Build with kernel compatibility check is failing due to missing config CONFIG_DEBUG_LIST.

Enable CONFIG_DEBUG_LIST to fix the build issue.

Tracked-On: OAM-108756