### PR TITLE
Switch allocator & mapper from 2.0 to 4.0

### DIFF
--- a/groups/device-specific/cic-cloud/manifest.xml
+++ b/groups/device-specific/cic-cloud/manifest.xml
@@ -72,7 +72,7 @@
     <hal format="hidl">
         <name>android.hardware.graphics.allocator</name>
         <transport>hwbinder</transport>
-        <version>2.0</version>
+        <version>4.0</version>
         <interface>
             <name>IAllocator</name>
             <instance>default</instance>
@@ -81,7 +81,7 @@
     <hal format="hidl">
         <name>android.hardware.graphics.mapper</name>
         <transport arch="32+64">passthrough</transport>
-        <version>2.0</version>
+        <version>4.0</version>
         <interface>
             <name>IMapper</name>
             <instance>default</instance>

--- a/groups/graphics/true/product.mk
+++ b/groups/graphics/true/product.mk
@@ -12,9 +12,8 @@ PRODUCT_PACKAGES += \
     android.hardware.drm@1.0-impl \
     android.hardware.drm@1.3-service.clearkey \
     android.hardware.graphics.composer@2.3-service \
-    android.hardware.graphics.allocator@2.0-service \
-    android.hardware.graphics.allocator@2.0-impl \
-    android.hardware.graphics.mapper@2.0-impl
+    android.hardware.graphics.mapper@4.0-impl.minigbm \
+    android.hardware.graphics.allocator@4.0-service.minigbm
 
 PRODUCT_PACKAGES += \
     vulkan.intel \


### PR DESCRIPTION
This to help enable allocator & mapper to 4.0, which is required to support API 30.

Tracked-On: OAM-105783