### PR TITLE
[iwlwifi] Add separate flag to load iwl7000 driver

### DIFF
--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -8,7 +8,12 @@ on early-boot
     insmod /vendor/lib/modules/compat.ko
 {{/iwl_upstream_drv}} 
     insmod /vendor/lib/modules/cfg80211.ko
+{{^iwl_7000_drv}}
+    insmod /vendor/lib/modules/mac80211.ko
+{{/iwl_7000_drv}}
+{{#iwl_7000_drv}}
     insmod /vendor/lib/modules/iwl7000_mac80211.ko
+{{/iwl_7000_drv}}
     insmod /vendor/lib/modules/iwlwifi.ko
     insmod /vendor/lib/modules/iwlmvm.ko power_scheme=1
 

--- a/groups/wlan/iwlwifi/option.spec
+++ b/groups/wlan/iwlwifi/option.spec
@@ -10,3 +10,4 @@ libwifi-hal = false
 firmware =
 nvm = true
 iwl_upstream_drv = true
+iwl_7000_drv = true


### PR DESCRIPTION
celadon_ivi has yocto kernel which uses open source iwilwifi driver whereas caas has chrome kernel using chrome based iwl7000 driver for wifi. For One Android code base we need to make the driver loading decissive for separate targets.

Added iwl_7000_drv flag and set it to true to distinguish celadon_ivi target, and load specific driver.

Tracked-On: OAM-108959