### PR TITLE
Load audio modules

### DIFF
--- a/groups/audio/project-celadon/init.rc
+++ b/groups/audio/project-celadon/init.rc
@@ -1,4 +1,6 @@
+{{^ivi}}
 on post-fs && property:vendor.intel.enable.audio=legacy-hda
+    insmod /vendor/lib/modules/snd-dummy.ko
     insmod /vendor/lib/modules/snd-compress.ko
     insmod /vendor/lib/modules/snd-hrtimer.ko
     insmod /vendor/lib/modules/snd-ctl-led.ko
@@ -16,6 +18,7 @@ on post-fs && property:vendor.intel.enable.audio=legacy-hda
     insmod /vendor/lib/modules/usblp.ko
 
 on post-fs && property:vendor.intel.enable.audio=sof-hda
+    insmod /vendor/lib/modules/snd-dummy.ko
     insmod /vendor/lib/modules/snd-compress.ko
     insmod /vendor/lib/modules/snd-hrtimer.ko
     insmod /vendor/lib/modules/snd-ctl-led.ko
@@ -56,9 +59,51 @@ on post-fs && property:vendor.intel.enable.audio=sof-hda
     insmod /vendor/lib/modules/snd-usb-hiface.ko
     insmod /vendor/lib/modules/snd-seq-midi-event.ko
     insmod /vendor/lib/modules/snd-seq-midi.ko
+{{/ivi}}
 
-on boot
+{{#ivi}}
+on early-boot
     insmod /vendor/lib/modules/snd-dummy.ko
+    insmod /vendor/lib/modules/snd-soc-da7219.ko
+    insmod /vendor/lib/modules/snd-soc-ssm4567.ko
+    insmod /vendor/lib/modules/snd-soc-rl6231.ko
+    insmod /vendor/lib/modules/snd-soc-rl6347a.ko
+    insmod /vendor/lib/modules/snd-soc-rt5640.ko
+    insmod /vendor/lib/modules/snd-soc-rt5663.ko
+    insmod /vendor/lib/modules/snd-soc-rt5682.ko
+    insmod /vendor/lib/modules/snd-soc-rt5682-i2c.ko
+    insmod /vendor/lib/modules/snd-soc-tdf8532.ko
+    insmod /vendor/lib/modules/snd-soc-rt298.ko
+    insmod /vendor/lib/modules/snd-soc-rt274.ko
+    insmod /vendor/lib/modules/snd-soc-rt286.ko
+    insmod /vendor/lib/modules/snd-soc-rt1308.ko
+    insmod /vendor/lib/modules/snd-soc-max98357a.ko
+    insmod /vendor/lib/modules/snd-soc-max98373.ko
+    insmod /vendor/lib/modules/snd-soc-max98927.ko
+    insmod /vendor/lib/modules/snd-soc-avs-tdf8532.ko
+    insmod /vendor/lib/modules/snd-soc-avs-ssm4567.ko
+    insmod /vendor/lib/modules/snd-soc-avs-rt5682.ko
+    insmod /vendor/lib/modules/snd-soc-avs-rt5663.ko
+    insmod /vendor/lib/modules/snd-soc-avs-rt5640.ko
+    insmod /vendor/lib/modules/snd-soc-avs-rt1308.ko
+    insmod /vendor/lib/modules/snd-soc-avs-rt298.ko
+    insmod /vendor/lib/modules/snd-soc-avs-rt286.ko
+    insmod /vendor/lib/modules/snd-soc-avs-rt274.ko
+    insmod /vendor/lib/modules/snd-soc-avs-nau8825.ko
+    insmod /vendor/lib/modules/snd-soc-avs-max98373.ko
+    insmod /vendor/lib/modules/snd-soc-avs-max98357a.ko
+    insmod /vendor/lib/modules/snd-soc-avs-max98927.ko
+    insmod /vendor/lib/modules/snd-soc-avs-i2s-test.ko
+    insmod /vendor/lib/modules/snd-soc-avs-dmic.ko
+    insmod /vendor/lib/modules/snd-soc-avs-da7219.ko
+    insmod /vendor/lib/modules/snd-hda-ext-core.ko
+    insmod /vendor/lib/modules/snd-soc-hda-codec.ko
+    insmod /vendor/lib/modules/snd-soc-avs-hdaudio.ko
+    insmod /vendor/lib/modules/snd-soc-avs.ko ignore_fw_version=1
+    insmod /vendor/lib/modules/snd-soc-avs-probe.ko
+    insmod /vendor/lib/modules/snd-soc-hdac-hda.ko
+    insmod /vendor/lib/modules/snd-soc-hdac-hdmi.ko
+{{/ivi}}
 
 on property:sys.boot_completed=1 && property:ro.vendor.hdmi.audio=tgl
     stop audioserver

--- a/groups/audio/project-celadon/option.spec
+++ b/groups/audio/project-celadon/option.spec
@@ -1,0 +1,2 @@
+[defaults]
+ivi = false


### PR DESCRIPTION
This patch adds changes to load cAVS audio
modules on ivi flag set(in case of ivi) and
in other case it loads snd/sof modules.

