### PR TITLE
Add Evs pipeline services

### DIFF
--- a/groups/device-type/car/product.mk
+++ b/groups/device-type/car/product.mk
@@ -20,6 +20,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += android.hardware.automotive.vehicle.intel@2.0-service
 {{/aosp_hal}}
 
+PRODUCT_PACKAGES += android.hardware.automotive.evs@1.1-sample
+PRODUCT_PACKAGES += android.frameworks.automotive.display@1.0-service
+PRODUCT_PACKAGES += evs_app
+
 PRODUCT_PACKAGES += android.hardware.automotive.audiocontrol@1.0-service.intel
 
 {{#aosp_hal}}


### PR DESCRIPTION
On reverse gear from vehicle HAL EVS Application failed to start EVS application.

Evs sample driver, display service and EVS application added so that during bootup those services will start and respond for reverse gear signal.

Tracked-On: OAM-109740
Change-Id: I3cb81ad56e08bde353785fe93b95073747b2e201