### PR TITLE
Enable audio modules load

### DIFF
--- a/groups/audio/project-celadon/default/mixer_paths_0.xml
+++ b/groups/audio/project-celadon/default/mixer_paths_0.xml
@@ -1,8 +1,8 @@
 <mixer>
   <!-- These are the initial mixer settings -->
-  <ctl name="Master Playback Volume" value="87 87" />
+  <ctl name="Front Playback Volume" value="127 127" />
   <ctl name="Master Playback Switch" value="1 1" />
-  <ctl name="Headphone Playback Switch" value="0 0" />
+  <ctl name="Master Playback Volume" value="127" />
   <ctl name="Speaker Playback Switch" value="0 0" />
   <ctl name="Capture Switch" value="0 0" />
 
@@ -14,6 +14,7 @@
   <path name="headphone">
     <ctl name="Master Playback Switch" value="1 1" />
     <ctl name="Headphone Playback Switch" value="1 1" />
+    <ctl name="Headphone Playback Volume" value="127 127" />
   </path>
 
   <path name="main-mic">

--- a/groups/audio/project-celadon/init.rc
+++ b/groups/audio/project-celadon/init.rc
@@ -1,4 +1,5 @@
-on post-fs && property:vendor.intel.enable.audio=legacy-hda
+on boot
+    insmod /vendor/lib/modules/snd-dummy.ko
     insmod /vendor/lib/modules/snd-compress.ko
     insmod /vendor/lib/modules/snd-hrtimer.ko
     insmod /vendor/lib/modules/snd-ctl-led.ko
@@ -14,51 +15,6 @@ on post-fs && property:vendor.intel.enable.audio=legacy-hda
     insmod /vendor/lib/modules/snd-soc-acpi.ko
     insmod /vendor/lib/modules/snd-soc-acpi-intel-match.ko
     insmod /vendor/lib/modules/usblp.ko
-
-on post-fs && property:vendor.intel.enable.audio=sof-hda
-    insmod /vendor/lib/modules/snd-compress.ko
-    insmod /vendor/lib/modules/snd-hrtimer.ko
-    insmod /vendor/lib/modules/snd-ctl-led.ko
-    insmod /vendor/lib/modules/snd-hda-core.ko
-    insmod /vendor/lib/modules/snd-hda-codec.ko
-    insmod /vendor/lib/modules/snd-hda-codec-generic.ko
-    insmod /vendor/lib/modules/snd-intel-dspcfg.ko dsp_driver=3
-    insmod /vendor/lib/modules/snd-hda-intel.ko
-    insmod /vendor/lib/modules/snd-hda-codec-realtek.ko
-    insmod /vendor/lib/modules/snd-hda-codec-hdmi.ko
-    insmod /vendor/lib/modules/snd-intel-sdw-acpi.ko
-    insmod /vendor/lib/modules/snd-soc-core.ko
-    insmod /vendor/lib/modules/snd-soc-acpi.ko
-    insmod /vendor/lib/modules/snd-soc-acpi-intel-match.ko
-    insmod /vendor/lib/modules/usblp.ko
-    insmod /vendor/lib/modules/snd-sof.ko
-    insmod /vendor/lib/modules/snd-sof-xtensa-dsp.ko
-    insmod /vendor/lib/modules/snd-sof-pci.ko
-    insmod /vendor/lib/modules/snd-sof-intel-ipc.ko
-    insmod /vendor/lib/modules/snd-sof-acpi.ko
-    insmod /vendor/lib/modules/snd-hda-ext-core.ko
-    insmod /vendor/lib/modules/snd-sof-intel-hda.ko
-    insmod /vendor/lib/modules/snd-soc-hdac-hda.ko
-    insmod /vendor/lib/modules/snd-sof-intel-hda-common.ko
-    insmod /vendor/lib/modules/snd-sof-pci-intel-tgl.ko
-    insmod /vendor/lib/modules/snd-mixer-oss.ko
-    insmod /vendor/lib/modules/snd-seq.ko
-    insmod /vendor/lib/modules/snd-soc-dmic.ko
-    insmod /vendor/lib/modules/snd-soc-hdac-hdmi.ko
-    insmod /vendor/lib/modules/snd-soc-intel-hda-dsp-common.ko
-    insmod /vendor/lib/modules/snd-soc-skl_hda_dsp.ko
-    insmod /vendor/lib/modules/snd-soc-sst-dsp.ko
-    insmod /vendor/lib/modules/snd-soc-sst-ipc.ko
-    insmod /vendor/lib/modules/snd-sof-acpi-intel-bdw.ko
-    insmod /vendor/lib/modules/snd-sof-pci-intel-apl.ko
-    insmod /vendor/lib/modules/snd-sof-pci-intel-cnl.ko
-    insmod /vendor/lib/modules/snd-sof-pci-intel-icl.ko
-    insmod /vendor/lib/modules/snd-usb-hiface.ko
-    insmod /vendor/lib/modules/snd-seq-midi-event.ko
-    insmod /vendor/lib/modules/snd-seq-midi.ko
-
-on boot
-    insmod /vendor/lib/modules/snd-dummy.ko
 
 on property:sys.boot_completed=1 && property:ro.vendor.hdmi.audio=tgl
     stop audioserver


### PR DESCRIPTION
This patch includes changes for
1> loading of audio modules on Boot.
2> Set mixer volume for playback