### PR TITLE
Allow inclusion of super.img into out/dist based on build flag

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -1,6 +1,11 @@
 {{^use_cic}}
 BOARD_AVB_ENABLE := true
 
+# Don't include super.img to out/dist by default
+ifneq ($(GENERATE_SUPER_IMG), true)
+BOARD_SUPER_IMAGE_IN_UPDATE_PACKAGE := true
+endif
+
 #
 # -- OTA RELATED DEFINES --
 #


### PR DESCRIPTION
When 'make flashfiles dist publish RELEASE_BUILD=true' is used, super.img
is included into out/dist which adds 4G space. To save the storage space
super.img will only be included when make is done with GENERATE_SUPER_IMG
set to true.

Tracked-On: OAM-110014