### PR TITLE
Add kernel command line parameter to enable ramoops

### DIFF
--- a/groups/kernel/BoardConfig.mk
+++ b/groups/kernel/BoardConfig.mk
@@ -42,6 +42,20 @@ BOARD_KERNEL_CMDLINE += \
 BOARD_KERNEL_CMDLINE += \
         memmap=4M\$$0x5c400000
 {{/memory_hole}}
+
+ifneq ($(TARGET_BUILD_VARIANT),user)
+BOARD_KERNEL_CMDLINE += \
+        memmap=4M\$$0x100000000
+BOARD_KERNEL_CMDLINE += \
+        ramoops.mem_address=0x100000000
+BOARD_KERNEL_CMDLINE += \
+        ramoops.mem_size=0x400000
+BOARD_KERNEL_CMDLINE += \
+        ramoops.console_size=0x200000
+BOARD_KERNEL_CMDLINE += \
+        ramoops.dump_oops=1
+endif
+
 {{#interactive_governor}}
 BOARD_KERNEL_CMDLINE += \
 	intel_pstate=disable


### PR DESCRIPTION
Kernel panic logs are useful to figure out what happened when a kernel panic occurs.

With this change, ramoops writes its logs to the RAM before the system crashes.
With root access, these logs can be retrieved from /sys/fs/pstore/console-ramoops.

Tracked-On: OAM-108007
Signed-off-by: Guo, Jade <jade.guo@intel.com>