### PR TITLE
[celadon_ivi] Add kernel command line parameter to enable ramoops

### DIFF
--- a/groups/device-specific/celadon_ivi/BoardConfig.mk
+++ b/groups/device-specific/celadon_ivi/BoardConfig.mk
@@ -9,6 +9,20 @@ BOARD_KERNEL_CMDLINE += \
 	loop.max_part=7 \
 	idle=halt
 
+# for ramoops
+ifneq ($(TARGET_BUILD_VARIANT),user)
+BOARD_KERNEL_CMDLINE += \
+        memmap=4M\$$0x100000000
+BOARD_KERNEL_CMDLINE += \
+        ramoops.mem_address=0x100000000
+BOARD_KERNEL_CMDLINE += \
+        ramoops.mem_size=0x400000
+BOARD_KERNEL_CMDLINE += \
+        ramoops.console_size=0x200000
+BOARD_KERNEL_CMDLINE += \
+        ramoops.dump_oops=1
+endif
+
 BOARD_FLASHFILES += ${TARGET_DEVICE_DIR}/bldr_utils.img:bldr_utils.img
 BOARD_FLASHFILES += $(PRODUCT_OUT)/LICENSE
 BOARD_FLASHFILES += $(PRODUCT_OUT)/scripts/start_flash_usb.sh

--- a/groups/kernel/BoardConfig.mk
+++ b/groups/kernel/BoardConfig.mk
@@ -43,19 +43,6 @@ BOARD_KERNEL_CMDLINE += \
         memmap=4M\$$0x5c400000
 {{/memory_hole}}
 
-ifneq ($(TARGET_BUILD_VARIANT),user)
-BOARD_KERNEL_CMDLINE += \
-        memmap=4M\$$0x100000000
-BOARD_KERNEL_CMDLINE += \
-        ramoops.mem_address=0x100000000
-BOARD_KERNEL_CMDLINE += \
-        ramoops.mem_size=0x400000
-BOARD_KERNEL_CMDLINE += \
-        ramoops.console_size=0x200000
-BOARD_KERNEL_CMDLINE += \
-        ramoops.dump_oops=1
-endif
-
 {{#interactive_governor}}
 BOARD_KERNEL_CMDLINE += \
 	intel_pstate=disable


### PR DESCRIPTION
This patch move the change from a general boardconfig file to only celadon_ivi specific boardconfig file. Kernel panic logs are useful to figure out what happened when a kernel panic occurs.

With this change, ramoops writes its logs to the RAM before the system crashes. With root access, these logs can be retrieved from /sys/fs/pstore/console-ramoops.

Tracked-On: OAM-110074