### PR TITLE
Add a new fstab entry for udisk in recovery mode

### DIFF
--- a/groups/storage/sdcard-mmc0-v-usb-sd-r/fstab.recovery
+++ b/groups/storage/sdcard-mmc0-v-usb-sd-r/fstab.recovery
@@ -1,2 +1,3 @@
+/dev/block/sda1                         /udiska          vfat    defaults                                   voldmanaged=udiska:auto
 /dev/block/sdb1                         /udiskb          vfat    defaults                                   voldmanaged=udiskb:auto
 /dev/block/sda1                    /sdcard          vfat    defaults                                   voldmanaged=sdcard:auto


### PR DESCRIPTION
udisk sometimes appeared as /dev/sda1 in recovery mode.

Tracked-On: OAM-110620