### PR TITLE
Revert "linux-intel-lts2021: enable intel_idle"

### DIFF
--- a/groups/device-specific/celadon_ivi/BoardConfig.mk
+++ b/groups/device-specific/celadon_ivi/BoardConfig.mk
@@ -7,6 +7,7 @@ BOARD_KERNEL_CMDLINE += \
 	intel_iommu=off \
 	i915.enable_pvmmio=0 \
 	loop.max_part=7 \
+	idle=halt
 
 # for ramoops
 ifneq ($(TARGET_BUILD_VARIANT),user)

--- a/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
+++ b/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
@@ -589,7 +589,7 @@ CONFIG_CPU_IDLE_GOV_MENU=y
 # CONFIG_CPU_IDLE_GOV_TEO is not set
 # end of CPU Idle
 
-CONFIG_INTEL_IDLE=y
+# CONFIG_INTEL_IDLE is not set
 # end of Power management and ACPI options
 
 #


### PR DESCRIPTION
This reverts commit 4c872d2cecbd1ea6117f1be56b09d0139092a1b7.