### PR TITLE
Fix a fstab entry for udisk in recovery mode

### DIFF
--- a/groups/storage/sdcard-mmc0-v-usb-sd-r/fstab.recovery
+++ b/groups/storage/sdcard-mmc0-v-usb-sd-r/fstab.recovery
@@ -1,3 +1,3 @@
-/dev/block/sda1                         /udiska          vfat    defaults                                   voldmanaged=udiska:auto
-/dev/block/sdb1                         /udiskb          vfat    defaults                                   voldmanaged=udiskb:auto
+/dev/block/sda                         /udiska          vfat    defaults                                   voldmanaged=udiska:auto
+/dev/block/sda1                         /udiskb          vfat    defaults                                   voldmanaged=udiskb:auto
 /dev/block/sda1                    /sdcard          vfat    defaults                                   voldmanaged=sdcard:auto


### PR DESCRIPTION
In Android, some udisk devices appeared as /dev/block/sda, and the other ones appeared as /dev/block/sda1.
When do the OTA from udisk, only one USB disk device should be inserted, so won't consider the scenario of /dev/block/sdb*.

Tracked-On: OAM-110844