### PR TITLE
Fix property name mismatch in init scripts

### DIFF
--- a/groups/houdini/true/init.rc
+++ b/groups/houdini/true/init.rc
@@ -2,10 +2,10 @@
 on early-init
     mount binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc
 
-on property:ro.enable.native.bridge.exec=1
+on property:ro.vendor.enable.native.bridge.exec=1
     copy /system/vendor/etc/binfmt_misc/arm_exe /proc/sys/fs/binfmt_misc/register
     copy /system/vendor/etc/binfmt_misc/arm_dyn /proc/sys/fs/binfmt_misc/register
 
-on property:ro.enable.native.bridge.exec64=1
+on property:ro.vendor.enable.native.bridge.exec64=1
     copy /system/vendor/etc/binfmt_misc/arm64_exe /proc/sys/fs/binfmt_misc/register
     copy /system/vendor/etc/binfmt_misc/arm64_dyn /proc/sys/fs/binfmt_misc/register


### PR DESCRIPTION
We declared "ro.vendor.enable.native.bridge.exec64" but were using "ro.enable.native.bridge.exec64" in init scripts. Hence, some pre-requisites were not getting executed. To fix we need to update init scripts to match the declared property name.

Tracked-On: OAM-111001