### PR TITLE
Enable gnss service to mock gps.

### DIFF
--- a/groups/device-specific/celadon_ivi/product.mk
+++ b/groups/device-specific/celadon_ivi/product.mk
@@ -27,6 +27,7 @@ PRODUCT_PACKAGES +=  \
                     android.hardware.graphics.mapper@4.0-impl.minigbm \
                     android.hardware.graphics.allocator@4.0-service.minigbm \
                     android.hardware.renderscript@1.0-impl \
+		    android.hardware.gnss@2.1-service \
                     android.hardware.graphics.composer@2.4-service
 
 


### PR DESCRIPTION
The com.android.gms.persistent service is failing continuously and causing all the GMS apps to behave unusual. The root cause is that the gps service provider needed to mock the gnss service is not enabled.

Added gnss service to mock the location.

Tracked-On: OAM-111028