### PR TITLE
Fix for AV1 SW playback crash

### DIFF
--- a/groups/codec2/true/option.spec
+++ b/groups/codec2/true/option.spec
@@ -10,3 +10,4 @@ hw_ve_vp8 = false
 hw_ve_vp9 = false
 hw_ve_h265 = true
 hw_ve_h264 = true
+enable_hw=true

--- a/groups/codec2/true/product.mk
+++ b/groups/codec2/true/product.mk
@@ -3,9 +3,13 @@
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_performance_c2.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_performance.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/mfx_c2_store.conf:$(TARGET_COPY_OUT_VENDOR)/etc/mfx_c2_store.conf \
-    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_c2.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs.xml \
     $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_intel_c2_video.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_intel_c2_video.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_c2_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_c2_audio.xml
+
+{{#enable_hw}}
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/{{_extra_dir}}/media_codecs_c2.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs.xml \
+{{/enable_hw}}
 
 PRODUCT_PACKAGES += \
     libmfx_c2_components_hw \

--- a/groups/device-specific/cic-cloud/system.prop
+++ b/groups/device-specific/cic-cloud/system.prop
@@ -16,3 +16,4 @@ persist.sys.disable_rescue=true
 ro.product.first_api_level=30
 
 ro.logd.kernel=false
+debug.stagefright.c2-poolmask=0x80000


### PR DESCRIPTION
AV1 SW playback crash due to ion backend missing. In order for AV1 SW video playback to work, buffer backend store needs to be BLOB or ION. Crash is seen because neither mask to use blob nor permission for ion is not set.

Fix the issue by setting the mask and also giving permission to /dev/ion.

Tracked-On: OAM-111155