### PR TITLE
Support fastboot with slim bootloader

### DIFF
--- a/groups/boot-arch/project-celadon/AndroidBoard.mk
+++ b/groups/boot-arch/project-celadon/AndroidBoard.mk
@@ -207,6 +207,7 @@ else # BOOTLOADER_SLOT == false
 	$(hide) mkdir -p $(efi_root)/EFI/INTEL/
 endif # BOOTLOADER_SLOT
 	$(hide) $(ACP) $(PRODUCT_OUT)/sbl_os $(efi_root)/boot
+	$(hide) $(ACP) $(PRODUCT_OUT)/sbl_fb $(efi_root)/boot
 	$(hide) $(ACP) $(TOP)/$(PREBUILT_KERNELFLINGER) $(efi_root)/EFI/BOOT/bootx64.efi
 	$(hide) $(ACP) $(TOP)/$(PREBUILT_KERNELFLINGER) $(efi_root)/EFI/BOOT/bootia32.efi
 	$(hide) (cd $(efi_root) && zip -qry ../$(notdir $@) .)
@@ -234,6 +235,7 @@ $(hide)mmd -i $(BOARD_BOOTLOADER_VAR_IMG) ::EFI;
 $(hide)mmd -i $(BOARD_BOOTLOADER_VAR_IMG) ::EFI/BOOT;
 $(hide)mmd -i $(BOARD_BOOTLOADER_VAR_IMG) ::boot;
 $(hide)mcopy -Q -i $(BOARD_BOOTLOADER_VAR_IMG) $(PRODUCT_OUT)/sbl_os ::boot/sbl_os;
+$(hide)mcopy -Q -i $(BOARD_BOOTLOADER_VAR_IMG) $(PRODUCT_OUT)/sbl_fb ::boot/sbl_fb;
 $(hide)mcopy -Q -i $(BOARD_BOOTLOADER_VAR_IMG) $(TOP)/$(PREBUILT_KERNELFLINGER) ::EFI/BOOT/bootx64.efi;
 cp $(BOARD_BOOTLOADER_VAR_IMG) $(BOARD_BOOTLOADER_DEFAULT_IMG)
 cp $(BOARD_BOOTLOADER_VAR_IMG) $(bootloader_bin)
@@ -242,7 +244,7 @@ endef
 
 fastboot_image: fb4sbl-$(TARGET_BUILD_VARIANT)
 
-bootloader: $(BOARD_BOOTLOADER_DIR) kf4sbl-$(TARGET_BUILD_VARIANT)
+bootloader: $(BOARD_BOOTLOADER_DIR) kf4sbl-$(TARGET_BUILD_VARIANT) fb4sbl-$(TARGET_BUILD_VARIANT)
 	$(call generate_bootloader_var)
 
 ifneq ($(INTEL_PATH_PREBUILTS_OUT),)


### PR DESCRIPTION
Fastboot is used to flash Android images.
Build fastboot as ELF format to support SBL boot

Tracked-On: OAM-111201