### PR TITLE
Default the dummy sound card

### DIFF
--- a/groups/audio/project-celadon/init.rc
+++ b/groups/audio/project-celadon/init.rc
@@ -105,6 +105,12 @@ on early-boot
     insmod /vendor/lib/modules/snd-soc-hdac-hdmi.ko
 {{/ivi}}
 
+on boot
+    insmod /vendor/lib/modules/snd.ko
+    insmod /vendor/lib/modules/snd-timer.ko
+    insmod /vendor/lib/modules/snd-pcm.ko
+    insmod /vendor/lib/modules/snd-dummy.ko
+
 on property:sys.boot_completed=1 && property:ro.vendor.hdmi.audio=tgl
     stop audioserver
     start audioserver


### PR DESCRIPTION
Dummy sound card help in verification of audio cases when the actual sound cards are not present
on the hardware.

Tracked-On: OAM-111063

Signed-off-by: pmandri padmashree.mandri@intel.com