### PR TITLE
CtsOsTestCases failed due to Missing SoC Properties.

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -181,3 +181,5 @@ KERNELFLINGER_SUPPORT_LIVE_BOOT ?= true
 ENABLE_GRUB_INSTALLER ?= true
 {{/grub_installer}}
 {{/use_cic}}
+
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/soc

--- a/groups/boot-arch/project-celadon/files.spec
+++ b/groups/boot-arch/project-celadon/files.spec
@@ -4,6 +4,7 @@
 [extrafiles]
 update_ifwi_ab.sh: "ifwi update script running in postinstall"
 startup.nsh: "Auto installer start"
+set_soc_prop.sh: "Set SoC Properties"
 
 [mapping]
 {{target}}/acpi: acpi

--- a/groups/boot-arch/project-celadon/product.mk
+++ b/groups/boot-arch/project-celadon/product.mk
@@ -141,3 +141,5 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/developer_gsi_keys.mk)
 KERNELFLINGER_SUPPORT_KEYBOX_PROVISION := true
 {{/keybox_provision}}
 {{/use_cic}}
+
+PRODUCT_COPY_FILES += $(LOCAL_PATH)/{{_extra_dir}}/set_soc_prop.sh:vendor/bin/set_soc_prop.sh

--- a/groups/boot-arch/project-celadon/set_soc_prop.sh
+++ b/groups/boot-arch/project-celadon/set_soc_prop.sh
@@ -1,0 +1,13 @@
+#!/vendor/bin/sh
+
+MODEL_NAME=`cat /proc/cpuinfo | grep -i -m 1 "model name" | cut -d ':' -f 2 | cut -d '@' -f 1`
+
+arr=($MODEL_NAME)
+
+for w in "${arr[@]}"; do
+        if [ $(echo $w | grep -c "-") -gt 0 ]; then
+                MODEL_NAME=$w
+        fi
+done
+
+setprop vendor.cpu.model_name "$MODEL_NAME"

--- a/groups/device-specific/caas/caas.mk
+++ b/groups/device-specific/caas/caas.mk
@@ -61,6 +61,9 @@ PRODUCT_LOCALES := en_US en_IN fr_FR it_IT es_ES et_EE de_DE nl_NL cs_CZ pl_PL j
 PRODUCT_AAPT_CONFIG := normal large mdpi
 PRODUCT_AAPT_PREF_CONFIG := mdpi
 
+PRODUCT_VENDOR_PROPERTIES += \
+    ro.soc.manufacturer=$(PRODUCT_MANUFACTURER)
+
 PRODUCT_RESTRICT_VENDOR_FILES := false
 PRODUCT_SET_DEBUGFS_RESTRICTIONS := false
 {{^ota-update}}

--- a/groups/device-specific/caas/init.rc
+++ b/groups/device-specific/caas/init.rc
@@ -41,3 +41,7 @@ on post-fs
     insmod /vendor/lib/modules/asix.ko
     insmod /vendor/lib/modules/r8152.ko
     insmod /vendor/lib/modules/r8169.ko
+
+on post-fs-data
+    exec - system system -- /vendor/bin/set_soc_prop.sh
+    setprop ro.soc.model ${vendor.cpu.model_name}


### PR DESCRIPTION
Following CTS test android.os.cts.BuildTest#testBuildConstants is failing due to missing SoC properties. A12 onwards, Below SoC properties need to define to pass CTS and cts-on-gsi test-: ro.soc.manufacturer
ro.soc.model

Tracked-On: OAM-111307