### PR TITLE
Userdata checkpoint enable

### DIFF
--- a/groups/kernel/gmin64/config-lts/linux-intel-lts2021/0001-Userdata-checkpoint-enable.patch
+++ b/groups/kernel/gmin64/config-lts/linux-intel-lts2021/0001-Userdata-checkpoint-enable.patch
@@ -1,0 +1,31 @@
+From e4722cd38d74aa8df33a360aded1f47a81ae461c Mon Sep 17 00:00:00 2001
+From: "Kang, Zecheng" <zecheng.kang@intel.com>
+Date: Mon, 7 Aug 2023 13:45:40 +0800
+Subject: [PATCH] Userdata checkpoint enable
+
+Checkpoint feature need enable in ota
+DM-BOW should enable first in this configuration
+Checkpoint feature enable must depends on userdata_checkpoint=true in
+mixins.spec and CONFIGURE_DM_BOW
+
+Tracked-On: OAM-110267
+Signed-off-by: Kang, Zecheng <zecheng.kang@intel.com>
+---
+ .../gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig       | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig b/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
+index 16162d6..099cb49 100644
+--- a/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
++++ b/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
+@@ -2171,6 +2171,7 @@ CONFIG_DM_VERITY_FEC=y
+ # CONFIG_DM_LOG_WRITES is not set
+ # CONFIG_DM_INTEGRITY is not set
+ # CONFIG_DM_BOW is not set
++CONFIG_DM_BOW=y
+ CONFIG_DM_USER=y
+ # CONFIG_TARGET_CORE is not set
+ # CONFIG_FUSION is not set
+-- 
+2.17.1
+


### PR DESCRIPTION
Checkpoint feature need enable in ota
DM-BOW should enable first in this configuration
Checkpoint feature enable must depends on userdata_checkpoint=true in mixins.spec and CONFIGURE_DM_BOW

Tracked-On: OAM-110267