### PR TITLE
adding needed permission for fan

### DIFF
--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -10,6 +10,7 @@ on boot
     chown system system /sys/devices/system/cpu/intel_pstate/no_turbo
     chown system system /sys/class/powercap/intel-rapl:0/enabled
     chown system system /sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw
+    chown system system /sys/class/thermal/cooling_device0/cur_state
     chown system system /sys/class/dmi/id/product_uuid
     chown system system /sys/class/dmi/id/product_name
     chown system system /system/vendor/etc/


### PR DESCRIPTION
thermal daemon doesn't have permission to access cooling device.
so adding needed permission.

Tracked-On: OAM-111821
Signed-off-by: Ranjan, Rajani <rajani.ranjan@intel.com>