### PR TITLE
Use sw vulkan driver in VIRTIO-3D mode

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -23,7 +23,7 @@ case "$(cat /proc/fb)" in
                         else
                                 echo "virtio rendering"
                                 setprop vendor.egl.set mesa
-                                setprop vendor.vulkan.set intel
+                                setprop vendor.vulkan.set pastel
                         fi
                 fi
                 ;;


### PR DESCRIPTION
Found one caas virtio-gpu issue, which use intel Vulkan driver. Instead we need use pastel software vulkan driver

Tracked-On: OAM-111883