### PR TITLE
Set cameraIdOffset to 0 for uvc device

### DIFF
--- a/groups/camera-ext/ext-camera-only/external_camera_config.xml
+++ b/groups/camera-ext/ext-camera-only/external_camera_config.xml
@@ -16,6 +16,7 @@
 
 <ExternalCamera>
     <Provider>
+        <CameraIdOffset>0</CameraIdOffset>
         <ignore> <!-- Internal video devices to be ignored by external camera HAL -->
         </ignore>
     </Provider>

--- a/groups/camera-ext/ivi/external_camera_config.xml
+++ b/groups/camera-ext/ivi/external_camera_config.xml
@@ -16,6 +16,7 @@
 
 <ExternalCamera>
     <Provider>
+        <CameraIdOffset>0</CameraIdOffset>
         <ignore> <!-- Internal video devices to be ignored by external camera HAL -->
         </ignore>
     </Provider>


### PR DESCRIPTION
Issue: CameraService reports invalid cameraId when using UVC sensor.

RootCause: External camera provider will set cameraId of external camera device to id+CameraIdOffset, CameraIdOffset is 200 by default if not set in external_camera_config.xml. Hence the cameraId exceeds the cameraIds range in CameraService.

Fix: Set CameraIdOffset to 0 in external_camera_config.xml.

Test: Verify camera functionalities by android camera apps.

Tracked-On: OAM-111732