### PR TITLE
move iw from system bin to vendor bin

### DIFF
--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -53,7 +53,7 @@ service iprenew_p2p /system/bin/dhcpcd -n
     disabled
     oneshot
 
-service apcreate /system/bin/iw phy phy0 interface add wlan1 type __ap
+service apcreate /vendor/bin/iw phy phy0 interface add wlan1 type __ap
     user root
     group root shell
     disabled

--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -5,7 +5,7 @@ PRODUCT_PACKAGES += \
     wifilogd \
     wpa_supplicant \
     wpa_cli \
-    iw \
+    iw_vendor \
     TetheringConfigOverlay \
     TetheringConfigOverlayGsi \
     ServiceConnectivityResourcesConfigOverlay


### PR DESCRIPTION
Fix for sepolicy blocking iw in creating wifi AP interface
iw is not able to create Wi-Fi AP interface due to sepolicy.
As iw is built as system package, addition of sepolicy requires
changes to system/sepolicy which is not recommended. So, using
the vendor iw package instead of system iw package.

Tracked-On: OAM-112388