### PR TITLE
Fix bluetooth crash due to new AVRCP service getting enabled

### DIFF
--- a/groups/device-specific/celadon_ivi/system.prop
+++ b/groups/device-specific/celadon_ivi/system.prop
@@ -4,7 +4,7 @@
 
 persist.sys.enable_rescue=false
 persist.sys.disable_rescue=true
-persist.bluetooth.enablenewavrcp=true
+persist.bluetooth.enablenewavrcp=false
 sys.rescue_level=0
 ro.board.platform=celadon
 audio.safemedia.bypass=true


### PR DESCRIPTION
When persist.bluetooth.enablenewavrcp is set to true, bluetooth AVRCP target profile is provided as a service in the Bluetooth application. Crash is seen while getting this new AVRCP service.

Disable the newavrcp service by setting persist.bluetooth.enablenewavrcp to false.

Tracked-On: OAM-112473