### PR TITLE
Partition layout for booting from multiple SBL containers

### DIFF
--- a/groups/boot-arch/project-celadon/gpt.ini
+++ b/groups/boot-arch/project-celadon/gpt.ini
@@ -1,14 +1,14 @@
 {{^use_cic}}
 [base]
 {{^dynamic-partitions}}
-partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata system {{#vendor-partition}}vendor {{/vendor-partition}}{{#product-partition}}product {{/product-partition}}{{#odm-partition}}odm {{/odm-partition}}{{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}data persistent teedata vbmeta
+partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} {{#acrn}}multiboot tee {{/acrn}}boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata system {{#vendor-partition}}vendor {{/vendor-partition}}{{#product-partition}}product {{/product-partition}}{{#odm-partition}}odm {{/odm-partition}}{{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}data persistent teedata vbmeta
 {{/dynamic-partitions}}
 {{#dynamic-partitions}}
 {{#dp_retrofit}}
-partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata system {{#vendor-partition}}vendor {{/vendor-partition}}{{#product-partition}}product {{/product-partition}}{{#odm-partition}}odm {{/odm-partition}}{{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}data persistent teedata vbmeta
+partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} {{#acrn}}multiboot tee {{/acrn}}boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata system {{#vendor-partition}}vendor {{/vendor-partition}}{{#product-partition}}product {{/product-partition}}{{#odm-partition}}odm {{/odm-partition}}{{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}data persistent teedata vbmeta
 {{/dp_retrofit}}
 {{^dp_retrofit}}
-partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata {{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}super data persistent teedata vbmeta
+partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} {{#acrn}}multiboot tee {{/acrn}}boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata {{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}super data persistent teedata vbmeta
 {{/dp_retrofit}}
 {{/dynamic-partitions}}
 device = auto
@@ -61,6 +61,24 @@ len = {{bootloader_len}}
 type = bootloader
 has_slot = true
 {{/fw_sbl}}
+
+{{#acrn}}
+[partition.multiboot]
+label = multiboot
+len = 33
+type = fat
+{{#slot-ab}}
+has_slot = true
+{{/slot-ab}}
+
+[partition.tee]
+label = tee
+len = 33
+type = fat
+{{#slot-ab}}
+has_slot = true
+{{/slot-ab}}
+{{/acrn}}
 
 [partition.boot]
 label = boot


### PR DESCRIPTION
Adds 2 extra partitions, "multiboot" for ACRN and "tee" for TEE. These partitions are designed for booting from multiple containers in SBL. A new boot-acrn option "sbl_multicontainer" is added to control this feature.

Tracked-On: OAM-112552