### PR TITLE
Create image for multiboot and tee partition

### DIFF
--- a/groups/boot-arch/project-celadon/flashfiles.ini
+++ b/groups/boot-arch/project-celadon/flashfiles.ini
@@ -70,6 +70,35 @@ description = Flash tos partition
 {{/slot-ab}}
 {{/trusty}}
 
+{{#acrn}}
+{{^slot-ab}}
+[command.flash.multiboot]
+tool = fastboot
+args = flash multiboot $file
+file = radio:multiboot.img
+description = Flash multiboot partition
+
+[command.flash.tee]
+tool = fastboot
+args = flash tee $file
+file = radio:tee.img
+description = Flash tee partition
+{{/slot-ab}}
+{{#slot-ab}}
+[command.flash.multiboot]
+tool = fastboot
+args = flash multiboot_a $file
+file = radio:multiboot.img
+description = Flash multiboot partition
+
+[command.flash.tee]
+tool = fastboot
+args = flash tee_a $file
+file = radio:tee.img
+description = Flash tee partition
+{{/slot-ab}}
+{{/acrn}}
+
 {{#bootloader_policy}}
 {{#blpolicy_use_efi_var}}
 # The following command is duplicated on purpose:


### PR DESCRIPTION
Update AndroidBoard.mk for creating "multiboot" and "tee" partition images. These files are only created when "sbl_multicontainer" is enabled.

Tracked-On: OAM-112552