### PR TITLE
Add a/b slot support for bootloader partition

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -168,6 +168,7 @@ AB_OTA_PARTITIONS += vbmeta
 AB_OTA_PARTITIONS += tos
 {{/trusty}}
 
+{{^fw_sbl}}
 {{#bootloader_slot_ab}}
 BOOTLOADER_SLOT := true
 BOARD_ESP_PARTITION_SIZE := $$(({{esp_partition_size}} * 1024 * 1024))
@@ -175,6 +176,10 @@ BOARD_ESP_BLOCK_SIZE := $(BOARD_BOOTLOADER_BLOCK_SIZE)
 BOARD_FLASHFILES += $(PRODUCT_OUT)/esp.img
 AB_OTA_PARTITIONS += bootloader
 {{/bootloader_slot_ab}}
+{{/fw_sbl}}
+{{#fw_sbl}}
+AB_OTA_PARTITIONS += bootloader
+{{/fw_sbl}}
 {{/slot-ab}}
 
 {{#usb_storage}}

--- a/groups/boot-arch/project-celadon/fstab
+++ b/groups/boot-arch/project-celadon/fstab
@@ -30,8 +30,10 @@ system   /system  ext4 ro,barrier=1 wait{{#slot-ab}},slotselect{{/slot-ab}},avb_
 {{#bootloader_slot_ab}}
 /dev/block/by-name/esp          /esp            emmc    defaults                                                    recoveryonly
 {{/bootloader_slot_ab}}
-/dev/block/by-name/bootloader   /bootloader     emmc    defaults                                                    recoveryonly{{#bootloader_slot_ab}},slotselect{{/bootloader_slot_ab}}
+/dev/block/by-name/bootloader   /bootloader     emmc    defaults                                                    recoveryonly{{^fw_sbl}}{{#bootloader_slot_ab}},slotselect{{/bootloader_slot_ab}}{{/fw_sbl}}
+{{^fw_sbl}}
 /dev/block/by-name/bootloader2  /bootloader2    emmc    defaults                                                    recoveryonly
+{{/fw_sbl}}
 /dev/block/by-name/persistent   /persistent     emmc    defaults                                                    defaults
 /dev/block/by-name/metadata     /metadata       ext4    noatime,nosuid,nodev,errors=panic{{#metadata_encryption}},discard{{/metadata_encryption}}                           wait,check,formattable,first_stage_mount
 {{/use_cic}}

--- a/groups/boot-arch/project-celadon/fstab.recovery
+++ b/groups/boot-arch/project-celadon/fstab.recovery
@@ -30,8 +30,10 @@ system   /system  ext4 ro,barrier=1 wait{{#slot-ab}},slotselect{{/slot-ab}},avb_
 {{#bootloader_slot_ab}}
 /dev/block/by-name/esp          /esp            emmc    defaults                                                    recoveryonly
 {{/bootloader_slot_ab}}
-/dev/block/by-name/bootloader   /bootloader     emmc    defaults                                                    recoveryonly{{#bootloader_slot_ab}},slotselect{{/bootloader_slot_ab}}
+/dev/block/by-name/bootloader   /bootloader     emmc    defaults                                                    recoveryonly{{^fw_sbl}}{{#bootloader_slot_ab}},slotselect{{/bootloader_slot_ab}}{{/fw_sbl}}
+{{^fw_sbl}}
 /dev/block/by-name/bootloader2  /bootloader2    emmc    defaults                                                    recoveryonly
+{{/fw_sbl}}
 /dev/block/by-name/persistent   /persistent     emmc    defaults                                                    defaults
 /dev/block/by-name/metadata     /metadata       ext4    noatime,nosuid,nodev,errors=panic                           wait,check
 {{/use_cic}}

--- a/groups/boot-arch/project-celadon/gpt.ini
+++ b/groups/boot-arch/project-celadon/gpt.ini
@@ -1,14 +1,14 @@
 {{^use_cic}}
 [base]
 {{^dynamic-partitions}}
-partitions = {{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}bootloader bootloader2 boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata system {{#vendor-partition}}vendor {{/vendor-partition}}{{#product-partition}}product {{/product-partition}}{{#odm-partition}}odm {{/odm-partition}}{{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}data persistent teedata vbmeta
+partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata system {{#vendor-partition}}vendor {{/vendor-partition}}{{#product-partition}}product {{/product-partition}}{{#odm-partition}}odm {{/odm-partition}}{{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}data persistent teedata vbmeta
 {{/dynamic-partitions}}
 {{#dynamic-partitions}}
 {{#dp_retrofit}}
-partitions = {{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}bootloader bootloader2 boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata system {{#vendor-partition}}vendor {{/vendor-partition}}{{#product-partition}}product {{/product-partition}}{{#odm-partition}}odm {{/odm-partition}}{{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}data persistent teedata vbmeta
+partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata system {{#vendor-partition}}vendor {{/vendor-partition}}{{#product-partition}}product {{/product-partition}}{{#odm-partition}}odm {{/odm-partition}}{{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}data persistent teedata vbmeta
 {{/dp_retrofit}}
 {{^dp_retrofit}}
-partitions = {{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}bootloader bootloader2 boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata {{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}super data persistent teedata vbmeta
+partitions = {{^fw_sbl}}{{#bootloader_slot_ab}}esp esp2 {{/bootloader_slot_ab}}{{/fw_sbl}}bootloader {{^fw_sbl}}bootloader2{{/fw_sbl}} boot {{#trusty}}tos {{/trusty}}{{^slot-ab}}recovery {{/slot-ab}}misc metadata {{#acpi-partition}}acpi {{/acpi-partition}}{{#acpio-partition}}acpio {{/acpio-partition}}{{^slot-ab}}cache {{/slot-ab}}super data persistent teedata vbmeta
 {{/dp_retrofit}}
 {{/dynamic-partitions}}
 device = auto
@@ -16,6 +16,7 @@ device = auto
 nb_slot = {{nb_slot}}
 {{/slot-ab}}
 
+{{^fw_sbl}}
 {{#bootloader_slot_ab}}
 [partition.esp]
 label = esp
@@ -51,6 +52,15 @@ flags = boot
 label = bootloader2
 len = {{bootloader_len}}
 type = fat
+{{/fw_sbl}}
+
+{{#fw_sbl}}
+[partition.bootloader]
+label = bootloader
+len = {{bootloader_len}}
+type = bootloader
+has_slot = true
+{{/fw_sbl}}
 
 [partition.boot]
 label = boot


### PR DESCRIPTION
bootloader partition should be added to AB_OTA_PARTITIONS, and this requires bootloader partition support a/b slots.
Tracked-On: OAM-112771