### PR TITLE
Add rules to build vbox guest additions modules

### DIFF
--- a/groups/kernel/AndroidBoard.mk
+++ b/groups/kernel/AndroidBoard.mk
@@ -298,6 +298,22 @@ endef
 $(foreach v,$(BOARD_DTB_VARIANTS),$(eval $(call board_dtb_per_variant,$(v))))
 {{/build_dtbs}}
 
+{{#vbox_mods_version}}
+VBOX_ADDITIONS_PATH := ../modules/VBoxGuestAdditions
+VBOX_MODS_SRC_PATH := $(VBOX_ADDITIONS_PATH)/{{{vbox_mods_version}}}
+VBOX_MODS_OBJ_PATH := $(LOCAL_KERNEL_PATH)/$(VBOX_ADDITIONS_PATH)/{{{vbox_mods_version}}}
+VBOX_MODS_TARGET := $(LOCAL_KERNEL_PATH)/build_VBoxGuestAdditions_{{{vbox_mods_version}}}
+
+$(VBOX_MODS_TARGET): $(LOCAL_KERNEL)
+	@echo BUILDING $(VBOX_MODS_SRC_PATH)
+	$(hide) mkdir -p $(VBOX_MODS_OBJ_PATH)
+	$(hide) $(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS) M=$(VBOX_MODS_SRC_PATH) V=1 modules
+	$(hide) $(KERNEL_MAKE_CMD) $(KERNEL_MAKE_OPTIONS) M=$(VBOX_MODS_SRC_PATH) INSTALL_MOD_STRIP=1 modules_install
+	@touch $@
+
+$(LOCAL_KERNEL_PATH)/copy_modules: $(VBOX_MODS_TARGET)
+{{/vbox_mods_version}}
+
 # Add a kernel target, so "make kernel" will build the kernel
 .PHONY: kernel
 kernel: $(LOCAL_KERNEL_PATH)/copy_modules $(PRODUCT_OUT)/kernel

--- a/groups/kernel/gmin64/load_kernel_modules.in
+++ b/groups/kernel/gmin64/load_kernel_modules.in
@@ -3,3 +3,11 @@ load_kernel_modules() {
     insmod $modules/brd.ko rd_nr=16 rd_size=16384
 }
 load_kernel_modules
+
+{{#vbox_mods_version}}
+load_vbox_modules() {
+    insmod $modules/vboxguest.ko
+    insmod $modules/vboxsf.ko
+}
+load_vbox_modules
+{{/vbox_mods_version}}

--- a/groups/kernel/option.spec-gmin
+++ b/groups/kernel/option.spec-gmin
@@ -31,3 +31,4 @@ lts2021_chromium_cfg_path =
 linux_intel_lts2021_src_path =
 linux_intel_lts2021_cfg_path =
 more_modules = false
+vbox_mods_version = false


### PR DESCRIPTION
Add build rules in AndroidBoard.mk to build vbox

Updated AndroidBoard.mk to build vbox guest module outside kernel tree.

vbox_mods_version option provided to control build of vbox guest module.

Tracked-On: OAM-112344
Signed-off-by: Yadong Qi yadong.qi@intel.com