### PR TITLE
Improve compilation speed for android build

### DIFF
--- a/groups/flashfiles/ini/files.spec
+++ b/groups/flashfiles/ini/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+installer.cmd : "hardcoded installer.cmd, need to be updated based on partition change"

--- a/groups/flashfiles/ini/installer.cmd
+++ b/groups/flashfiles/ini/installer.cmd
@@ -1,0 +1,16 @@
+flashing unlock
+flash gpt gpt.bin
+flash bootloader bootloader.img
+erase teedata
+erase misc
+erase persistent
+erase metadata
+format userdata
+format config
+flash vbmeta_a vbmeta.img
+flash vendor_boot_a vendor_boot.img
+flash acpio_a acpio.img
+flash boot_a boot.img
+flash super super.img.part00 super.img.part01 
+flashing lock
+continue

--- a/groups/flashfiles/ini/product.mk
+++ b/groups/flashfiles/ini/product.mk
@@ -1,0 +1,1 @@
+PRODUCT_COPY_FILES += $(LOCAL_PATH)/extra_files/flashfiles/installer.cmd:$(PRODUCT_OUT)/installer.cmd


### PR DESCRIPTION
FFTF python script used for flashfiles.zip in IVI. It uses ZipWrite python api to create it. This method is time consuming and adds several unwanted build steps that adds overhead. Like, flash.json generation, unpacking of target files, installer.cmd generation.

This fix, changes FFTF python to a normal FFTF bash script, which uses tar + pigz combo for faster flashfiles generation.

NOTE:
We deprecate flash.json as its used only by PFT & installer.cmd will be maintained in product config repo.

Tracked-On: OAM-112083