### PR TITLE
Manifest and package changes for minigbm AIDL HAL

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -76,25 +76,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.graphics.mapper</name>
-        <transport arch="32+64">passthrough</transport>
-        <version>4.0</version>
-        <interface>
-            <name>IMapper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-
-    <hal format="hidl">
-        <name>android.hardware.graphics.allocator</name>
-        <transport>hwbinder</transport>
-        <version>4.0</version>
-        <interface>
-            <name>IAllocator</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
         <version>2.4</version>

--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -26,8 +26,8 @@ PRODUCT_PACKAGES +=  \
                     android.hardware.usb-service.example \
                     camera.device@1.0-impl \
                     android.hardware.camera.provider@2.4-impl \
-                    android.hardware.graphics.mapper@4.0-impl.minigbm \
-                    android.hardware.graphics.allocator@4.0-service.minigbm \
+                    android.hardware.graphics.mapper@4.0-impl.minigbm_intel \
+                    android.hardware.graphics.allocator-service.minigbm \
                     android.hardware.renderscript@1.0-impl \
                     android.hardware.graphics.composer@2.4-service \
                     android.hardware.identity \

--- a/groups/device-specific/caas_dev/manifest.xml
+++ b/groups/device-specific/caas_dev/manifest.xml
@@ -76,25 +76,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.graphics.mapper</name>
-        <transport arch="32+64">passthrough</transport>
-        <version>4.0</version>
-        <interface>
-            <name>IMapper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-
-    <hal format="hidl">
-        <name>android.hardware.graphics.allocator</name>
-        <transport>hwbinder</transport>
-        <version>4.0</version>
-        <interface>
-            <name>IAllocator</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
         <version>2.4</version>

--- a/groups/device-specific/caas_dev/product.mk
+++ b/groups/device-specific/caas_dev/product.mk
@@ -26,8 +26,8 @@ PRODUCT_PACKAGES +=  \
                     android.hardware.usb-service.example \
                     camera.device@1.0-impl \
                     android.hardware.camera.provider@2.4-impl \
-                    android.hardware.graphics.mapper@4.0-impl.minigbm \
-                    android.hardware.graphics.allocator@4.0-service.minigbm \
+                    android.hardware.graphics.mapper@4.0-impl.minigbm_intel \
+                    android.hardware.graphics.allocator@4.0-service.minigbm_intel \
                     android.hardware.renderscript@1.0-impl \
                     android.hardware.graphics.composer@2.4-service \
                     android.hardware.identity \

--- a/groups/device-specific/celadon_ivi/manifest.xml
+++ b/groups/device-specific/celadon_ivi/manifest.xml
@@ -68,25 +68,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.graphics.mapper</name>
-        <transport arch="32+64">passthrough</transport>
-        <version>4.0</version>
-        <interface>
-            <name>IMapper</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-
-    <hal format="hidl">
-        <name>android.hardware.graphics.allocator</name>
-        <transport>hwbinder</transport>
-        <version>4.0</version>
-        <interface>
-            <name>IAllocator</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
         <version>2.4</version>

--- a/groups/device-specific/celadon_ivi/product.mk
+++ b/groups/device-specific/celadon_ivi/product.mk
@@ -22,8 +22,8 @@ PRODUCT_PACKAGES +=  \
                     android.hardware.usb@1.0-service \
                     camera.device@1.0-impl \
                     android.hardware.camera.provider@2.4-impl \
-                    android.hardware.graphics.mapper@4.0-impl.minigbm \
-                    android.hardware.graphics.allocator@4.0-service.minigbm \
+                    android.hardware.graphics.mapper@4.0-impl.minigbm_intel \
+                    android.hardware.graphics.allocator-service.minigbm \
                     android.hardware.renderscript@1.0-impl \
                     android.hardware.graphics.composer@2.4-service
 

--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -59,7 +59,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
 {{#minigbm}}
 # Mini gbm
 PRODUCT_PACKAGES += \
-    gralloc.$(TARGET_GFX_INTEL)
+    gralloc.$(TARGET_GFX_INTEL) \
+    mapper.minigbm \
+    libminigbm_gralloc_intel
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.gralloc=$(TARGET_GFX_INTEL)


### PR DESCRIPTION
Changes include:
- Removal of allocator and mapper entries in manifest.xml as those are added in minigbm project.
- Added libminigbm_gralloc_intel package
- Updated allocator service and mapper library names

Tracked-On: OAM-112813