### PR TITLE
Disable 8k resolution for c2.intel.hevc.encoder

### DIFF
--- a/groups/codec2/true/media_codecs_intel_c2_video.xml
+++ b/groups/codec2/true/media_codecs_intel_c2_video.xml
@@ -123,7 +123,7 @@ and updated to vendor media codecs.
 
 {{#hw_ve_h265}}
 	<MediaCodec name="c2.intel.hevc.encoder" type="video/hevc" >
-            <Limit name="size" min="176x144" max="8192x8192" />
+            <Limit name="size" min="176x144" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="blocks-per-second" range="1-972000" />


### PR DESCRIPTION
android.media.cts.VideoEncoderTest#testOtherH265FlexNearMaxMax case
will check the maximum supported resolution. Max resoultion of 8k causes
CTS interruption as it exceeds the 30 minute limit.

As 8k encoding is not a requirement for ivi reduced the maximum
resolution to 4k.

Tracked-On: OAM-112862