### PR TITLE
Stop thermal-daemon if platform doesn't support

### DIFF
--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -22,3 +22,7 @@ on post-fs-data
 
 on property:sys.boot_completed=1 && property:vendor.thermal.enable=1
     start thermal-daemon
+
+on property:persist.vendor.thermal.daemon.supported=0
+    stop thermal-daemon
+


### PR DESCRIPTION
In situations where the platform does not support the thermal daemon feature, it is unnecessary to run the thermal-daemon service.This commit introduces a conditional check to halt the service when the feature is not available, thereby optimizing resource usage.

Tracked-On: OAM-112768