### PR TITLE
Disabled Omx in manifest.xml

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -101,19 +101,6 @@
             <instance>default</instance>
         </interface>
     </hal-->
-    <hal format="hidl">
-        <name>android.hardware.media.omx</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IOmx</name>
-            <instance>default</instance>
-        </interface>
-        <interface>
-            <name>IOmxStore</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
     <!--hal format="hidl">
         <name>android.hardware.drm</name>
         <transport>hwbinder</transport>


### PR DESCRIPTION
android.hardware.media.omx@1.0::IOmxStore/default is deprecated in compatibility matrix at FCM Version 8, so we disabled it.

Tracked-On: OAM-112807