### PR TITLE
Camera-Add-aidl-camera-provider-for-external-camera

### DIFF
--- a/groups/camera-ext/ext-camera-only/product.mk
+++ b/groups/camera-ext/ext-camera-only/product.mk
@@ -6,9 +6,8 @@ PRODUCT_COPY_FILES += \
 
 
 # External camera service
-PRODUCT_PACKAGES += android.hardware.camera.provider@2.4-external-service \
-                    android.hardware.camera.provider@2.4-service_64 \
-                    android.hardware.camera.provider@2.4-impl
+PRODUCT_PACKAGES += android.hardware.camera.provider-V1-external-service \
+                    android.hardware.camera.provider-V1-external-impl
 #VHAL camera
 PRODUCT_PACKAGES += camera.$(TARGET_BOARD_PLATFORM) \
                     camera.$(TARGET_BOARD_PLATFORM).jpeg

--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -164,14 +164,9 @@
             <instance>default</instance>
         </interface>
     </hal>
-    <hal format="hidl">
+    <hal format="aidl">
         <name>android.hardware.camera.provider</name>
-        <transport>hwbinder</transport>
-        <version>2.4</version>
-        <interface>
-            <name>ICameraProvider</name>
-            <instance>external/0</instance>
-        </interface>
+	<fqname>ICameraProvider/external/0</fqname>
     </hal>
     <!--hal format="hidl">
         <name>android.hardware.boot</name>

--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -139,15 +139,9 @@
         <fqname>@1.4::ICryptoFactory/clearkey</fqname>
         <fqname>@1.4::IDrmFactory/clearkey</fqname>
     </hal-->
-    <hal format="hidl">
+    <hal format="aidl">
         <name>android.hardware.camera.provider</name>
-        <transport>hwbinder</transport>
-        <version>2.4</version>
-        <interface>
-            <name>ICameraProvider</name>
-            <instance>external/0</instance>
-            <instance>legacy/0</instance>
-        </interface>
+	<fqname>ICameraProvider/external/0</fqname>
     </hal>
     <!--hal format="hidl">
         <name>android.hardware.boot</name>


### PR DESCRIPTION
As android.hardware.camera.provider@2.4::ICameraProvider is deprecated in compatibility matrix for FCM Version 8, ICameraProvider AIDL packages added

Tracked-On: OAM-112809