### PR TITLE
Enable serial console in recovery mode

### DIFF
--- a/groups/boot-arch/project-celadon/init.recovery.rc
+++ b/groups/boot-arch/project-celadon/init.recovery.rc
@@ -5,6 +5,11 @@ service watchdogd /system/bin/watchdogd{{#watchdog_parameters}} {{{watchdog_para
     oneshot
     seclabel u:r:watchdogd:s0
 
+service console /system/bin/sh
+    console
+    seclabel u:r:su:s0
+    setenv HOSTNAME console
+
 on boot
     start watchdogd
     write /proc/sys/kernel/hung_task_timeout_secs{{#hung_task_timeout_secs}} {{{hung_task_timeout_secs}}}{{/hung_task_timeout_secs}}


### PR DESCRIPTION
This can help with debugging issues in userdebug build, in user build the serial is disabled.

Tracked-On: OAM-112901