### PR TITLE
MIXIN changes for AIDL Conversion of Thermal HAL

### DIFF
--- a/groups/device-specific/caas/framework_manifest.xml
+++ b/groups/device-specific/caas/framework_manifest.xml
@@ -47,15 +47,10 @@
         <version>1</version>
         <fqname>IHealth/default</fqname>
     </hal-->
-    <hal format="hidl">
+    <hal format="aidl">
         <name>android.hardware.thermal</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <version>2.0</version>
-        <interface>
-            <name>IThermal</name>
-            <instance>default</instance>
-        </interface>
+        <version>1</version>
+        <fqname>IThermal/default</fqname>
     </hal>
     <hal format="aidl">
         <name>android.hardware.gatekeeper</name>

--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -10,16 +10,6 @@
         <fqname>IHealth/default</fqname>
     </hal-->
     <hal format="hidl">
-        <name>android.hardware.thermal</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <version>2.0</version>
-        <interface>
-            <name>IThermal</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.audio</name>
         <transport>hwbinder</transport>
         <version>7.1</version>

--- a/groups/thermal/thermal-daemon/product.mk
+++ b/groups/thermal/thermal-daemon/product.mk
@@ -5,4 +5,4 @@ PRODUCT_COPY_FILES += \
 	$(INTEL_PATH_COMMON)/thermal/thermal-daemon/thermal-cpu-cdev-order.xml:/vendor/etc/thermal-daemon/thermal-cpu-cdev-order.xml
 
 # Thermal Hal
-PRODUCT_PACKAGES += android.hardware.thermal@2.0-service.intel
+PRODUCT_PACKAGES += android.hardware.thermal@aidl-service.intel


### PR DESCRIPTION
Below are the details on this change.
1. caas/framework_manifest.xml & caas/manifest.xml --> Remove unused Thermal HIDL HAL Entry from framework_manifest.xml.
2. ../thermal/hal/product.mk Adding Thermal AIDL HAL in PRODUCT PACKAGES

Tracked-On: OAM-112805