### PR TITLE
System property to disable thermal logs

### DIFF
--- a/groups/device-specific/celadon_ivi/system.prop
+++ b/groups/device-specific/celadon_ivi/system.prop
@@ -11,3 +11,5 @@ audio.safemedia.bypass=true
 debug.nn.cpuonly=0
 camera.disable_treble=false
 ro.incremental.enable=yes
+persist.vendor.disable.thermal.logs=false
+persist.vendor.thermal.daemon.supported=1

--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -22,3 +22,7 @@ on post-fs-data
 
 on property:sys.boot_completed=1 && property:vendor.thermal.enable=1
     start thermal-daemon
+
+on property:persist.vendor.thermal.daemon.supported=0
+    stop thermal-daemon
+


### PR DESCRIPTION
This commit introduces a new system property that, when set, disables the logging of thermal Daemon to reduce log clutter and improve system performance.

Tracked-On: OAM-113302