### PR TITLE
Modify flashfiles.ini to support android flash tool

### DIFF
--- a/groups/flashfiles/ini/flashfiles.ini
+++ b/groups/flashfiles/ini/flashfiles.ini
@@ -171,11 +171,6 @@ description = Get the active slot
 defaultValue = a
 mandatory = false
 
-[command.slot-ab.set-active]
-tool = fastboot
-args = --set-active=${slot}
-description = Set the active slot
-
 {{/slot-ab}}
 [command.unlock.unlock]
 tool = fastboot
@@ -337,7 +332,7 @@ description = Set OEM variables
 
 [command.format.data]
 tool = fastboot
-args = format {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}}
+args = format{{#data_use_f2fs}}:f2fs{{/data_use_f2fs}} {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}}
 description = Format {{^dynamic-partitions}}data{{/dynamic-partitions}}{{#dynamic-partitions}}userdata{{/dynamic-partitions}} partition
 {{/mfgos}}
 


### PR DESCRIPTION
1. Add the suffix of fs_type back to the format command. installer doesn't support the syntax of 'format:fs_type' command previously, so 'format:f2fs' is changed to 'format'. But the installer.cmd file will be shared by flash tool and installer, and flash tool support the synctax of 'format:fs_type', so need to add the fs_type suffix back for format command. installer has been refined to support the syntax of 'format:fs_type' now.
2. Remove set-active command from flashfiles.ini, slot a will be used by default during the flash process.

Tracked-On: OAM-113370