### PR TITLE
Config country code CN in ro.boot.wificountrycode

### DIFF
--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -2,6 +2,7 @@ on post-fs-data
     chmod 0660 /data/misc/wifi/p2p_supplicant.conf
     setprop wifi.interface wlan0
     setprop wifi.direct.interface p2p-dev-wlan0
+    setprop ro.boot.wificountrycode CN
 
 on early-boot
 {{^iwl_upstream_drv}}


### PR DESCRIPTION
Config country code CN in ro.boot.wificountrycode

Tests:
when system boot, you can see logcat log as below: WifiCountryCode: Default country code from system property ro.boot.wificountrycode is CN

Tracked-On: OAM-113448