### PR TITLE
Change the path of ueventd.rc

### DIFF
--- a/groups/device-specific/celadon_ivi/product.mk
+++ b/groups/device-specific/celadon_ivi/product.mk
@@ -8,7 +8,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.rc:root/init.recovery.$(TARGET_PRODUCT).rc \
 {{#treble}}
     $(LOCAL_PATH)/init.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.$(TARGET_PRODUCT).rc \
-    $(LOCAL_PATH)/ueventd.rc:$(TARGET_COPY_OUT_VENDOR)/ueventd.rc \
+    $(LOCAL_PATH)/ueventd.rc:$(TARGET_COPY_OUT_VENDOR)/etc/ueventd.rc \
 {{/treble}}
 {{^treble}}
     $(LOCAL_PATH)/init.rc:root/init.$(TARGET_PRODUCT).rc \


### PR DESCRIPTION
Update the path of ueventd.rc because Android T doesn't support legacy ueventd configuration file.

Tracked-On: OAM-113518