### PR TITLE
Increase retry count to fastboot flashing lock

### DIFF
--- a/groups/flashfiles/ini/flashfiles.ini
+++ b/groups/flashfiles/ini/flashfiles.ini
@@ -351,6 +351,7 @@ timeout = 180000
 {{^acrn-guest}}
 timeout = 3600000
 {{/acrn-guest}}
+retry = 2
 description = Set device state to locked
 
 [command.reboot.continue]


### PR DESCRIPTION
"fastboot flashing lock" will write data to TPM, sometimes it would fail, but re-write to it always success

Tracked-On: OAM-114357