### PR TITLE
Add logcat2hvc in debug-tools mixins group

### DIFF
--- a/groups/debug-tools/doc.spec
+++ b/groups/debug-tools/doc.spec
@@ -10,12 +10,13 @@ debug tools is used to integrate some debug related tools, like peeknpoke lspci 
 ==== Options
 
 --- true
-this option will enable peeknpoke lspci etc into android build.
+this option will enable peeknpoke lspci logcat2hvc etc into android build.
 
 
     --- code dir
         - external/pciutils
         - vendor/intel/tools/peeknpoke
+        - vendor/intel/tools/log_capture/logcat2hvc
 
 --- false
 this option will disable above tools into android build.

--- a/groups/debug-tools/true/BoardConfig.mk
+++ b/groups/debug-tools/true/BoardConfig.mk
@@ -1,1 +1,7 @@
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/debug-tools/androidterm
+
+{{#logcat2hvc}}
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/logcat2hvc
+
+BOARD_KERNEL_CMDLINE += printk.devkmsg=on
+{{/logcat2hvc}}

--- a/groups/debug-tools/true/option.spec
+++ b/groups/debug-tools/true/option.spec
@@ -1,1 +1,2 @@
 [defaults]
+logcat2hvc=

--- a/groups/debug-tools/true/product.mk
+++ b/groups/debug-tools/true/product.mk
@@ -5,3 +5,8 @@ PRODUCT_PACKAGES_DEBUG += \
     pytimechart-record \
     lspci \
     llvm-symbolizer
+
+{{#logcat2hvc}}
+PRODUCT_PACKAGES_DEBUG += \
+    logcat2hvc
+{{/logcat2hvc}}


### PR DESCRIPTION
Logcat2hvc is used to redirect logcat message to hvc (Hyperv Console) on CrosVM Celadon Windows solution.

Test Done: Boot check


Tracked-On: OAM-114679