### PR TITLE
Add logcat2hvc build dependency

### DIFF
--- a/groups/debug-tools/true/BoardConfig.mk
+++ b/groups/debug-tools/true/BoardConfig.mk
@@ -1,7 +1,9 @@
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/debug-tools/androidterm
 
+ifeq ($(MIXIN_DEBUG_LOGS),true)
 {{#logcat2hvc}}
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/logcat2hvc
 
 BOARD_KERNEL_CMDLINE += printk.devkmsg=on
 {{/logcat2hvc}}
+endif

--- a/groups/debug-tools/true/product.mk
+++ b/groups/debug-tools/true/product.mk
@@ -6,7 +6,9 @@ PRODUCT_PACKAGES_DEBUG += \
     lspci \
     llvm-symbolizer
 
+ifeq ($(MIXIN_DEBUG_LOGS),true)
 {{#logcat2hvc}}
 PRODUCT_PACKAGES_DEBUG += \
     logcat2hvc
 {{/logcat2hvc}}
+endif


### PR DESCRIPTION
logcat2hvc depends on logsvc selinux policy, and logsvc is defined in crashlogd. Add dependency to ensure logcat2hvc would be built only with non user-build and debug-crashlogd mixin group enabled.


Tracked-On: OAM-114762