### PR TITLE
cvmb: disable ClipboardAgent

### DIFF
--- a/groups/device-specific/caas_cvmb/product.mk
+++ b/groups/device-specific/caas_cvmb/product.mk
@@ -17,8 +17,6 @@ PRODUCT_COPY_FILES += \
 
 PRODUCT_PACKAGES += vndservicemanager
 
-PRODUCT_PACKAGES += ClipboardAgent
-
 PRODUCT_PACKAGES += androidx.window.extensions \
 		    androidx.window.sidecar
 


### PR DESCRIPTION
Disable ClipboardAgent for cvmb since it is not supported now.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>
Tracked-On: OAM-116770