### PR TITLE
Allows Apps to create input surface

### DIFF
--- a/groups/media/auto/product.mk
+++ b/groups/media/auto/product.mk
@@ -48,3 +48,6 @@ PRODUCT_PACKAGES += lihdcpcommon
 
 PRODUCT_PACKAGES += \
     libpciaccess
+
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += debug.stagefright.c2inputsurface=-1
+


### PR DESCRIPTION
android.hardware.media.omx was disabled now, codec is unable to create inputsurface, so we have to allow apps to do this.

Tracked-On: OAM-117999