### PR TITLE
Configure rro overlay for overriding captive_portal_http_url

### DIFF
--- a/groups/net/common/product.mk
+++ b/groups/net/common/product.mk
@@ -1,0 +1,2 @@
+PRODUCT_PACKAGES += \
+    NetworkConfigOverlay 


### PR DESCRIPTION
Use "http://connect.rom.miui.com/generate_204" as portal http url to replace default url "http://www.google.com/generate_204"

Test: Connect wifi and check network status.

Tracked-On: OAM-118021