### PR TITLE
Set memlock rlimit to default value(64KB)

### DIFF
--- a/groups/kernel/init.rc
+++ b/groups/kernel/init.rc
@@ -84,6 +84,3 @@ on property:sys.boot_completed=1
 
 on early-init
 	mount proc proc /proc remount hidepid=2,gid=3009
-
-on boot
-	setrlimit 8 8388608 8388608


### PR DESCRIPTION
From U dessert, Google force Android to limit memlock to 64KB. CTS test is enforced only in U+ devies.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-117744