### PR TITLE
Set media performance class

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -38,6 +38,7 @@ PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce
 PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.useautofastjni=true
 PRODUCT_PRODUCT_PROPERTIES += persist.adb.tcp.port=5555
 PRODUCT_PRODUCT_PROPERTIES += persist.sys.fuse.bpf.enable=true
+PRODUCT_PRODUCT_PROPERTIES += ro.odm.build.media_performance_class=34
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.crypto.volume.metadata.method=dm-default-key \


### PR DESCRIPTION
Set the android.os.Build.VERSION_CODES.MEDIA_PERFORMANCE_CLASS to android.os.Build.VERSION_CODES.U

Tests Done: Boot check, read write performance KPI are as expected
Tracked-On: OAM-
Signed-off-by: Salini Venate <salini.venate@intel.com>