### PR TITLE
Fixed CTS issue testHasMsOsDescriptors

### DIFF
--- a/groups/usb-gadget/auto/init.rc
+++ b/groups/usb-gadget/auto/init.rc
@@ -101,6 +101,7 @@ on property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
     symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f2
 
 on property:sys.usb.config=adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/os_desc/use 1
     write /config/usb_gadget/g1/idVendor 0x8087
     write /config/usb_gadget/g1/idProduct 0x09ef
 


### PR DESCRIPTION
Enabled MS OS descriptors to fix CTS issue.
Test case details:
Module Name: CtsAdbHostTestCases
Test: android.adb.cts.AdbHostTest#testHasMsOsDescriptors