### PR TITLE
Change teedata partition mount point to /mnt/vendor/persist

### DIFF
--- a/groups/tee/optee/AndroidBoard.mk
+++ b/groups/tee/optee/AndroidBoard.mk
@@ -1,8 +1,2 @@
-# /persist is using for the optee secure storage
-make_persist_dir:
-	@mkdir -p $(PRODUCT_OUT)/root/persist
-
-$(PRODUCT_OUT)/ramdisk.img: make_persist_dir
-
 # OPTEE_ELF triggered by keymaster TA in optee-os
 $(OPTEE_ELF) : dba51a17-0563-11e7-93b1-6fa7b0071a51.ta

--- a/groups/tee/optee/BoardConfig.mk
+++ b/groups/tee/optee/BoardConfig.mk
@@ -20,4 +20,4 @@ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/tee/optee
 AB_OTA_PARTITIONS += tee
 
 include vendor/intel/optee/optee_client/optee_client.device.mk
-$(call soong_config_set,optee_client,cfg_tee_fs_parent_path,/persist/tee)
+$(call soong_config_set,optee_client,cfg_tee_fs_parent_path,/mnt/vendor/persist/tee)

--- a/groups/tee/optee/fstab
+++ b/groups/tee/optee/fstab
@@ -1,1 +1,1 @@
-/dev/block/by-name/teedata       /persist         ext4    discard,noatime,noauto_da_alloc,nosuid,nodev,data=ordered,user_xattr,barrier=1          wait,formattable
+/dev/block/by-name/teedata       /mnt/vendor/persist         ext4    discard,noatime,noauto_da_alloc,nosuid,nodev,data=ordered,user_xattr,barrier=1          wait,formattable

--- a/groups/tee/optee/init.rc
+++ b/groups/tee/optee/init.rc
@@ -1,12 +1,13 @@
+on init
+    mkdir /mnt/vendor 0755 root root
+    mkdir /mnt/vendor/persist 0771 system system
+
 on post-fs
     chmod 666 /dev/tee0
     chmod 666 /dev/teepriv0
 
-    chown system system /persist
-    chmod 0771 /persist
-    restorecon /persist
-    mkdir /persist/tee 0770 shell shell
-    restorecon_recursive /persist/tee
+    restorecon_recursive /mnt/vendor/persist
+    mkdir /mnt/vendor/persist/tee 0770 system system
 
     start tee-supplicantd
     start vendor.keymint-optee


### PR DESCRIPTION
Currently teedata partition's mount point is /persist. Vendor dir under rootfs may be overridden after flashing the GSI image, and teedata partition cannot be mounted any longer.

Test done: tee clients work normally after flashing GSI image.

Tracked-On: OAM-121938