### PR TITLE
Fixed CTS issues

### DIFF
--- a/groups/media/auto/files.spec
+++ b/groups/media/auto/files.spec
@@ -1,2 +1,3 @@
 [extrafiles]
 auto_hal.in : "auto media script"
+igfx_user_feature_next.txt: "feature configuration for media driver"

--- a/groups/media/auto/igfx_user_feature_next.txt
+++ b/groups/media/auto/igfx_user_feature_next.txt
@@ -1,0 +1,10 @@
+[config]
+Perf Profiler Enable=1
+Perf Profiler Output File Name=linux_perf_out.bin
+Perf Profiler Multi Process Support=0
+Perf Profiler Register 8=1835148
+Perf Profiler Buffer Size=10000000
+Enable HCP Scalability Decode=0
+Disable Media Encode Scalability=1
+
+[report]

--- a/groups/media/auto/product.mk
+++ b/groups/media/auto/product.mk
@@ -42,6 +42,9 @@ BOARD_HAVE_OMX_SRC := true
 PRODUCT_PACKAGES += i965_drv_video
 PRODUCT_PACKAGES += libigfxcmrt
 
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/{{_extra_dir}}/igfx_user_feature_next.txt:vendor/etc/igfx_user_feature_next.txt
+
 # Open source hdcp
 PRODUCT_PACKAGES += libhdcpsdk
 PRODUCT_PACKAGES += lihdcpcommon


### PR DESCRIPTION
Scalability feature will cause gpu hang issue.
when run video cts of CtsMediaEncoderTestCases.

set the configs below in igfx_user_feature_next.txt
* Enable HCP Scalability Decode=0
* Disable Media Encode Scalability=1 
to disable Scalability feature.

Tracked-On: OAM-120515