### PR TITLE
Fix assumption fail for avc bitrate range

### DIFF
--- a/groups/codec2/true/media_codecs_intel_c2_video.xml
+++ b/groups/codec2/true/media_codecs_intel_c2_video.xml
@@ -126,6 +126,7 @@ and updated to vendor media codecs.
             <Limit name="bitrate" range="1-25000000" />
             <Limit name="performance-point-3840x2160" value="120" />
             <Limit name="performance-point-1920x1080" value="180" />
+            <Feature name="bitrate-modes" value="VBR,CBR" />
             <!--Feature name="intra-refresh" /-->
             <Diagnostics dumpOutput="false" />
         </MediaCodec>
@@ -140,6 +141,7 @@ and updated to vendor media codecs.
             <Limit name="bitrate" range="1-40000000" />
             <Limit name="performance-point-3840x2160" value="120" />
             <Limit name="performance-point-1920x1080" value="180" />
+            <Feature name="bitrate-modes" value="VBR,CBR" />
         </MediaCodec>
 {{/hw_ve_h265}}
 

--- a/groups/codec2/true/media_codecs_intel_c2_video.xml
+++ b/groups/codec2/true/media_codecs_intel_c2_video.xml
@@ -121,8 +121,8 @@ and updated to vendor media codecs.
             <Limit name="size" min="176x144" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
-            <Limit name="block-count" range="1-8192" /> <!-- max 2048x1024 -->
-            <Limit name="blocks-per-second" range="1-245760" />
+            <Limit name="block-count" range="1-65536" /> <!-- max 4096x4096 equivalent -->
+            <Limit name="blocks-per-second" range="1-1966080" />
             <Limit name="bitrate" range="1-25000000" />
             <Limit name="performance-point-3840x2160" value="120" />
             <Limit name="performance-point-1920x1080" value="180" />
@@ -137,6 +137,7 @@ and updated to vendor media codecs.
             <Limit name="size" min="176x144" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
+            <Limit name="block-count" range="1-245760" />
             <Limit name="blocks-per-second" range="1-972000" />
             <Limit name="bitrate" range="1-40000000" />
             <Limit name="performance-point-3840x2160" value="120" />

--- a/groups/codec2/true/media_codecs_intel_c2_video.xml
+++ b/groups/codec2/true/media_codecs_intel_c2_video.xml
@@ -123,7 +123,7 @@ and updated to vendor media codecs.
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-8192" /> <!-- max 2048x1024 -->
             <Limit name="blocks-per-second" range="1-245760" />
-            <Limit name="bitrate" range="1-12000000" />
+            <Limit name="bitrate" range="1-25000000" />
             <Limit name="performance-point-3840x2160" value="120" />
             <Limit name="performance-point-1920x1080" value="180" />
             <!--Feature name="intra-refresh" /-->


### PR DESCRIPTION
Cases:android.media.codec.cts.EncodeVirtualDisplayTest#testEncodeVirtualDisplay [1_c2.android.avc.encoder_AVCLevel31]

Tracked-On: OAM-122003