### PR TITLE
Update the min size of VP9 decoder for CTS assumptions.

### DIFF
--- a/groups/codec2/true/media_codecs_intel_c2_video.xml
+++ b/groups/codec2/true/media_codecs_intel_c2_video.xml
@@ -61,7 +61,7 @@ and updated to vendor media codecs.
 {{#hw_vd_vp9}}
         <MediaCodec name="c2.intel.vp9.decoder" type="video/x-vnd.on2.vp9">
             <Alias name="OMX.intel.vp9.decoder" /> <!--[WA]ijkplayer only knows the name starts with "OMX" -->
-            <Limit name="size" min="64x64" max="8192x8192" />
+            <Limit name="size" min="2x2" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-262144" />


### PR DESCRIPTION
The min size 64x64 limit CTs to run some testcase with small size videos. Update the size to keep aligned with SW VP9 decoder.

Tracked-On: OAM-122626