### PR TITLE
feat: Unlock device by default for development

### DIFF
--- a/groups/flashfiles/ini/flashfiles.ini
+++ b/groups/flashfiles/ini/flashfiles.ini
@@ -338,7 +338,7 @@ default = true
 
 [command.lock.lock]
 tool = fastboot
-args = flashing lock
+args = flashing unlock
 group = lock-device
 {{#acrn-guest}}
 timeout = 180000


### PR DESCRIPTION
- Unlocks the device by default to facilitate development and testing.
- Note: This change is intended for development purposes only and should not be merged into production branches.