### PR TITLE
Move optee prop settings to init.rc

### DIFF
--- a/groups/tee/optee/init.rc
+++ b/groups/tee/optee/init.rc
@@ -2,6 +2,10 @@ on init
     mkdir /mnt/vendor 0755 root root
     mkdir /mnt/vendor/persist 0771 system system
 
+on init && property:ro.boot.tee=optee
+    setprop ro.hardware.keystore optee
+    setprop ro.hardware.gatekeeper optee
+
 on post-fs
     chmod 666 /dev/tee0
     chmod 666 /dev/teepriv0

--- a/groups/tee/optee/product.mk
+++ b/groups/tee/optee/product.mk
@@ -9,8 +9,6 @@ PRODUCT_PACKAGES += \
 	android.hardware.security.keymint-service.optee \
 	wait_for_keymaster_optee
 
-PRODUCT_PROPERTY_OVERRIDES += \
-	ro.hardware.keystore=optee
 {{/hw_km}}
 
 {{^hw_km}}
@@ -20,7 +18,6 @@ PRODUCT_PACKAGES += android.hardware.security.keymint-service
 {{#hw_gk}}
 # optee gatekeeper
 PRODUCT_PACKAGES += android.hardware.gatekeeper@1.0-service.optee
-PRODUCT_PROPERTY_OVERRIDES += ro.hardware.gatekeeper=optee
 {{/hw_gk}}
 
 {{^hw_gk}}


### PR DESCRIPTION
To support one aaos image, move optee prop settings to init.rc ro.boot.tee will be passed by acrn if needed

Tracked-On: OAM-124398