### PR TITLE
mixin: Add gpt.ini to flashfiles images

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -96,6 +96,7 @@ DEVICE_PACKAGE_OVERLAYS += $(INTEL_PATH_HARDWARE)/bootctrl/boot/overlay
 BOARD_GPT_BIN = $(PRODUCT_OUT)/gpt.bin
 BOARD_FLASHFILES += $(BOARD_GPT_BIN):gpt.bin
 INSTALLED_RADIOIMAGE_TARGET += $(BOARD_GPT_BIN)
+BOARD_FLASHFILES += device/intel/project-celadon/$(TARGET_PRODUCT)/gpt.ini
 
 # We offer the possibility to flash from a USB storage device using
 # the "installer" EFI application

--- a/groups/flashfiles/ini/flashfiles.ini
+++ b/groups/flashfiles/ini/flashfiles.ini
@@ -50,7 +50,7 @@ sets = unlock partition {{#bootloader}}bootloader {{/bootloader}}erase format fl
 sets = unlock partition {{#bootloader}}bootloader {{/bootloader}}erase format flash configure reboot2usfb
 {{/super_img_in_flashzip}}
 {{/dynamic-partitions}}
-additional-files += provdatazip:installer.efi provdatazip:startup.nsh{{^slot-ab}} images:cache.img{{/slot-ab}} provdatazip:LICENSE
+additional-files += provdatazip:installer.efi provdatazip:startup.nsh{{^slot-ab}} images:cache.img{{/slot-ab}} provdatazip:LICENSE provdatazip:gpt.ini
 enable = {{{installer}}}
 
 {{^mfgos}}


### PR DESCRIPTION
The gpt.ini file is a GPT configuration file used
during the Android flashing process in the SOS environment. Each build may have different partition tables.
We need these GPT files to prevent flashing failures

Test Done:
make flashfiles use_tar=true
Flash and boot success

Tracked-On: OAM-124426