### PR TITLE
Remove TEE from the OTA partition list

### DIFF
--- a/groups/tee/optee/BoardConfig.mk
+++ b/groups/tee/optee/BoardConfig.mk
@@ -17,7 +17,5 @@ TARGET_USE_OPTEE := true
 TARGET_USE_IVSHMEM := true
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/tee/optee
 
-AB_OTA_PARTITIONS += tee
-
 include vendor/intel/optee/optee_client/optee_client.device.mk
 $(call soong_config_set,optee_client,cfg_tee_fs_parent_path,/mnt/vendor/persist/tee)


### PR DESCRIPTION
There is no TEE specific partition for base_aaos and aaos_iasw now, tee image is put into the SOS file
system. Need to remove tee from OTA partition list, or the OTA may fail since it cannot find the tee partition.

Tracked-On: OAM-124783