### PR TITLE
Enable Android Desktop mode by default

### DIFF
--- a/groups/device-type/tablet/option.spec
+++ b/groups/device-type/tablet/option.spec
@@ -1,2 +1,2 @@
 [defaults]
-tablet_core_hardware_path = frameworks/native/data/etc
+pc_core_hardware_path = frameworks/native/data/etc

--- a/groups/device-type/tablet/product.mk
+++ b/groups/device-type/tablet/product.mk
@@ -1,5 +1,8 @@
-PRODUCT_CHARACTERISTICS := tablet
+PRODUCT_CHARACTERISTICS := pc
 
 PRODUCT_COPY_FILES += \
-        {{{tablet_core_hardware_path}}}/tablet_core_hardware.xml:vendor/etc/permissions/tablet_core_hardware.xml
+        {{{pc_core_hardware_path}}}/pc_core_hardware.xml:vendor/etc/permissions/pc_core_hardware.xml
+
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.freeform_window_management.xml:vendor/etc/permissions/android.software.freeform_window_management.xml
 


### PR DESCRIPTION
This patch will enable desktop mode by default on
Android 15. The device when launched will enable
freeform windowing mode by default.

Tests Done: Build and boot. Open Gallery to see
	if it opens in freeform mode.

Tracked-On: NA