### PR TITLE
Support for Multi-Passenger feature.

### DIFF
--- a/groups/multi-passenger/doc.spec
+++ b/groups/multi-passenger/doc.spec
@@ -1,0 +1,15 @@
+=== Overview
+
+this group is used for enabling multi-passenger feature
+
+==== Options
+
+--- true
+Will enable multi-passenger
+
+--- false
+Will disable multi-passenger
+
+--- default
+when not explicitly selected in mixin spec file, the default option will be used.
+

--- a/groups/multi-passenger/true/display_settings.xml
+++ b/groups/multi-passenger/true/display_settings.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<display-settings>
+<!-- Use physical port number instead of local id -->
+<config identifier="1" />
+
+<!-- Display settings for 1st Home -->
+<display name="port:1"
+    shouldShowSystemDecors="true"
+    shouldShowIme="true" />
+
+<!-- Display settings for 2nd Home -->
+<display name="port:2"
+    shouldShowSystemDecors="true"
+    shouldShowIme="true" />
+
+<!-- Display settings for 3rd Home -->
+<display name="port:3"
+    shouldShowSystemDecors="true"
+    shouldShowIme="true" />
+
+<!-- Display settings for 4th Home -->
+<display name="port:4"
+    shouldShowSystemDecors="true"
+    shouldShowIme="true" />
+
+</display-settings>

--- a/groups/multi-passenger/true/files.spec
+++ b/groups/multi-passenger/true/files.spec
@@ -1,0 +1,4 @@
+[devicefiles]
+overlay-multi_passenger : "multi-passenger overlay configuration"
+display_settings.xml: "display configuration for secondary display"
+

--- a/groups/multi-passenger/true/overlay-multi_passenger/frameworks/base/core/res/res/values/config.xml
+++ b/groups/multi-passenger/true/overlay-multi_passenger/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate.
+
+     NOTE: The naming convention is "config_camelCaseValue". Some legacy
+     entries do not follow the convention, but all new entries should. -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Whether the system enables per-display focus. If the system has the input method for each
+         display, this value should be true. -->
+    <bool name="config_perDisplayFocusEnabled">true</bool>
+
+    <!--  Maximum number of supported users -->
+    <integer name="config_multiuserMaximumUsers">10</integer>
+
+    <!-- Maximum number of users we allow to be running at a time -->
+    <integer name="config_multiuserMaxRunningUsers">5</integer>
+
+    <!-- True if the device supports system decorations on secondary displays. -->
+    <bool name="config_supportsSystemDecorsOnSecondaryDisplays">true</bool>
+    <!-- This is the default launcher package with an activity to use on secondary displays that
+         support system decorations.
+         This launcher package must have an activity that supports multiple instances and has
+         corresponding launch mode set in AndroidManifest.
+         {@see android.view.Display#FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS} -->
+    <string name="config_secondaryHomePackage" translatable="false">com.android.car.multidisplay</string>
+    <!-- Whether to only install system packages on a user if they're whitelisted for that user
+         type. These are flags and can be freely combined.
+         0  - disable whitelist (install all system packages; no logging)
+         1  - enforce (only install system packages if they are whitelisted)
+         2  - log (log non-whitelisted packages)
+         4  - any package not mentioned in the whitelist file is implicitly whitelisted on all users
+         8  - same as 4, but just for the SYSTEM user
+         16 - ignore OTAs (don't install system packages during OTAs)
+         Common scenarios:
+          - to enable feature (fully enforced) for a complete whitelist: 1
+          - to enable feature for an incomplete whitelist (so use implicit whitelist mode): 5
+          - to enable feature but implicitly whitelist for SYSTEM user to ease local development: 9
+          - to disable feature completely if it had never been enabled: 16
+          - to henceforth disable feature and try to undo its previous effects: 0
+        Note: This list must be kept current with PACKAGE_WHITELIST_MODE_PROP in
+        frameworks/base/services/core/java/com/android/server/pm/UserSystemPackageInstaller.java
+        Package whitelist disabled for testing profile user as default whitelist does not
+        support PROFILE user. -->
+    <integer name="config_userTypePackageWhitelistMode">2</integer>
+
+    <!-- Whether the device allows users to start in background visible on displays.
+         Should be false for most devices, except automotive vehicle with passenger displays. -->
+    <bool name="config_multiuserVisibleBackgroundUsers">true</bool>
+
+    <!-- Enable multi-user IME sessions -->
+    <string translatable="false" name="config_deviceSpecificInputMethodManagerService">com.android.server.inputmethod.InputMethodManagerServiceProxy$Lifecycle</string>
+    <!-- Disable hidding the NavBars (CarSystemBars), as a workaround for b/259604616 -->
+    <bool name="config_hideNavBarForKeyboard">false</bool>
+
+</resources>

--- a/groups/multi-passenger/true/overlay-multi_passenger/frameworks/base/core/res/res/xml/config_user_types.xml
+++ b/groups/multi-passenger/true/overlay-multi_passenger/frameworks/base/core/res/res/xml/config_user_types.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2019 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<user-types>
+    <full-type name="android.os.usertype.full.GUEST"
+        max-allowed="3" >
+        <default-restrictions no_factory_reset="true" no_remove_user="true"
+                  no_modify_accounts="true" no_install_apps="true" no_install_unknown_sources="true"
+                  no_uninstall_apps="true"/>
+    </full-type>
+
+    <profile-type name="android.os.usertype.profile.CLONE"
+        enabled='0' >
+    </profile-type>
+</user-types>
+

--- a/groups/multi-passenger/true/product.mk
+++ b/groups/multi-passenger/true/product.mk
@@ -1,0 +1,14 @@
+# enables the rro package for passenger(secondary) user.
+ENABLE_PASSENGER_SYSTEMUI_RRO := true
+
+PRODUCT_PACKAGES += CarServiceMultiDisplayOverlay \
+                    MultiDisplaySecondaryHomeTestLauncher
+
+PRODUCT_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay-multi_passenger
+
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.managed_users.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.managed_users.xml
+
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/display_settings.xml:$(TARGET_COPY_OUT_VENDOR)/etc/display_settings.xml
+


### PR DESCRIPTION
Enabling all the configuration for multi-passenger feature support.

Tests-: Connect 2 display with device and reboot.
it is showing multidisplay launcher on second screen and both the displays, users are able to use concurrently.

Tracked-On: OAM-125141