### PR TITLE
Add sha256 hash_algorithm which is used by AVB for DLKM partitions

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -48,6 +48,12 @@ BOARD_SYSTEM_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 TARGET_COPY_OUT_SYSTEM_DLKM := system_dlkm
 AB_OTA_PARTITIONS += system_dlkm
 
+# Enabled chained vbmeta for system_dlkm
+BOARD_AVB_VBMETA_SYSTEM_DLKM := system_dlkm
+BOARD_AVB_VBMETA_SYSTEM_DLKM_KEY_PATH := external/avb/test/data/testkey_rsa4096.pem
+BOARD_AVB_VBMETA_SYSTEM_DLKM_ALGORITHM := SHA256_RSA4096
+BOARD_AVB_SYSTEM_DLKM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
+
 #fastbootd over ethernet support
 TARGET_RECOVERY_UI_LIB:=librecovery_ui_ethernet
 

--- a/groups/odm-partition/true/BoardConfig.mk
+++ b/groups/odm-partition/true/BoardConfig.mk
@@ -8,6 +8,7 @@ ODM_PARTITION_SIZE := $(shell echo {{partition_size}}*1048576 | bc)
 BOARD_USES_ODM_DLKMIMAGE := true
 BOARD_ODM_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 TARGET_COPY_OUT_ODM_DLKM := odm_dlkm
+BOARD_AVB_ODM_DLKM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
 
 {{^dynamic-partitions}}
 BOARD_ODMIMAGE_PARTITION_SIZE := $(ODM_PARTITION_SIZE)

--- a/groups/vendor-partition/true/BoardConfig.mk
+++ b/groups/vendor-partition/true/BoardConfig.mk
@@ -9,6 +9,12 @@ BOARD_USES_VENDOR_DLKMIMAGE := true
 BOARD_VENDOR_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 TARGET_COPY_OUT_VENDOR_DLKM := vendor_dlkm
 
+# Enabled chained vbmeta for vendor_dlkm
+BOARD_AVB_VBMETA_VENDOR_DLKM := vendor_dlkm
+BOARD_AVB_VBMETA_VENDOR_DLKM_KEY_PATH :=  external/avb/test/data/testkey_rsa4096.pem
+BOARD_AVB_VBMETA_VENDOR_DLKM_ALGORITHM := SHA256_RSA4096
+BOARD_AVB_VENDOR_DLKM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
+
 {{^dynamic-partitions}}
 BOARD_VENDORIMAGE_PARTITION_SIZE := $(VENDOR_PARTITION_SIZE)
 {{/dynamic-partitions}}


### PR DESCRIPTION
Default AVB hash_algorithm is SHA1 which is not allowed by XTS

Test Done:
1. boot
2. VTS vts_security_avb_test and vts_dlkm_partition_test
3. CTS CtsNativeVerifiedBootTestCases

Tracked-On: OAM-125595