### PR TITLE
Fix trace error caused by wifi modules

### DIFF
--- a/groups/wlan/iwlwifi/init.rc
+++ b/groups/wlan/iwlwifi/init.rc
@@ -37,7 +37,7 @@ service iprenew_p2p /system/bin/dhcpcd -n
 
 service load_iwl_modules /vendor/bin/load_iwl_modules.sh
     user system
-    group system shell
+    group system shell readtracefs
     capabilities SYS_MODULE MKNOD
     oneshot
     disabled


### PR DESCRIPTION
This is a regession issue that caused by commit: c7bb847c504bcc "Load mac80211 module based on iwl7000_mac80211 module existence" . The reason is that wifi modules need to be in readtracefs group
to access trace node in /sys/kernel/debug/. This patch adds readtracefs group for this service.

Tracked-On: OAM-125337