### PR TITLE
Fix BT crash due to BT audio HAL dependency

### DIFF
--- a/groups/bluetooth/btusb/product.mk
+++ b/groups/bluetooth/btusb/product.mk
@@ -6,7 +6,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PROPERTY_OVERRIDES += bluetooth.rfkill=1
 
 PRODUCT_PACKAGES += \
-    android.hardware.bluetooth-service.default.vbt 
+{{#ivi}}
+    android.hardware.bluetooth.audio-impl \
+{{/ivi}}
+    android.hardware.bluetooth-service.default.vbt
 
 {{#ivi}}
 PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/bluetooth/overlay-car


### PR DESCRIPTION
Bluetooth LE Audio profiles requires Bluetooth Audio AIDL HAL to be present for successful initialization. This is causing continuous BT crash.

Add Bluetooth Audio AIDL HAL as part of btusb product.mk for successful BT LE Audio profile initialization. Now BT works fine. This is required only for base aaos builds (ivi), as audio is still hidl.

Tests done:
1. Flash AAOS
2. Check BT on/off success

Tracked-On: OAM-126100