### PR TITLE
Remove support for zygote32 and dex2oat32

### DIFF
--- a/groups/device-specific/caas/caas.mk
+++ b/groups/device-specific/caas/caas.mk
@@ -23,8 +23,8 @@ PRODUCT_FULL_TREBLE_OVERRIDE := true
 PRODUCT_FULL_TREBLE_OVERRIDE := false
 {{/treble}}
 
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.zygote=zygote64_32
-PRODUCT_COPY_FILES += system/core/rootdir/init.zygote64_32.rc:root/init.zygote64_32.rc
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.zygote=zygote64
+PRODUCT_COPY_FILES += system/core/rootdir/init.zygote64.rc:root/init.zygote64.rc
 
 BOARD_USE_64BIT_USERSPACE := true
 
@@ -49,7 +49,7 @@ _board_config_mk := $(shell find $(dir $(current_product_makefile)) -maxdepth 2 
 TARGET_DEVICE := $(shell basename $(TARGET_DEVICE_DIR))
 
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit_only.mk)
 $(call inherit-product, $(LOCAL_PATH)/device.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/window_extensions.mk)
 


### PR DESCRIPTION
Since we are not supporting 32bit anymore we need
to remove zygote32 and since 32bit abi is removed
dex2oat32 is not getting generated.

With this patch dex2oat64 will get generated and zygote32 support is completely removed. This should give overall performace boost.

Tests Done: build and boot

Tracked-On: OAM-126135