### PR TITLE
Merge bsp_diff patches of iasw and base

### DIFF
--- a/groups/camera-ext/aaos_iasw/BoardConfig.mk
+++ b/groups/camera-ext/aaos_iasw/BoardConfig.mk
@@ -1,0 +1,4 @@
+BOARD_CAMERA_USB_STANDALONE = true
+
+# SELinux support for USB camera
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/camera-ext/ivi

--- a/groups/camera-ext/aaos_iasw/files.spec
+++ b/groups/camera-ext/aaos_iasw/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+ivi_camera_config.xml: "ivihal camera parameters"

--- a/groups/camera-ext/aaos_iasw/ivi_camera_config.xml
+++ b/groups/camera-ext/aaos_iasw/ivi_camera_config.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<IVICamera platform="ivi_config_1">
+    <Provider>
+        <CameraIdOffset>0</CameraIdOffset>
+        <CaptureManager>disable</CaptureManager>
+        <ignore> <!-- Internal video devices to be ignored by external camera HAL -->
+            <!--
+            <id>5</id>
+            <id>6</id>
+            <id>7</id>
+            -->
+        </ignore>
+    </Provider>
+    <!-- See ExternalCameraUtils.cpp for default values of Device configurations below
+    <Device>
+        <Path>/dev/video0</Path>
+        <Driver>intel-ipu6-isys</Driver>
+        <NumVideoBuffers count="2"/>
+        <NumStillBuffers count="2"/>
+        <Setting width="1920" height="1080" fps="30" format="UYVY"/>
+        <Bind>
+            <VirtId>10</VirtId>
+        </Bind>
+    </Device>
+-->
+    <Device>
+        <Path>/dev/video1</Path>
+        <Driver>intel-ipu6-isys</Driver>
+        <NumVideoBuffers count="2"/>
+        <NumStillBuffers count="2"/>
+        <Setting width="1920" height="1080" fps="30" format="UYVY"/>
+        <Bind>
+            <VirtId>11</VirtId>
+            <VirtId>12</VirtId>
+        </Bind>
+    </Device>
+    <!--
+    <Device>
+        <Path>/dev/video5</Path>
+        <Driver>uvcvideo</Driver>
+        <NumVideoBuffers count="2"/>
+        <NumStillBuffers count="2"/>
+        <Setting width="1920" height="1080" fps="30" format="YUYV"/>
+        <Bind>
+            <VirtId>13</VirtId>
+        </Bind>
+    </Device>
+    -->
+
+    <Loopback>
+        <PairId>50</PairId>
+        <SrcCamera>/dev/video1</SrcCamera>
+        <Driver>v4l2 loopback</Driver>
+        <Setting width="1920" height="1080" fps="30" format="UYVY"/>
+    </Loopback>
+
+    <MediaCtlConfig id="1" platform="ivi_config_1">
+        <!-- IPU sensors -->
+        <format name="max9295a_dummy" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="max926717f_dummy" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <format name="max96722" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="max96722" pad="1" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="max96722" pad="4" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <format name="Intel IPU6 CSI-2 1" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="Intel IPU6 CSI-2 1" pad="1" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <format name="Intel IPU6 CSI2 BE SOC 0" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="Intel IPU6 CSI2 BE SOC 0" pad="1" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="Intel IPU6 CSI2 BE SOC 0" pad="2" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <format name="Intel IPU6 BE SOC capture 0" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="Intel IPU6 BE SOC capture 1" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <!-- DPIN -->
+
+        <link srcName="max96717f_dummy" srcPad="0" sinkName="max96722" sinkPad="0" enable="true"/>
+        <link srcName="max9295a_dummy" srcPad="0" sinkName="max96722" sinkPad="1" enable="true"/>
+        <link srcName="max96722" srcPad="4" sinkName="Intel IPU6 CSI-2 1" sinkPad="0" enable="true"/>
+
+        <link srcName="Intel IPU6 CSI-2 1" srcPad="1" sinkName="Intel IPU6 CSI2 BE SOC 0" sinkPad="0" enable="true"/>
+
+        <link srcName="Intel IPU6 CSI2 BE SOC 0" srcPad="2" sinkName="Intel IPU6 BE SOC capture 1" sinkPad="0" enable="true"/>
+        <link srcName="Intel IPU6 CSI2 BE SOC 0" srcPad="1" sinkName="Intel IPU6 BE SOC capture 0" sinkPad="0" enable="true"/>
+
+    </MediaCtlConfig>
+</IVICamera>

--- a/groups/camera-ext/aaos_iasw/product.mk
+++ b/groups/camera-ext/aaos_iasw/product.mk
@@ -1,0 +1,17 @@
+# Camera: Device-specific configuration files.
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.camera.autofocus.xml:vendor/etc/permissions/android.hardware.camera.autofocus.xml \
+    frameworks/native/data/etc/android.hardware.camera.xml:vendor/etc/permissions/android.hardware.camera.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/ivi_camera_config.xml:vendor/etc/ivi_camera_config.xml
+
+# External camera service
+
+PRODUCT_PACKAGES += android.iacamera.provider@2.4-ivi-service \
+                    android.ia.hardware.camera.provider@2.4-ivi \
+                    android.hardware.camera.provider@2.4-impl-ia
+
+PRODUCT_PACKAGES += android.ia.hardware.camera.provider-ivi \
+					android.iacamera.provider-ivi-service
+
+PRODUCT_PACKAGES += Camera2
+PRODUCT_PACKAGES += MultiCameraApp

--- a/groups/camera-ext/aaos_iasw/ueventd.rc
+++ b/groups/camera-ext/aaos_iasw/ueventd.rc
@@ -1,0 +1,2 @@
+# Camera
+/dev/video*       0660  system  camera

--- a/groups/camera-ext/base_aaos/BoardConfig.mk
+++ b/groups/camera-ext/base_aaos/BoardConfig.mk
@@ -1,0 +1,4 @@
+BOARD_CAMERA_USB_STANDALONE = true
+
+# SELinux support for USB camera
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/camera-ext/ivi

--- a/groups/camera-ext/base_aaos/files.spec
+++ b/groups/camera-ext/base_aaos/files.spec
@@ -1,0 +1,2 @@
+[extrafiles]
+ivi_camera_config.xml: "ivihal camera parameters"

--- a/groups/camera-ext/base_aaos/ivi_camera_config.xml
+++ b/groups/camera-ext/base_aaos/ivi_camera_config.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<IVICamera platform="ivi_config_1">
+    <Provider>
+        <CameraIdOffset>0</CameraIdOffset>
+        <CaptureManager>disable</CaptureManager>
+        <ignore> <!-- Internal video devices to be ignored by external camera HAL -->
+            <id>1</id>
+            <id>2</id>
+            <id>3</id>
+        </ignore>
+    </Provider>
+    <!-- See ExternalCameraUtils.cpp for default values of Device configurations below
+    <Device>
+        <Path>/dev/video0</Path>
+        <Driver>intel-ipu6-isys</Driver>
+        <NumVideoBuffers count="2"/>
+        <NumStillBuffers count="2"/>
+        <Setting width="1920" height="1080" fps="30" format="UYVY"/>
+        <Bind>
+            <VirtId>10</VirtId>
+        </Bind>
+    </Device>
+-->
+    <Device>
+        <Path>/dev/video1</Path>
+        <Driver>intel-ipu6-isys</Driver>
+        <NumVideoBuffers count="2"/>
+        <NumStillBuffers count="2"/>
+        <Setting width="1920" height="1080" fps="30" format="UYVY"/>
+        <Bind>
+            <VirtId>11</VirtId>
+            <VirtId>12</VirtId>
+        </Bind>
+    </Device>
+    <!--
+    <Device>
+        <Path>/dev/video5</Path>
+        <Driver>uvcvideo</Driver>
+        <NumVideoBuffers count="2"/>
+        <NumStillBuffers count="2"/>
+        <Setting width="1920" height="1080" fps="30" format="YUYV"/>
+        <Bind>
+            <VirtId>13</VirtId>
+        </Bind>
+    </Device>
+    -->
+
+    <Loopback>
+        <PairId>50</PairId>
+        <SrcCamera>/dev/video1</SrcCamera>
+        <Driver>v4l2 loopback</Driver>
+        <Setting width="1920" height="1080" fps="30" format="UYVY"/>
+    </Loopback>
+
+    <MediaCtlConfig id="1" platform="ivi_config_1">
+        <!-- IPU sensors -->
+        <format name="max9295a_dummy" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="max926717f_dummy" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <format name="max96722" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="max96722" pad="1" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="max96722" pad="4" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <format name="Intel IPU6 CSI-2 1" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="Intel IPU6 CSI-2 1" pad="1" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <format name="Intel IPU6 CSI2 BE SOC 0" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="Intel IPU6 CSI2 BE SOC 0" pad="1" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="Intel IPU6 CSI2 BE SOC 0" pad="2" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <format name="Intel IPU6 BE SOC capture 0" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+        <format name="Intel IPU6 BE SOC capture 1" pad="0" width="1920" height="1080" format="V4L2_MBUS_FMT_UYVY8_1X16"/>
+
+        <!-- DPIN -->
+
+        <link srcName="max96717f_dummy" srcPad="0" sinkName="max96722" sinkPad="0" enable="true"/>
+        <link srcName="max9295a_dummy" srcPad="0" sinkName="max96722" sinkPad="1" enable="true"/>
+        <link srcName="max96722" srcPad="4" sinkName="Intel IPU6 CSI-2 1" sinkPad="0" enable="true"/>
+
+        <link srcName="Intel IPU6 CSI-2 1" srcPad="1" sinkName="Intel IPU6 CSI2 BE SOC 0" sinkPad="0" enable="true"/>
+
+        <link srcName="Intel IPU6 CSI2 BE SOC 0" srcPad="2" sinkName="Intel IPU6 BE SOC capture 1" sinkPad="0" enable="true"/>
+        <link srcName="Intel IPU6 CSI2 BE SOC 0" srcPad="1" sinkName="Intel IPU6 BE SOC capture 0" sinkPad="0" enable="true"/>
+
+    </MediaCtlConfig>
+</IVICamera>

--- a/groups/camera-ext/base_aaos/product.mk
+++ b/groups/camera-ext/base_aaos/product.mk
@@ -1,0 +1,16 @@
+# Camera: Device-specific configuration files.
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.camera.xml:vendor/etc/permissions/android.hardware.camera.xml \
+    $(LOCAL_PATH)/{{_extra_dir}}/ivi_camera_config.xml:vendor/etc/ivi_camera_config.xml
+
+# External camera service
+
+PRODUCT_PACKAGES += android.iacamera.provider@2.4-ivi-service \
+                    android.ia.hardware.camera.provider@2.4-ivi \
+                    android.hardware.camera.provider@2.4-impl-ia
+
+PRODUCT_PACKAGES += android.ia.hardware.camera.provider-ivi \
+					android.iacamera.provider-ivi-service
+
+PRODUCT_PACKAGES += Camera2
+PRODUCT_PACKAGES += MultiCameraApp

--- a/groups/camera-ext/base_aaos/ueventd.rc
+++ b/groups/camera-ext/base_aaos/ueventd.rc
@@ -1,0 +1,2 @@
+# Camera
+/dev/video*       0660  system  camera


### PR DESCRIPTION
Issue Detailed: Too many bsp_diff patches to enable camera hal of both base_aaos and iasw.

Issue Fixed: Merge the diff patches in this repo. Other two related prs are in Sepolicy and mixins.spec.

Tested-On: camera preview/capture/record in base_aaos and iasw images.

Tracked-On: OAM-125158