### PR TITLE
Config no_outgoing_calls and sms as false for default user

### DIFF
--- a/groups/multi-passenger/true/overlay-multi_passenger/frameworks/base/core/res/res/xml/config_user_types.xml
+++ b/groups/multi-passenger/true/overlay-multi_passenger/frameworks/base/core/res/res/xml/config_user_types.xml
@@ -15,6 +15,10 @@
 -->
 
 <user-types>
+    <full-type name="android.os.usertype.full.SECONDARY" >
+        <default-restrictions no_sms="false" no_outgoing_calls="false"/>
+    </full-type>
+
     <full-type name="android.os.usertype.full.GUEST"
         max-allowed="3" >
         <default-restrictions no_factory_reset="true" no_remove_user="true"


### PR DESCRIPTION
When enable Multi-passenger, the user restriction will block out going call and sms, which will block BT HFP call test. Make the default user restriction as "no_sms=false, no_outgoing_calls=false" then we can test sms and phone call on any user.

Tests:
BT HFP call can work.

Tracked-On: OAM-125172