### PR TITLE
Add test kernel module for system and odm DLKM partition

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -216,3 +216,6 @@ ENABLE_GRUB_INSTALLER ?= true
 {{/use_cic}}
 
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/soc
+
+BOARD_SYSTEM_KERNEL_MODULES := kernel/prebuilts/6.1/x86_64/pppox.ko
+BOARD_ODM_KERNEL_MODULES  := kernel/prebuilts/6.1/x86_64/pppox.ko


### PR DESCRIPTION
The vts_dlkm_partition_test vts test case will check if
 “/<system/odm>/lib/modules” is a symlink to
 “/<system/odm>_dlkm/lib/modules. If there is no module
in the partition, symlink will not be created.
So this is a WA patch to pass the VTS. The WA patch can be removed if enable GKI on X86 platform.

Test Done:
Boot
vts_dlkm_partition_test

Tracked-On: OAM-126048