### PR TITLE
Add out going call rights to the system user

### DIFF
--- a/groups/multi-passenger/true/overlay-multi_passenger/frameworks/base/core/res/res/xml/config_user_types.xml
+++ b/groups/multi-passenger/true/overlay-multi_passenger/frameworks/base/core/res/res/xml/config_user_types.xml
@@ -22,6 +22,10 @@
                   no_uninstall_apps="true"/>
     </full-type>
 
+    <system-type name="android.os.usertype.system.HEADLESS" >
+	 <default-restrictions no_sms="false" no_outgoing_calls="false"/>
+    </system-type>
+
     <profile-type name="android.os.usertype.profile.CLONE"
         enabled='0' >
     </profile-type>


### PR DESCRIPTION
When enable Multi-passenger, the user restriction will block out going call and sms, which will block BT HFP call test. Make the default user restriction as "no_sms=false, no_outgoing_calls=false" then we can test sms and phone call on any user.

Tests:
BT HFP call can work.

Tracked-On: OAM-125172