### PR TITLE
Moving Embargoed target list out of mixins

### DIFF
--- a/mixin-update
+++ b/mixin-update
@@ -41,6 +41,7 @@ class Configurer:
     EXEMPT_FN = "exempt_groups.txt"
     RULE_FN = "new_group_creation_rule.txt"
     VALID_TARGETS_FN = "valid_targets.spec"
+    EMBARGOED_VALID_TARGETS_FN = "../../../vendor/intel/utils_priv/embargoed_valid_targets.spec"
     SCRIPT_FN = "mixin-update"
     VERSION = "3.2.3"
 
@@ -1287,20 +1288,27 @@ class Updater(FileHelper):
         self.debug("Pass")
         return retval
 
+def get_valid_target_list(fn, ret):
+    valid_targets = ""
+    cp = Parser().read_spec_file(fn)
+    for platform in cp.sections():
+        for target in cp.options(platform):
+            valid_targets += "{} ".format(target)
+            sf = os.path.join(Configurer.INTERNAL_DEVICE_DIR, platform, target, Configurer.PRODUCT_SPEC_FN)
+            if os.path.exists(sf):
+                ret.append(sf)
+    return valid_targets
 
 def get_valid_spec_files_and_targets():
     fn = os.path.join(os.path.dirname(sys.argv[0]), Configurer.VALID_TARGETS_FN)
+    emb_fn = os.path.join(os.path.dirname(sys.argv[0]), Configurer.EMBARGOED_VALID_TARGETS_FN)
     dlines = []
     ret = []
     valid_targets = ""
     if os.path.exists(fn):
-        cp = Parser().read_spec_file(fn)
-        for platform in cp.sections():
-            for target in cp.options(platform):
-                valid_targets += "{} ".format(target)
-                sf = os.path.join(Configurer.INTERNAL_DEVICE_DIR, platform, target, Configurer.PRODUCT_SPEC_FN)
-                if os.path.exists(sf):
-                    ret.append(sf)
+        valid_targets += get_valid_target_list(fn, ret)
+        if os.path.exists(emb_fn):
+            valid_targets += get_valid_target_list(emb_fn, ret)
     else:
         for root, dirs, files in os.walk("device"):
             if Configurer.PRODUCT_SPEC_FN in files:

--- a/valid_targets.spec
+++ b/valid_targets.spec
@@ -1,5 +1,2 @@
 [project-celadon]
-base_aaos:
 caas:
-aaos_iasw:
-celadon_desktop:


### PR DESCRIPTION
This patch will move the embargoed list out of mixins and will read the list from embargoed repo if exists.

Tests Done: source and lunch

Tracked-On: OAM-126496