### PR TITLE
Enable multipane by default in A15

### DIFF
--- a/groups/device-specific/caas/product.mk
+++ b/groups/device-specific/caas/product.mk
@@ -36,6 +36,7 @@ PRODUCT_PROPERTY_OVERRIDES += ro.control_privapp_permissions=enforce
 PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.useautofastjni=true
 PRODUCT_PRODUCT_PROPERTIES += persist.adb.tcp.port=5555
 PRODUCT_PRODUCT_PROPERTIES += persist.sys.fuse.bpf.enable=true
+PRODUCT_PRODUCT_PROPERTIES += persist.settings.large_screen_opt.enabled=true
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.crypto.volume.metadata.method=dm-default-key \


### PR DESCRIPTION
From A15 onwards Settings large-screen optimization is disabled by default for performance reasons. It can be explicitly enabled by setting the property
persist.settings.large_screen_opt.enabled.

Tests Done: Settings App opens in multi-pane mode

Tracked-On: OAM-126515