### PR TITLE
add 2 more pcms for different context

### DIFF
--- a/groups/multi-passenger/true/audio/audio_hal_configuration.xml
+++ b/groups/multi-passenger/true/audio/audio_hal_configuration.xml
@@ -11,16 +11,13 @@
     <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
   </Stream>
   <Stream Address="bus1_navigation_out" Direction="playback" Mmap="false">
-    <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
-  </Stream>
-  <Stream Address="bus2_voice_command_out" Direction="playback" Mmap="false">
-    <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
+    <Pcm Card="SoundCard" Device="5" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
   </Stream>
   <Stream Address="bus3_call_ring_out" Direction="playback" Mmap="false">
-    <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
+    <Pcm Card="SoundCard" Device="6" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
   </Stream>
   <Stream Address="bus4_call_out" Direction="playback" Mmap="false">
-    <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
+    <Pcm Card="SoundCard" Device="6" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
   </Stream>
   <Stream Address="Built-In Mic" Direction="capture" Mmap="false">
     <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="960" PeriodCount="4" StartThreshhold="1" StopThreshold="3840" AdditionalOutputDeviceDelay="5"/>

--- a/groups/multi-passenger/true/audio/audio_policy_configuration_attached_devices.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration_attached_devices.xml
@@ -17,7 +17,6 @@
     <!-- One bus per context -->
     <item>bus0_media_out</item>
     <item>bus1_navigation_out</item>
-    <item>bus2_voice_command_out</item>
     <item>bus3_call_ring_out</item>
     <item>bus4_call_out</item>
 

--- a/groups/multi-passenger/true/audio/audio_policy_configuration_devices.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration_devices.xml
@@ -35,16 +35,6 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus2_voice_command_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus2_voice_command_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
     <devicePort tagName="bus3_call_ring_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
                 address="bus3_call_ring_out">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"

--- a/groups/multi-passenger/true/audio/audio_policy_configuration_mixports.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration_mixports.xml
@@ -25,11 +25,6 @@
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
     </mixPort>
-    <mixPort name="mixport_bus2_voice_command_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
     <mixPort name="mixport_bus3_call_ring_out" role="source">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"

--- a/groups/multi-passenger/true/audio/audio_policy_configuration_routes.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration_routes.xml
@@ -32,8 +32,6 @@
 
     <route type="mix" sink="bus0_media_out" sources="mixport_bus0_media_out"/>
     <route type="mix" sink="bus1_navigation_out" sources="mixport_bus1_navigation_out"/>
-    <route type="mix" sink="bus2_voice_command_out"
-           sources="mixport_bus2_voice_command_out"/>
     <route type="mix" sink="bus3_call_ring_out" sources="mixport_bus3_call_ring_out"/>
     <route type="mix" sink="bus4_call_out" sources="mixport_bus4_call_out"/>
 

--- a/groups/multi-passenger/true/audio/car_audio_configuration.xml
+++ b/groups/multi-passenger/true/audio/car_audio_configuration.xml
@@ -40,8 +40,6 @@
                 <group>
                     <device address="bus1_navigation_out">
                         <context context="navigation"/>
-                    </device>
-                    <device address="bus2_voice_command_out">
                         <context context="voice_command"/>
                     </device>
                 </group>


### PR DESCRIPTION
poc and mbl rvp should use one pcm for all the contexts as there is only one pcm devices.

Tracked-On: OAM-126362