### PR TITLE
Fix for hardware codec not used

### DIFF
--- a/groups/media/auto/product.mk
+++ b/groups/media/auto/product.mk
@@ -5,12 +5,13 @@ PRODUCT_PACKAGES += \
 
 # Media SDK and OMX IL components
 PRODUCT_PACKAGES += \
-    libmfx_omx_core
+    libmfx_omx_core \
+    libmfx_omx_components_hw
+{{/enable_msdk_omx}}
 
 {{#add_hw_msdk}}
 # MediaSDK library
 PRODUCT_PACKAGES += \
-    libmfx_omx_components_hw \
     libmfxhw32
 
 ifeq ($(BOARD_USE_64BIT_USERSPACE),true)
@@ -43,7 +44,6 @@ PRODUCT_PACKAGES += \
     libva \
     libva-android
 
-{{#add_hw_msdk}}
 # Open source media_driver
 PRODUCT_PACKAGES += i965_drv_video
 PRODUCT_PACKAGES += libigfxcmrt
@@ -54,5 +54,3 @@ PRODUCT_PACKAGES += lihdcpcommon
 
 PRODUCT_PACKAGES += \
     libpciaccess
-{{/add_hw_msdk}}
-{{/enable_msdk_omx}}


### PR DESCRIPTION
Hardware codecs are not getting used as the media driver is not getting built.

Fix the issue by making media driver build irrespective of enable_msdk_omx and add_hw_msdk flag.

Tests done:
- Android boot in GVT-d mode
- Video playback and recording using hardware codecs
- adb reboot

Tracked-On: OAM-127048