### PR TITLE
Fixed for external storage in music player apps.

### DIFF
--- a/groups/device-type/car/product.mk
+++ b/groups/device-type/car/product.mk
@@ -17,6 +17,8 @@ PRODUCT_PACKAGES += \
     VmsPublisherClientSample \
     VmsSubscriberClientSample \
 
+PRODUCT_PACKAGES += IntelExternalStoragePermissionService
+
 PRODUCT_PACKAGES += cardisplayproxyd
 PRODUCT_PACKAGES += evs_intel_app
 PRODUCT_PACKAGES += evsmanagerd


### PR DESCRIPTION
Music player apps are not showing usb storage.
It seems due to missing MANAGE_EXTERNAL_STORAGE permission.

Granting this permission if 3rd party apps are requesting this permission in their AndroidManifest file.

Tests: Install VLC app and launch. Its showing usb storage.

Tracked-On: OAM-122719