### PR TITLE
Define sepolicy module of bluetooth

### DIFF
--- a/groups/bluetooth/false/BoardConfig.mk
+++ b/groups/bluetooth/false/BoardConfig.mk
@@ -1,0 +1,1 @@
+BOARD_SEPOLICY_M4DEFS += module_bluetooth=false


### PR DESCRIPTION
Define sepolicy module of bluetooth and set its value to false. Other modules may reference the sepolicy rules of bluetooth, and there will be compiler errors if bluetooth is disabled. Need to wrap the rules referenced by other modules by using SEPolicy macros to eliminate the compiler errors.

Tracked-On: OAM-127489