### PR TITLE
Update optee config

### DIFF
--- a/groups/tee/optee/BoardConfig.mk
+++ b/groups/tee/optee/BoardConfig.mk
@@ -17,7 +17,5 @@ TARGET_USE_OPTEE := true
 TARGET_USE_IVSHMEM := true
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/tee/optee
 
-AB_OTA_PARTITIONS += tee
-
 include vendor/intel/optee/optee_client/optee_client.device.mk
 $(call soong_config_set,optee_client,cfg_tee_fs_parent_path,/mnt/vendor/persist/tee)

--- a/groups/tee/optee/product.mk
+++ b/groups/tee/optee/product.mk
@@ -9,6 +9,9 @@ PRODUCT_PACKAGES += \
 	android.hardware.security.keymint-service.optee \
 	wait_for_keymaster_optee
 
+PRODUCT_PRODUCT_PROPERTIES += remote_provisioning.tee.rkp_only=true
+PRODUCT_PRODUCT_PROPERTIES += remote_provisioning.hostname=remoteprovisioning.googleapis.com
+
 PRODUCT_PROPERTY_OVERRIDES += \
 	ro.hardware.keystore=optee
 {{/hw_km}}
@@ -24,7 +27,7 @@ PRODUCT_PROPERTY_OVERRIDES += ro.hardware.gatekeeper=optee
 {{/hw_gk}}
 
 {{^hw_gk}}
-PRODUCT_PACKAGES += android.hardware.gatekeeper-service.software
+PRODUCT_PACKAGES += com.android.hardware.gatekeeper.nonsecure
 {{/hw_gk}}
 
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
1, Remove TEE from the OTA partition list.
2, Set RKP related properties.
3, Update software Gatekeeper service.

Tests Done:
1, Android boot and reboot OK.
2, Properties set OK.