### PR TITLE
Enable wifi RTT and NAN features

### DIFF
--- a/groups/wlan/iwlwifi/BoardConfig.mk
+++ b/groups/wlan/iwlwifi/BoardConfig.mk
@@ -12,3 +12,9 @@ BOARD_WPA_SUPPLICANT_PRIVATE_LIB ?= lib_driver_cmd_intc
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/load_iwl_modules
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/iwlwifi
 WIFI_HIDL_UNIFIED_SUPPLICANT_SERVICE_RC_ENTRY := true
+
+{{^ivi}}
+{{#nan}}
+WIFI_HIDL_FEATURE_AWARE := true
+{{/nan}}
+{{/ivi}}

--- a/groups/wlan/iwlwifi/option.spec
+++ b/groups/wlan/iwlwifi/option.spec
@@ -10,3 +10,5 @@ libwifi-hal = false
 firmware =
 nvm = true
 iwl_upstream_drv = true
+nan = false
+ivi = false

--- a/groups/wlan/iwlwifi/product.mk
+++ b/groups/wlan/iwlwifi/product.mk
@@ -21,6 +21,15 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.wifi.direct.xml:vendor/etc/permissions/android.hardware.wifi.direct.xml \
     frameworks/native/data/etc/android.software.ipsec_tunnels.xml:vendor/etc/permissions/android.software.ipsec_tunnels.xml
 
+{{^ivi}}
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.wifi.rtt.xml:vendor/etc/permissions/android.hardware.wifi.rtt.xml
+{{#nan}}
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.wifi.aware.xml:vendor/etc/permissions/android.hardware.wifi.aware.xml
+{{/nan}}
+{{/ivi}}
+
 PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-disable_keepalive_offload
 
 PRODUCT_COPY_FILES += $(LOCAL_PATH)/{{_extra_dir}}/load_iwl_modules.sh:vendor/bin/load_iwl_modules.sh


### PR DESCRIPTION
RTT and NAN features are not enabled in caas.

Enabled RTT and NAN for caas. Since NAN and hotspot cannot work simultaneously, moved NAN to mixins options, whenever required can enable and validate.

Tests done:
[RTT]
1. Flash BM
2. In adb shell #>pm list features | grep wifi
3. Check rtt is listing
4. Verify RTT service is running in logcat
5. Check wifi on success
6. Check hotspot on success

[NAN]
1. Build with nan=true and flash BM
2. In adb shell #>pm list features | grep wifi
3. Check aware is listing
4. Verify aware service is running in logcat
5. Check wifi on success

Tracked-On: OAM-127694