### PR TITLE
Remove sensor features on base_aaos and aaos_iasw target

### DIFF
--- a/groups/sensors/mediation/product.mk
+++ b/groups/sensors/mediation/product.mk
@@ -7,12 +7,17 @@ PRODUCT_PACKAGES += \
 	android.hardware.sensors@aidl-service.intel
 
 {{#enable_sensor_list}}
+ifeq ($(TARGET_PRODUCT), caas)
 PRODUCT_COPY_FILES += \
         frameworks/native/data/etc/android.hardware.sensor.ambient_temperature.xml:vendor/etc/permissions/android.hardware.sensor.ambient_temperature.xml \
         frameworks/native/data/etc/android.hardware.sensor.accelerometer.xml:vendor/etc/permissions/android.hardware.sensor.accelerometer.xml \
         frameworks/native/data/etc/android.hardware.sensor.gyroscope.xml:vendor/etc/permissions/android.hardware.sensor.gyroscope.xml \
         frameworks/native/data/etc/android.hardware.sensor.compass.xml:vendor/etc/permissions/android.hardware.sensor.compass.xml \
         frameworks/native/data/etc/android.hardware.sensor.light.xml:vendor/etc/permissions/android.hardware.sensor.light.xml
+else ifeq ($(TARGET_PRODUCT), aaos_iasw)
+PRODUCT_COPY_FILES += \
+        frameworks/native/data/etc/android.hardware.location.gps.xml:vendor/etc/permissions/android.hardware.location.gps.xml
+endif
 
 AUTO_IN += $(TARGET_DEVICE_DIR)/{{_extra_dir}}/auto_hal.in
 {{/enable_sensor_list}}


### PR DESCRIPTION
To align with Android14 sensor features settings:
1. remove sensor features on base_aaos
2. enable GPS feature on aaos_iasw.
3. Clean the related patches in bsp_diff

Backport the patch from Android14.
commit id: c9ee8ae283fc6b010b1827ca918a85e39751eded disable/enable sensors with respect to targets.

Tracked-On: OAM-127765