### PR TITLE
Revert "Fixed for external storage in music player apps."

### DIFF
--- a/groups/device-type/car/product.mk
+++ b/groups/device-type/car/product.mk
@@ -17,8 +17,6 @@ PRODUCT_PACKAGES += \
     VmsPublisherClientSample \
     VmsSubscriberClientSample \
 
-PRODUCT_PACKAGES += IntelExternalStoragePermissionService
-
 PRODUCT_PACKAGES += cardisplayproxyd
 PRODUCT_PACKAGES += evs_intel_app
 PRODUCT_PACKAGES += evsmanagerd


### PR DESCRIPTION
This reverts commit 0db95e92f2380bcec02b1dc4bd245260366b5bfe.

Tests: Run below cts test
atest android.appsecurity.cts.ExternalStorageHostTest

Tracked-On: OAM-127973