### PR TITLE
Enable mixer controls for ALC298 codec

### DIFF
--- a/groups/audio/project-celadon/default/mixer_paths_0.xml
+++ b/groups/audio/project-celadon/default/mixer_paths_0.xml
@@ -1,9 +1,9 @@
 <mixer>
   <!-- These are the initial mixer settings -->
-  <ctl name="Master Playback Volume" value="87 87" />
-  <ctl name="Master Playback Switch" value="1 1" />
+  <ctl name="Master Playback Volume" value="127" />
+  <ctl name="Master Playback Switch" value="1" />
   <ctl name="Headphone Playback Switch" value="0 0" />
-  <ctl name="Speaker Playback Switch" value="0 0" />
+  <ctl name="Speaker Playback Switch" value="1 1" />
   <ctl name="Capture Switch" value="0 0" />
 
   <path name="speaker">
@@ -18,13 +18,13 @@
 
   <path name="main-mic">
     <ctl name="Capture Switch" value="1 1" />
-    <ctl name="Capture Volume" value="63 63" />
+    <ctl name="Capture Volume" value="127 127" />
     <ctl name="Capture Source" value="Internal Mic" />
   </path>
 
   <path name="headset-mic">
     <ctl name="Capture Switch" value="1 1" />
-    <ctl name="Capture Volume" value="63 63" />
+    <ctl name="Capture Volume" value="127 127" />
     <ctl name="Capture Source" value="Headset Mic" />
   </path>
 </mixer>


### PR DESCRIPTION
This patch adds changes to enable mixer controls
to get playback and record working.