### PR TITLE
Change metadata partition to 64MB to meet GAS requirement

### DIFF
--- a/groups/boot-arch/project-celadon/gpt.ini
+++ b/groups/boot-arch/project-celadon/gpt.ini
@@ -84,7 +84,7 @@ type = misc
 
 [partition.metadata]
 label = metadata
-len = 16
+len = 64
 type = metadata
 
 [partition.system]


### PR DESCRIPTION
[G-0-864] MUST have a /metadata partition of at least 64 MB.

Test Done:
Boot

Tracked-On: OAM-128206