### PR TITLE
Enable multi zone audio in IASW

### DIFF
--- a/groups/multi-passenger/true/audio/audio_hal_configuration.xml
+++ b/groups/multi-passenger/true/audio/audio_hal_configuration.xml
@@ -5,6 +5,7 @@
     <Mixer Card="avsrt56401" MixerPath="/vendor/etc/mixer_paths_0.xml"/>
   </Stream>
 -->
+<!-- Audio Zone 0-->
   <Stream Address="bus0_media_out" Direction="playback" Mmap="false">
     <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
   </Stream>
@@ -35,13 +36,14 @@
     <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="960" PeriodCount="4" StartThreshhold="1" StopThreshold="3840" AdditionalOutputDeviceDelay="5"/>
   </Stream>
   </Stream>
-  <Stream Address="bus_1000_input_zone_0" Direction="capture" Mmap="false">
+  <Stream Address="input_bus1_zone_0" Direction="capture" Mmap="false">
     <Pcm Card="SoundCard" Device="1" SampleRate="48000"  Format="32" Channels="2" PeriodSize="960" PeriodCount="4" StartThreshhold="1" StopThreshold="3840" AdditionalOutputDeviceDelay="5"/>
   </Stream>
+  <!-- Audio Zone 1-->
   <Stream Address="bus100_audio_zone_1" Direction="playback" Mmap="false">
     <Pcm Card="SoundCard" Device="2" SampleRate="48000"  Format="32" Channels="2" PeriodSize="1024" PeriodCount="4" StartThreshhold="4096" AdditionalOutputDeviceDelay="5"/>
   </Stream>
-  <Stream Address="bus_2000_input_zone_1" Direction="capture" Mmap="false">
+  <Stream Address="input_bus100_zone_1" Direction="capture" Mmap="false">
     <Pcm Card="SoundCard" Device="2" SampleRate="48000"  Format="32" Channels="2" PeriodSize="960" PeriodCount="4" StartThreshhold="1" StopThreshold="3840" AdditionalOutputDeviceDelay="5"/>
   </Stream>
   </Streams>

--- a/groups/multi-passenger/true/audio/audio_policy_configuration.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration.xml
@@ -65,6 +65,9 @@
         <!-- Remote Submix Audio HAL -->
         <xi:include href="r_submix_audio_policy_configuration.xml"/>
 
+        <!-- Bluetooth Audio HAL -->
+        <xi:include href="bluetooth_audio_policy_configuration_7_0.xml"/>
+
     </modules>
     <!-- End of Modules section -->
 

--- a/groups/multi-passenger/true/audio/audio_policy_configuration_attached_devices.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration_attached_devices.xml
@@ -14,7 +14,8 @@
      limitations under the License.
 -->
 <attachedDevices>
-    <!-- One bus per context -->
+
+    <!-- Audio Zone 0 -->
     <item>bus0_media_out</item>
     <item>bus1_navigation_out</item>
     <item>bus2_voice_command_out</item>
@@ -24,22 +25,14 @@
     <item>bus6_notification_out</item>
     <item>bus7_system_sound_out</item>
 
-    <!-- TODO update for input-->
-    <item>bus_1000_input_zone_0</item>
     <item>Built-In Mic</item>
     <item>Built-In Back Mic</item>
     <item>Echo-Reference Mic</item>
+    <item>input_bus1_zone_0</item>
     
+    <!-- Audio Zone 1 -->
     <item>bus100_audio_zone_1</item>
-    <item>bus10_media_out</item>
-    <item>bus11_navigation_out</item>
-    <item>bus12_voice_command_out</item>
-    <item>bus13_call_ring_out</item>
-    <item>bus14_call_out</item>
-    <item>bus15_alarm_out</item>
-    <item>bus16_notification_out</item>
-    <item>bus17_system_sound_out</item>
-
-    <!-- TODO update for input-->
-    <item>bus_2000_input_zone_1</item>
+    
+    <item>input_bus100_zone_1</item>
+    
 </attachedDevices>

--- a/groups/multi-passenger/true/audio/audio_policy_configuration_devices.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration_devices.xml
@@ -14,7 +14,7 @@
      limitations under the License.
 -->
 <devicePorts>
-    <!-- zone 1 -->
+    <!-- Audio zone 0 -->
     <devicePort tagName="bus0_media_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
                 address="bus0_media_out">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
@@ -23,7 +23,7 @@
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
                   minValueMB="-3200" maxValueMB="600"
                   defaultValueMB="0" stepValueMB="100"/>
-            </gains>
+        </gains>
     </devicePort>
     <devicePort tagName="bus1_navigation_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
                 address="bus1_navigation_out">
@@ -96,18 +96,6 @@
         </gains>
     </devicePort>
 
-    <!-- TODO update for input-->
-    <devicePort tagName="bus_1000_input_zone_0" type="AUDIO_DEVICE_IN_BUS"
-                role="source" address="bus_1000_input_zone_0">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
     <devicePort tagName="Built-In Mic" type="AUDIO_DEVICE_IN_BUILTIN_MIC" role="source"
                 address="Built-In Mic" >
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
@@ -126,8 +114,19 @@
                  samplingRates="8000 11025 12000 16000 22050 24000 32000 44100 48000"
                  channelMasks="AUDIO_CHANNEL_IN_MONO AUDIO_CHANNEL_IN_STEREO AUDIO_CHANNEL_IN_FRONT_BACK"/>
     </devicePort>
+    <devicePort tagName="input_bus1_zone_0" type="AUDIO_DEVICE_IN_BUS"
+            role="source" address="input_bus1_zone_0">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                    samplingRates="48000"
+                    channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+        <gains>
+            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
+                    minValueMB="-3200" maxValueMB="600"
+                    defaultValueMB="0" stepValueMB="100"/>
+        </gains>
+    </devicePort>
 
-    <!-- zone 2 -->
+    <!-- Audio zone 1 -->
     <devicePort tagName="bus100_audio_zone_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
                 address="bus100_audio_zone_1">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
@@ -139,90 +138,8 @@
             </gains>
     </devicePort>
 
-    <devicePort tagName="bus10_media_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus10_media_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-            </gains>
-    </devicePort>
-    <devicePort tagName="bus11_navigation_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus11_navigation_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus12_voice_command_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus12_voice_command_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus13_call_ring_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus13_call_ring_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus14_call_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus14_call_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus15_alarm_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus15_alarm_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus16_notification_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus16_notification_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus17_system_sound_out" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus17_system_sound_out">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-
-    <!-- TODO update for input-->
-    <devicePort tagName="bus_2000_input_zone_1" type="AUDIO_DEVICE_IN_BUS"
-                role="source" address="bus_2000_input_zone_1">
+    <devicePort tagName="input_bus100_zone_1" type="AUDIO_DEVICE_IN_BUS"
+                role="source" address="input_bus100_zone_1">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_IN_STEREO"/>

--- a/groups/multi-passenger/true/audio/audio_policy_configuration_mixports.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration_mixports.xml
@@ -14,6 +14,8 @@
      limitations under the License.
 -->
 <mixPorts>
+
+<!-- Audio Zone 0-->
     <mixPort name="mixport_bus0_media_out" role="source"
              flags="AUDIO_OUTPUT_FLAG_PRIMARY">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
@@ -55,18 +57,19 @@
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
     </mixPort>
-    <!-- TODO update for input-->
+
     <mixPort name="primary input" role="sink">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
     </mixPort>
-    <mixPort name="mixport_bus_1000_input_zone_0" role="sink">
+    <mixPort name="mixport_input_bus1_zone_0" role="sink">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
     </mixPort>
 
+<!-- Audio Zone 1-->
     <mixPort name="mixport_bus100_audio_zone_1" role="source"
              flags="AUDIO_OUTPUT_FLAG_PRIMARY">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
@@ -74,49 +77,7 @@
                  channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         </mixPort>
 
-    <mixPort name="mixport_bus10_media_out" role="source"
-             flags="AUDIO_OUTPUT_FLAG_PRIMARY">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        </mixPort>
-    <mixPort name="mixport_bus11_navigation_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus12_voice_command_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus13_call_ring_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus14_call_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus15_alarm_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus16_notification_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus17_system_sound_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <!-- TODO update for input-->
-    <mixPort name="mixport_bus_2000_input_zone_1" role="sink">
+    <mixPort name="mixport_input_bus100_zone_1" role="sink">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_IN_STEREO"/>

--- a/groups/multi-passenger/true/audio/audio_policy_configuration_routes.xml
+++ b/groups/multi-passenger/true/audio/audio_policy_configuration_routes.xml
@@ -14,22 +14,8 @@
      limitations under the License.
 -->
 <routes>
-    <route type="mix" sink="bus100_audio_zone_1" sources="mixport_bus100_audio_zone_1"/>
-    <route type="mix" sink="bus10_media_out" sources="mixport_bus10_media_out"/>
-    <route type="mix" sink="bus11_navigation_out" sources="mixport_bus11_navigation_out"/>
-    <route type="mix" sink="bus12_voice_command_out"
-           sources="mixport_bus12_voice_command_out"/>
-    <route type="mix" sink="bus13_call_ring_out" sources="mixport_bus13_call_ring_out"/>
-    <route type="mix" sink="bus14_call_out" sources="mixport_bus14_call_out"/>
-    <route type="mix" sink="bus15_alarm_out" sources="mixport_bus15_alarm_out"/>
-    <route type="mix" sink="bus16_notification_out"
-           sources="mixport_bus16_notification_out"/>
-    <route type="mix" sink="bus17_system_sound_out"
-           sources="mixport_bus17_system_sound_out"/>
 
-    <!-- TODO update for input-->
-    <route type="mix" sink="mixport_bus_2000_input_zone_1" sources="bus_2000_input_zone_1"/>
-
+    <!-- Audio Zone 0-->
     <route type="mix" sink="bus0_media_out" sources="mixport_bus0_media_out"/>
     <route type="mix" sink="bus1_navigation_out" sources="mixport_bus1_navigation_out"/>
     <route type="mix" sink="bus2_voice_command_out"
@@ -41,9 +27,12 @@
            sources="mixport_bus6_notification_out"/>
     <route type="mix" sink="bus7_system_sound_out"
            sources="mixport_bus7_system_sound_out"/>
-
-    <!-- TODO update for input-->
-    <route type="mix" sink="mixport_bus_1000_input_zone_0" sources="bus_1000_input_zone_0"/>
+    
     <route type="mix" sink="primary input"
            sources="Built-In Mic,Built-In Back Mic,Echo-Reference Mic"/>
+    <route type="mix" sink="mixport_input_bus1_zone_0" sources="input_bus1_zone_0"/>
+    
+    <!-- Audio Zone 1-->
+    <route type="mix" sink="bus100_audio_zone_1" sources="mixport_bus100_audio_zone_1"/>
+    <route type="mix" sink="mixport_input_bus100_zone_1" sources="input_bus100_zone_1"/>
 </routes>

--- a/groups/multi-passenger/true/audio/car_audio_configuration.xml
+++ b/groups/multi-passenger/true/audio/car_audio_configuration.xml
@@ -59,14 +59,14 @@
                         <context context="vehicle_status"/>
                     </device>
                 </group>
-	    </volumeGroups>
+	        </volumeGroups>
             <inputDevices>
-		<inputDevice address="bus_1000_input_zone_0"/>
-		<inputDevice address="Built-In Mic"/>
-		<inputDevice address="Built-In Back Mic"/>
+                <!-- <inputDevice address="Built-In Mic"/>
+                <inputDevice address="Built-In Back Mic"/> -->
+                <inputDevice address="input_bus1_zone_0"/>
             </inputDevices>
-         </zone>
-      <zone name="front passenger zone 1" audioZoneId="1" occupantZoneId="1">
+        </zone>
+        <zone name="front passenger zone 1" audioZoneId="1" occupantZoneId="1">
          <volumeGroups>
             <group>
                 <device address="bus100_audio_zone_1">
@@ -86,7 +86,7 @@
              </group>
           </volumeGroups>
           <inputDevices>
-             <inputDevice address="bus_2000_input_zone_1"/>
+             <inputDevice address="input_bus100_zone_1"/>
           </inputDevices>
        </zone>
     </zones>


### PR DESCRIPTION
Enabled multi zone audio in IASW.
Fixed bluetooth crash by involving bt config file for bluetooth HAL. Removed useless devices in the configuration.
Removed built-in device in car config to make audio works,this should be fixed after recording works.

Test passed:
- Audio playback fine on all presented audio zone, so far there are two audio zones.

Tracked-On: OAM-128302