### PR TITLE
Configure virtual_ab compression

### DIFF
--- a/groups/dynamic-partitions/true/product.mk
+++ b/groups/dynamic-partitions/true/product.mk
@@ -19,7 +19,7 @@ $(call inherit-product, \
     $(SRC_TARGET_DIR)/product/virtual_ab_ota.mk)
 {{#virtual_ab_compression}}
 $(call inherit-product, \
-    $(SRC_TARGET_DIR)/product/virtual_ab_ota/compression.mk)
+    $(SRC_TARGET_DIR)/product/virtual_ab_ota/vabc_features.mk)
 PRODUCT_PACKAGES += snapuserd_ramdisk
 {{/virtual_ab_compression}}
 {{/virtual_ab}}


### PR DESCRIPTION
Changed inheritance of virtual_ab_ota makefile from compression.mk to vabc_features.mk

Dependant-PR: https://github.com/projectceladon/vendor-intel-utils/pull/2748

Tests done: Build-Flash-Verify

Tracked-on: OAM-125218