### PR TITLE
Dynamic zone configurations enable on Android 15

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
@@ -32,6 +32,7 @@
     
     <!-- Audio Zone 1 -->
     <item>bus100_CARD_0_DEV_2</item>
+    <item>bus101_CARD_0_DEV_3</item>
     
     <item>i_bus100_CARD_0_DEV_2</item>
     

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
@@ -137,6 +137,16 @@
                   defaultValueMB="0" stepValueMB="100"/>
             </gains>
     </devicePort>
+    <devicePort tagName="bus101_CARD_0_DEV_3" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus101_CARD_0_DEV_3">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+        <gains>
+            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
+                  minValueMB="-3200" maxValueMB="600"
+                  defaultValueMB="0" stepValueMB="100"/>
+            </gains>
+    </devicePort>
 
     <devicePort tagName="i_bus100_CARD_0_DEV_2" type="AUDIO_DEVICE_IN_BUS"
                 role="source" address="i_bus100_CARD_0_DEV_2">

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_mixports.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_mixports.xml
@@ -75,7 +75,13 @@
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        </mixPort>
+    </mixPort>
+    <mixPort name="mixport_bus101_audio_zone_1" role="source"
+             flags="AUDIO_OUTPUT_FLAG_PRIMARY">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+    </mixPort>
 
     <mixPort name="mixport_input_bus100_zone_1" role="sink">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
@@ -34,5 +34,6 @@
     
     <!-- Audio Zone 1-->
     <route type="mix" sink="bus100_CARD_0_DEV_2" sources="mixport_bus100_audio_zone_1"/>
+    <route type="mix" sink="bus101_CARD_0_DEV_3" sources="mixport_bus101_audio_zone_1"/>
     <route type="mix" sink="mixport_input_bus100_zone_1" sources="i_bus100_CARD_0_DEV_2"/>
 </routes>

--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -21,45 +21,49 @@
     - Volume groups
   in the car environment.
 -->
-<carAudioConfiguration version="2">
+<carAudioConfiguration version="3">
     <zones>
         <zone name="primary zone" isPrimary="true" occupantZoneId="0">
-            <volumeGroups>
-                <group>
-                    <device address="bus0_media_CARD_0_DEV_1">
-                        <context context="music"/>
-                        <context context="announcement"/>
-                        <context context="call"/>
-                    </device>
-                    <device address="bus6_notification_CARD_0_DEV_1">
-                        <context context="notification"/>
-                    </device>
-                </group>
-                <group>
-                    <device address="bus1_navigation_CARD_0_DEV_1">
-                        <context context="navigation"/>
-                    </device>
-                    <device address="bus2_voice_command_CARD_0_DEV_1">
-                        <context context="voice_command"/>
-                    </device>
-                </group>
-                <group>
-                    <device address="bus3_call_ring_CARD_0_DEV_1">
-                        <context context="call_ring"/>
-                    </device>
-                </group>
-                <group>
-                    <device address="bus5_alarm_CARD_0_DEV_1">
-                        <context context="alarm"/>
-                    </device>
-                    <device address="bus7_system_sound_CARD_0_DEV_1">
-                        <context context="system_sound"/>
-                        <context context="emergency"/>
-                        <context context="safety"/>
-                        <context context="vehicle_status"/>
-                    </device>
-                </group>
-	        </volumeGroups>
+            <zoneConfigs>
+                <zoneConfig name="primary zone config" isDefault="true">
+                    <volumeGroups>
+                        <group>
+                            <device address="bus0_media_CARD_0_DEV_1">
+                                <context context="music"/>
+                                <context context="announcement"/>
+                                <context context="call"/>
+                            </device>
+                            <device address="bus6_notification_CARD_0_DEV_1">
+                                <context context="notification"/>
+                            </device>
+                        </group>
+                        <group>
+                            <device address="bus1_navigation_CARD_0_DEV_1">
+                                <context context="navigation"/>
+                            </device>
+                            <device address="bus2_voice_command_CARD_0_DEV_1">
+                                <context context="voice_command"/>
+                            </device>
+                        </group>
+                        <group>
+                            <device address="bus3_call_ring_CARD_0_DEV_1">
+                                <context context="call_ring"/>
+                            </device>
+                        </group>
+                        <group>
+                            <device address="bus5_alarm_CARD_0_DEV_1">
+                                <context context="alarm"/>
+                            </device>
+                            <device address="bus7_system_sound_CARD_0_DEV_1">
+                                <context context="system_sound"/>
+                                <context context="emergency"/>
+                                <context context="safety"/>
+                                <context context="vehicle_status"/>
+                            </device>
+                        </group>
+                    </volumeGroups>
+                </zoneConfig>
+            </zoneConfigs>
             <inputDevices>
                 <!-- <inputDevice address="Built-In Mic"/>
                 <inputDevice address="Built-In Back Mic"/> -->
@@ -67,27 +71,51 @@
             </inputDevices>
         </zone>
         <zone name="front passenger zone 1" audioZoneId="1" occupantZoneId="1">
-         <volumeGroups>
-            <group>
-                <device address="bus100_CARD_0_DEV_2">
-                   <context context="music"/>
-                   <context context="navigation"/>
-                   <context context="voice_command"/>
-                   <context context="call_ring"/>
-                   <context context="call"/>
-                   <context context="alarm"/>
-                   <context context="notification"/>
-                   <context context="system_sound"/>
-                   <context context="emergency"/>
-                   <context context="safety"/>
-                   <context context="vehicle_status"/>
-                   <context context="announcement"/>
-                </device>
-             </group>
-          </volumeGroups>
-          <inputDevices>
-             <inputDevice address="i_bus100_CARD_0_DEV_2"/>
-          </inputDevices>
+            <zoneConfigs>
+                <zoneConfig name="front passenger zone 1 config 0" isDefault="true">
+                    <volumeGroups>
+                        <group>
+                            <device address="bus100_CARD_0_DEV_2">
+                            <context context="music"/>
+                            <context context="navigation"/>
+                            <context context="voice_command"/>
+                            <context context="call_ring"/>
+                            <context context="call"/>
+                            <context context="alarm"/>
+                            <context context="notification"/>
+                            <context context="system_sound"/>
+                            <context context="emergency"/>
+                            <context context="safety"/>
+                            <context context="vehicle_status"/>
+                            <context context="announcement"/>
+                            </device>
+                        </group>
+                    </volumeGroups>
+                </zoneConfig>
+                <zoneConfig name="front passenger zone 1 config 1">
+                    <volumeGroups>
+                        <group>
+                            <device address="bus101_CARD_0_DEV_3">
+                            <context context="music"/>
+                            <context context="navigation"/>
+                            <context context="voice_command"/>
+                            <context context="call_ring"/>
+                            <context context="call"/>
+                            <context context="alarm"/>
+                            <context context="notification"/>
+                            <context context="system_sound"/>
+                            <context context="emergency"/>
+                            <context context="safety"/>
+                            <context context="vehicle_status"/>
+                            <context context="announcement"/>
+                            </device>
+                        </group>
+                    </volumeGroups>
+                </zoneConfig>
+            </zoneConfigs>
+            <inputDevices>
+                <inputDevice address="i_bus100_CARD_0_DEV_2"/>
+            </inputDevices>
        </zone>
     </zones>
 </carAudioConfiguration>


### PR DESCRIPTION
Google provided the api to allow OEMs to configure different sets of devices for passengers.

Test done:
- Verified by Kitchen Sink application, the audio config in zone 1 can be smoothly switched.

Tracked-on: OAM-128466