### PR TITLE
Ensure correct SELinux context for /data/vendor/ota

### DIFF
--- a/groups/ota-coordinator/true/init.rc
+++ b/groups/ota-coordinator/true/init.rc
@@ -9,4 +9,5 @@ service ota_coordinator /vendor/bin/ota_coordinator
 on boot
     mkdir /data/vendor/ota 660 system system
     mount virtiofs myfs /data/vendor/ota 
+    restorecon --recursive --cross-filesystems /data/vendor/ota
     start ota_coordinator


### PR DESCRIPTION
Added a command to init.rc to recursively restore the SELinux context for /data/vendor/ota and its contents, even across filesystem boundaries.

Tracked-On: OAM-128450