### PR TITLE
 Support dynamically loadable kernel module for system/vendor/odm

### DIFF
--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -42,6 +42,12 @@ BOARD_CACHEIMAGE_PARTITION_SIZE ?= 104857600
 BOARD_SYSTEMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 DATA_USE_F2FS := {{data_use_f2fs}}
 
+# system dlkm support
+BOARD_USES_SYSTEM_DLKMIMAGE := true
+BOARD_SYSTEM_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
+TARGET_COPY_OUT_SYSTEM_DLKM := system_dlkm
+AB_OTA_PARTITIONS += system_dlkm
+
 #fastbootd over ethernet support
 TARGET_RECOVERY_UI_LIB:=librecovery_ui_ethernet
 

--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -48,6 +48,12 @@ BOARD_SYSTEM_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 TARGET_COPY_OUT_SYSTEM_DLKM := system_dlkm
 AB_OTA_PARTITIONS += system_dlkm
 
+# Enabled chained vbmeta for system_dlkm
+BOARD_AVB_VBMETA_SYSTEM_DLKM := system_dlkm
+BOARD_AVB_VBMETA_SYSTEM_DLKM_KEY_PATH := external/avb/test/data/testkey_rsa4096.pem
+BOARD_AVB_VBMETA_SYSTEM_DLKM_ALGORITHM := SHA256_RSA4096
+BOARD_AVB_SYSTEM_DLKM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
+
 #fastbootd over ethernet support
 TARGET_RECOVERY_UI_LIB:=librecovery_ui_ethernet
 

--- a/groups/boot-arch/project-celadon/BoardConfig.mk
+++ b/groups/boot-arch/project-celadon/BoardConfig.mk
@@ -207,3 +207,6 @@ ENABLE_GRUB_INSTALLER ?= true
 {{/use_cic}}
 
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/soc
+
+BOARD_SYSTEM_KERNEL_MODULES := kernel/prebuilts/6.1/x86_64/pppox.ko
+BOARD_ODM_KERNEL_MODULES  := kernel/prebuilts/6.1/x86_64/pppox.ko

--- a/groups/boot-arch/project-celadon/fstab
+++ b/groups/boot-arch/project-celadon/fstab
@@ -20,6 +20,9 @@ system   /system  ext4 ro,barrier=1  wait{{#slot-ab}},slotselect{{/slot-ab}},avb
 {{^multi_user_support}}
 /dev/block/by-name/{{#dynamic-partitions}}user{{/dynamic-partitions}}data         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}    noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}},quota,reservedsize=50m{{#fsverity}},fsverity{{/fsverity}}{{#metadata_encryption}},latemount,keydirectory=/metadata/vold/metadata_encryption{{#userdata_checkpoint}}{{^data_use_f2fs}},checkpoint=block{{/data_use_f2fs}}{{#data_use_f2fs}},checkpoint=fs{{/data_use_f2fs}}{{/userdata_checkpoint}}{{/metadata_encryption}}
 {{/multi_user_support}}
+{{#dynamic-partitions}}
+system_dlkm /system_dlkm {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait,logical,first_stage_mount,{{#slot-ab}}slotselect{{/slot-ab}},avb
+{{/dynamic-partitions}}
 /dev/block/by-name/boot         /boot           emmc    defaults                                                    defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
 {{^slot-ab}}
 /dev/block/by-name/recovery     /recovery       emmc    defaults                                                    defaults

--- a/groups/boot-arch/project-celadon/fstab.recovery
+++ b/groups/boot-arch/project-celadon/fstab.recovery
@@ -19,6 +19,9 @@ system   /system  {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4
 {{^multi_user_support}}
 /dev/block/by-name/{{#dynamic-partitions}}user{{/dynamic-partitions}}data         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}     noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}
 {{/multi_user_support}}
+{{#dynamic-partitions}}
+system_dlkm /system_dlkm {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait,logical,first_stage_mount,{{#slot-ab}}slotselect{{/slot-ab}}
+{{/dynamic-partitions}}
 /dev/block/by-name/boot         /boot           emmc    defaults                                                    defaults
 {{^slot-ab}}
 /dev/block/by-name/recovery     /recovery       emmc    defaults                                                    defaults

--- a/groups/dynamic-partitions/true/BoardConfig.mk
+++ b/groups/dynamic-partitions/true/BoardConfig.mk
@@ -1,6 +1,6 @@
 # Configure super partitions
 BOARD_SUPER_PARTITION_GROUPS := group_sys
-BOARD_GROUP_SYS_PARTITION_LIST := system{{#vendor-partition}} vendor{{/vendor-partition}}{{#product-partition}} product{{/product-partition}}{{#odm-partition}} odm{{/odm-partition}}
+BOARD_GROUP_SYS_PARTITION_LIST := system{{#vendor-partition}} vendor vendor_dlkm{{/vendor-partition}}{{#product-partition}} product{{/product-partition}}{{#odm-partition}} odm odm_dlkm{{/odm-partition}} system_dlkm
 
 {{^dp_retrofit}}
 BOARD_SUPER_PARTITION_SIZE := $(shell echo {{super_partition_size}}*1024*1024 | bc)
@@ -19,7 +19,7 @@ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/virtual_ab
 {{/dp_retrofit}}
 
 {{#dp_retrofit}}
-BOARD_SUPER_PARTITION_BLOCK_DEVICES := system{{#vendor-partition}} vendor{{/vendor-partition}}{{#product-partition}} product{{/product-partition}}{{#odm-partition}} odm{{/odm-partition}}
+BOARD_SUPER_PARTITION_BLOCK_DEVICES :=  system{{#vendor-partition}} vendor vendor_dlkm{{/vendor-partition}}{{#product-partition}} product{{/product-partition}}{{#odm-partition}} odm odm_dlkm{{/odm-partition}} system_dlkm
 BOARD_SUPER_PARTITION_METADATA_DEVICE := system
 BOARD_SUPER_PARTITION_SYSTEM_DEVICE_SIZE = $(SYSTEM_PARTITION_SIZE)
 {{#vendor-partition}}

--- a/groups/kernel/product.mk
+++ b/groups/kernel/product.mk
@@ -3,6 +3,6 @@
   KERNEL_MODULES_ROOT := root/$(KERNEL_MODULES_ROOT_PATH)
 {{/modules_in_bootimg}}
 
-KERNEL_MODULES_ROOT_PATH ?= vendor/lib/modules
+KERNEL_MODULES_ROOT_PATH ?= vendor_dlkm/lib/modules
 KERNEL_MODULES_ROOT ?= $(KERNEL_MODULES_ROOT_PATH)
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.vendor.boot.moduleslocation=/$(KERNEL_MODULES_ROOT_PATH)

--- a/groups/odm-partition/true/BoardConfig.mk
+++ b/groups/odm-partition/true/BoardConfig.mk
@@ -3,10 +3,17 @@
 TARGET_COPY_OUT_ODM := odm
 BOARD_ODMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 ODM_PARTITION_SIZE := $(shell echo {{partition_size}}*1048576 | bc)
+
+# odm_dlkm support
+BOARD_USES_ODM_DLKMIMAGE := true
+BOARD_ODM_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
+TARGET_COPY_OUT_ODM_DLKM := odm_dlkm
+
 {{^dynamic-partitions}}
 BOARD_ODMIMAGE_PARTITION_SIZE := $(ODM_PARTITION_SIZE)
 {{/dynamic-partitions}}
 TARGET_USE_ODM := true
 {{#slot-ab}}
 AB_OTA_PARTITIONS += odm
+AB_OTA_PARTITIONS += odm_dlkm
 {{/slot-ab}}

--- a/groups/odm-partition/true/BoardConfig.mk
+++ b/groups/odm-partition/true/BoardConfig.mk
@@ -8,6 +8,7 @@ ODM_PARTITION_SIZE := $(shell echo {{partition_size}}*1048576 | bc)
 BOARD_USES_ODM_DLKMIMAGE := true
 BOARD_ODM_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 TARGET_COPY_OUT_ODM_DLKM := odm_dlkm
+BOARD_AVB_ODM_DLKM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
 
 {{^dynamic-partitions}}
 BOARD_ODMIMAGE_PARTITION_SIZE := $(ODM_PARTITION_SIZE)

--- a/groups/odm-partition/true/fstab
+++ b/groups/odm-partition/true/fstab
@@ -11,4 +11,5 @@
 {{/dynamic-partitions}}
 {{#dynamic-partitions}}
 odm  /odm {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait{{#slot-ab}},slotselect{{/slot-ab}},avb,logical,first_stage_mount
+odm_dlkm /odm_dlkm {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}}  wait,logical,first_stage_mount,{{#slot-ab}},slotselect{{/slot-ab}},avb
 {{/dynamic-partitions}}

--- a/groups/odm-partition/true/fstab.recovery
+++ b/groups/odm-partition/true/fstab.recovery
@@ -6,4 +6,5 @@
 {{/dynamic-partitions}}
 {{#dynamic-partitions}}
 odm  /odm {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait{{#slot-ab}},slotselect{{/slot-ab}},logical,first_stage_mount
+odm_dlkm /odm_dlkm {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}}  wait,logical,first_stage_mount,{{#slot-ab}},slotselect{{/slot-ab}}
 {{/dynamic-partitions}}

--- a/groups/vendor-partition/true/BoardConfig.mk
+++ b/groups/vendor-partition/true/BoardConfig.mk
@@ -3,9 +3,16 @@
 TARGET_COPY_OUT_VENDOR := vendor
 BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 VENDOR_PARTITION_SIZE := $(shell echo {{partition_size}}*1048576 | bc)
+
+# vendor_dlkm support
+BOARD_USES_VENDOR_DLKMIMAGE := true
+BOARD_VENDOR_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
+TARGET_COPY_OUT_VENDOR_DLKM := vendor_dlkm
+
 {{^dynamic-partitions}}
 BOARD_VENDORIMAGE_PARTITION_SIZE := $(VENDOR_PARTITION_SIZE)
 {{/dynamic-partitions}}
 {{#slot-ab}}
 AB_OTA_PARTITIONS += vendor
+AB_OTA_PARTITIONS += vendor_dlkm
 {{/slot-ab}}

--- a/groups/vendor-partition/true/BoardConfig.mk
+++ b/groups/vendor-partition/true/BoardConfig.mk
@@ -9,6 +9,12 @@ BOARD_USES_VENDOR_DLKMIMAGE := true
 BOARD_VENDOR_DLKMIMAGE_FILE_SYSTEM_TYPE := {{system_fs}}
 TARGET_COPY_OUT_VENDOR_DLKM := vendor_dlkm
 
+# Enabled chained vbmeta for vendor_dlkm
+BOARD_AVB_VBMETA_VENDOR_DLKM := vendor_dlkm
+BOARD_AVB_VBMETA_VENDOR_DLKM_KEY_PATH :=  external/avb/test/data/testkey_rsa4096.pem
+BOARD_AVB_VBMETA_VENDOR_DLKM_ALGORITHM := SHA256_RSA4096
+BOARD_AVB_VENDOR_DLKM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
+
 {{^dynamic-partitions}}
 BOARD_VENDORIMAGE_PARTITION_SIZE := $(VENDOR_PARTITION_SIZE)
 {{/dynamic-partitions}}

--- a/groups/vendor-partition/true/fstab
+++ b/groups/vendor-partition/true/fstab
@@ -11,4 +11,5 @@
 {{/dynamic-partitions}}
 {{#dynamic-partitions}}
 vendor   /vendor  {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait{{#slot-ab}},slotselect{{/slot-ab}},avb,logical,first_stage_mount
+vendor_dlkm /vendor_dlkm {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait,logical,first_stage_mount,{{#slot-ab}}slotselect,{{/slot-ab}}avb
 {{/dynamic-partitions}}

--- a/groups/vendor-partition/true/fstab.recovery
+++ b/groups/vendor-partition/true/fstab.recovery
@@ -6,4 +6,5 @@
 {{/dynamic-partitions}}
 {{#dynamic-partitions}}
 vendor   /vendor  {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait{{#slot-ab}},slotselect{{/slot-ab}},logical,first_stage_mount
+vendor_dlkm /vendor_dlkm {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait,logical,first_stage_mount,{{#slot-ab}}slotselect,{{/slot-ab}}
 {{/dynamic-partitions}}


### PR DESCRIPTION
GAS Vendor Software Requirements 4.0:
    Automotive device implementations launched with Android 13
    or higher and running kernel version 5.15.41 or higher
    [G-0-777] MUST have the vendor_dlkm dynamic partition
    and the vendor_boot static partition.
    The patch enables DLKM for system/vendor/odm partitions
