### PR TITLE
Remove logwrapper for auto_detection

### DIFF
--- a/groups/aaf/cfc/init.rc
+++ b/groups/aaf/cfc/init.rc
@@ -1,7 +1,7 @@
 on fs
     mkdir /mnt/share
     mount 9p aaf /mnt/share
-    exec - system system -- /vendor/bin/logwrapper /vendor/bin/sh /vendor/bin/auto_detection.sh
+    exec - system system -- /vendor/bin/auto_detection.sh
     setprop ro.hardware.hwcomposer remote
     setprop vendor.sys.display.size 540x960
     setprop ro.hardware.gralloc ${vendor.gralloc.set}

--- a/groups/aaf/true/init.rc
+++ b/groups/aaf/true/init.rc
@@ -1,7 +1,7 @@
 on fs
     mkdir /mnt/share
     mount 9p aaf /mnt/share
-    exec - system system -- /vendor/bin/logwrapper /vendor/bin/sh /vendor/bin/auto_detection.sh
+    exec - system system -- /vendor/bin/auto_detection.sh
     setprop ro.hardware.hwcomposer ${vendor.hwcomposer.set}
     setprop ro.hardware.gralloc ${vendor.gralloc.set}
     setprop ro.hardware.egl ${vendor.egl.set}


### PR DESCRIPTION
logwrapper is a utility in Android that wraps a given command and redirects its output (both stdout and stderr) to the Android logging system. It's usually used in early development stage, and for auto_detection, logwrapper is here for serveral years now. From the SELinux's perspective, it's very confusing why a log utility needs some much permissions.

Tracked-On: OAM-128889