### PR TITLE
Remove virtiofs from recovery fstab

### DIFF
--- a/groups/ota-coordinator/true/fstab.recovery
+++ b/groups/ota-coordinator/true/fstab.recovery
@@ -1,1 +1,0 @@
-myfs                            /ota            virtiofs  defaults                                                  defaults


### PR DESCRIPTION
This one will cause OTA upgrade to fail if the launch script doesn't contain the corresponding content. Safely remove it since virtiofs will be mounted in aosp recovery code.

Tracked-On: OAM-128860