### PR TITLE
Fix for "Alarm tone plays on zone1 instead of zone0"

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -23,7 +23,7 @@
 -->
 <carAudioConfiguration version="3">
     <zones>
-        <zone name="primary zone" isPrimary="true" occupantZoneId="0">
+        <zone name="primary zone" isPrimary="true"  audioZoneId="0" occupantZoneId="0">
             <zoneConfigs>
                 <zoneConfig name="primary zone config" isDefault="true">
                     <volumeGroups>


### PR DESCRIPTION
audioZoneId is missing for primary zone
fixed issue by adding audioZoneId and tweaking primary zone to 0,0 and secondary zone 1,1

Tests conducted:
1.boot check is ok.
2.Verified reported issue.
3.Checked the alarm for both users.
4.Audio playback & recording works fine.

Tracked-On: OAM-129059