### PR TITLE
Re-Enable vendor AIDL Audio HAL

### DIFF
--- a/groups/audio/audio_base_aaos/product.mk
+++ b/groups/audio/audio_base_aaos/product.mk
@@ -30,7 +30,7 @@ PRODUCT_PACKAGES += \
 
 # Audio HAL
 PRODUCT_PACKAGES += \
-    com.android.hardware.audio \
+    com.android.hardware.audio.intel \
     android.hardware.automotive.audiocontrol-service.example
 
 # rro overlay for audioUseDynamicRouting


### PR DESCRIPTION
Revert "Revert "Rename example AIDL service and impl to vendor intel"" This reverts commit db3fd20dcefc5ca9d99ccc98b227a72d6db62309.

Tracked-On: OAM-129168