### PR TITLE
Fix Python warnings in mixins-update

### DIFF
--- a/mixin-update
+++ b/mixin-update
@@ -687,7 +687,7 @@ class Parser(FileHelper):
         definitions. If a ConfigParser is supplied as an argument, it will
         be augmented with the new data"""
         if not cp:
-            cp = configparser.SafeConfigParser()
+            cp = configparser.ConfigParser()
             cp.optionxform = str
 
         spec_file = sf
@@ -695,7 +695,8 @@ class Parser(FileHelper):
             spec_file = self.render_file_content(sf, params)
         try:
             with open(spec_file) as fp:
-                cp.readfp(fp)
+                cp.read_file(fp)
+
         except IOError:
             if os.path.islink(spec_file):
                 self.error("reading sf {} which is a symlink,"
@@ -709,10 +710,10 @@ class Parser(FileHelper):
         regx_val = re.compile(r"(?<!\\),")  # param's value can contain comma (escaped with backslash)
         res = []
         for group, option_params in selections:
-            m = re.match('([^\s(]+)\s*\(([^)]*)\)\s*$', option_params)
+            m = re.match(r'([^\s(]+)\s*\(([^)]*)\)\s*$', option_params)
             if m is not None:
                 option = m.group(1)
-                params = dict(map(str.strip, x.replace('\,',',').split('=', 1)) for x in regx_val.split(m.group(2)))
+                params = dict(map(str.strip, x.replace(r'\,',',').split('=', 1)) for x in regx_val.split(m.group(2)))
                 self._coerce_boolean(params)
                 res.append((group, option, ReadTrackingDict(params)))
             else:
@@ -1125,7 +1126,7 @@ class Updater(FileHelper):
             self.error("build-time references to paths inside mixin directory are not allowed; {} is invalid".format(src))
 
         # much faster than previous regexp (\w*)
-        m = re.findall('(' + '|'.join(self.warn_vars) + ')\s*:=', slines)
+        m = re.findall(r'(' + '|'.join(self.warn_vars) + r')\s*:=', slines)
         if m:
             self.warning("Non-accumulative assignment to '{}' found in {}".format(m[0], src))
 


### PR DESCRIPTION
1. fix the python3.12 onward mixins-update errors, while they are warnings in python3.10
2. fix the warnings like: SyntaxWarning: invalid escape sequence '\s'
  m = re.match('([^\s(]+)\s*\(([^)]*)\)\s*$', option_params)

Tests Done: Build and boot

Tracked-On: OAM-123206