### PR TITLE
Fix for "Sometimes audio tone doesn't play in Kitchensink"

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
@@ -17,13 +17,13 @@
 
     <!-- Audio Zone 0 -->
     <item>bus0_media_CARD_0_DEV_1</item>
-    <item>bus1_navigation_CARD_0_DEV_1</item>
+    <item>bus1_navigation_CARD_0_DEV_7</item>
     <item>bus2_voice_command_CARD_0_DEV_1</item>
-    <item>bus3_call_ring_CARD_0_DEV_1</item>
+    <item>bus3_call_ring_CARD_0_DEV_8</item>
     <item>bus4_call_CARD_0_DEV_1</item>
     <item>bus5_alarm_CARD_0_DEV_1</item>
     <item>bus6_notification_CARD_0_DEV_1</item>
-    <item>bus7_system_sound_CARD_0_DEV_1</item>
+    <item>bus7_system_sound_CARD_0_DEV_9</item>
 
     <item>Built-In Mic</item>
     <item>Built-In Back Mic</item>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
@@ -25,8 +25,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus1_navigation_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus1_navigation_CARD_0_DEV_1">
+    <devicePort tagName="bus1_navigation_CARD_0_DEV_7" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus1_navigation_CARD_0_DEV_7">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -45,8 +45,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus3_call_ring_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus3_call_ring_CARD_0_DEV_1">
+    <devicePort tagName="bus3_call_ring_CARD_0_DEV_8" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus3_call_ring_CARD_0_DEV_8">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -85,8 +85,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus7_system_sound_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus7_system_sound_CARD_0_DEV_1">
+    <devicePort tagName="bus7_system_sound_CARD_0_DEV_9" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus7_system_sound_CARD_0_DEV_9">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
@@ -17,15 +17,15 @@
 
     <!-- Audio Zone 0-->
     <route type="mix" sink="bus0_media_CARD_0_DEV_1" sources="mixport_bus0_media_out"/>
-    <route type="mix" sink="bus1_navigation_CARD_0_DEV_1" sources="mixport_bus1_navigation_out"/>
+    <route type="mix" sink="bus1_navigation_CARD_0_DEV_7" sources="mixport_bus1_navigation_out"/>
     <route type="mix" sink="bus2_voice_command_CARD_0_DEV_1"
            sources="mixport_bus2_voice_command_out"/>
-    <route type="mix" sink="bus3_call_ring_CARD_0_DEV_1" sources="mixport_bus3_call_ring_out"/>
+    <route type="mix" sink="bus3_call_ring_CARD_0_DEV_8" sources="mixport_bus3_call_ring_out"/>
     <route type="mix" sink="bus4_call_CARD_0_DEV_1" sources="mixport_bus4_call_out"/>
     <route type="mix" sink="bus5_alarm_CARD_0_DEV_1" sources="mixport_bus5_alarm_out"/>
     <route type="mix" sink="bus6_notification_CARD_0_DEV_1"
            sources="mixport_bus6_notification_out"/>
-    <route type="mix" sink="bus7_system_sound_CARD_0_DEV_1"
+    <route type="mix" sink="bus7_system_sound_CARD_0_DEV_9"
            sources="mixport_bus7_system_sound_out"/>
     
     <route type="mix" sink="primary input"

--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -31,34 +31,28 @@
                             <device address="bus0_media_CARD_0_DEV_1">
                                 <context context="music"/>
                                 <context context="announcement"/>
-                                <context context="call"/>
-                            </device>
-                            <device address="bus6_notification_CARD_0_DEV_1">
-                                <context context="notification"/>
                             </device>
                         </group>
                         <group>
-                            <device address="bus1_navigation_CARD_0_DEV_1">
+                            <device address="bus1_navigation_CARD_0_DEV_7">
                                 <context context="navigation"/>
                             </device>
-                            <device address="bus2_voice_command_CARD_0_DEV_1">
-                                <context context="voice_command"/>
-                            </device>
                         </group>
                         <group>
-                            <device address="bus3_call_ring_CARD_0_DEV_1">
+                            <device address="bus3_call_ring_CARD_0_DEV_8">
                                 <context context="call_ring"/>
+                                <context context="call"/>
                             </device>
                         </group>
                         <group>
-                            <device address="bus5_alarm_CARD_0_DEV_1">
-                                <context context="alarm"/>
-                            </device>
-                            <device address="bus7_system_sound_CARD_0_DEV_1">
+                            <device address="bus7_system_sound_CARD_0_DEV_9">
                                 <context context="system_sound"/>
                                 <context context="emergency"/>
                                 <context context="safety"/>
                                 <context context="vehicle_status"/>
+                                <context context="notification"/>
+                                <context context="voice_command"/>
+                                <context context="alarm"/>
                             </device>
                         </group>
                     </volumeGroups>


### PR DESCRIPTION
Updated device addresses properly map to audio contexts. 
This resolves sound loss issues during playback in the Kitchen Sink app when playing navigation or voice-related audio.

Tests conducted:
1.Boot check is ok.
2.Playing sound from setting bar is ok.
3.Verified the reported issue.
4.Playback & recording is fine in multiuser.

Tracked-On: OAM-129058