### PR TITLE
Fix for CtsBatteryHealthTestCases failing test cases

### DIFF
--- a/groups/health/hal/product.mk
+++ b/groups/health/hal/product.mk
@@ -1,2 +1,7 @@
-PRODUCT_PACKAGES +=   android.hardware.health-service.intel
-
+ifeq ($(TARGET_PRODUCT),base_aaos)
+        PRODUCT_PACKAGES += android.hardware.health-service.automotive
+else ifeq ($(TARGET_PRODUCT),aaos_iasw)
+        PRODUCT_PACKAGES += android.hardware.health-service.automotive
+else
+        PRODUCT_PACKAGES +=   android.hardware.health-service.intel
+endif


### PR DESCRIPTION
3 test cases were failing:
 - android.os.cts.batteryhealth.BatteryHealthTest#testAutomotive_getLongProperty
 - android.os.cts.batteryhealth.BatteryHealthTest#testAutomotive_getIntProperty
 - android.os.cts.batteryhealth.BatteryHealthTest#testAutomotive_getIntExtra

Updating product.mk to pick particular service with respect to the TARGET_PRODUCT fixes the issue.

Tests Done:
 - Android Boot
 - Required service being picked up

Tracked-On: OAM-127856