### PR TITLE
Make encoder support identical size ranges for width and height

### DIFF
--- a/groups/codec2/true/media_codecs_intel_c2_video.xml
+++ b/groups/codec2/true/media_codecs_intel_c2_video.xml
@@ -119,7 +119,7 @@ and updated to vendor media codecs.
 {{#hw_ve_h264}}
         <MediaCodec name="c2.intel.avc.encoder" type="video/avc">
             <!-- profiles and levels:  ProfileBaseline : Level41 -->
-            <Limit name="size" min="128x96" max="4096x4096" />
+            <Limit name="size" min="128x128" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-65536" /> <!-- max 4096x4096 equivalent -->
@@ -135,7 +135,7 @@ and updated to vendor media codecs.
 
 {{#hw_ve_h265}}
         <MediaCodec name="c2.intel.hevc.encoder" type="video/hevc" >
-            <Limit name="size" min="176x144" max="8192x8192" />
+            <Limit name="size" min="176x176" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-262144" />
@@ -150,7 +150,7 @@ and updated to vendor media codecs.
 
 {{#hw_ve_vp9}}
 	<MediaCodec name="c2.intel.vp9.encoder" type="video/x-vnd.on2.vp9" >
-            <Limit name="size" min="128x96" max="8192x8192" />
+            <Limit name="size" min="128x128" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-262144" />
@@ -163,7 +163,7 @@ and updated to vendor media codecs.
 
 {{#hw_ve_av1}}
         <MediaCodec name="c2.intel.av1.encoder" type="video/av01">
-            <Limit name="size" min="176x144" max="4096x4096" />
+            <Limit name="size" min="176x176" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-16384" />

--- a/groups/codec2/true/media_codecs_intel_c2_video_gen13.xml
+++ b/groups/codec2/true/media_codecs_intel_c2_video_gen13.xml
@@ -95,7 +95,7 @@ and updated to vendor media codecs.
     <Encoders>
         <MediaCodec name="c2.intel.avc.encoder" type="video/avc">
             <!-- profiles and levels:  ProfileBaseline : Level41 -->
-            <Limit name="size" min="176x144" max="4096x4096" />
+            <Limit name="size" min="128x128" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-8192" /> <!-- max 2048x1024 -->
@@ -108,7 +108,7 @@ and updated to vendor media codecs.
         </MediaCodec>
 
         <MediaCodec name="c2.intel.hevc.encoder" type="video/hevc" >
-            <Limit name="size" min="176x144" max="8192x8192" />
+            <Limit name="size" min="176x176" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="blocks-per-second" range="1-972000" />
@@ -118,7 +118,7 @@ and updated to vendor media codecs.
         </MediaCodec>
 
 	<MediaCodec name="c2.intel.vp9.encoder" type="video/x-vnd.on2.vp9" >
-            <Limit name="size" min="128x96" max="8192x8192" />
+            <Limit name="size" min="128x128" max="8192x8192" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-245760" />
@@ -129,7 +129,7 @@ and updated to vendor media codecs.
         </MediaCodec>
 
         <MediaCodec name="c2.intel.av1.encoder" type="video/av01">
-            <Limit name="size" min="176x144" max="4096x4096" />
+            <Limit name="size" min="176x176" max="4096x4096" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="block-count" range="1-16384" />


### PR DESCRIPTION
Some tests of testResolutionSupport in CtsMediaV2TestCases failed because encoder does not support identical size ranges, make encoder supported height range and width range identical.

Tracked-On: OAM-129545