### PR TITLE
Add node creation for uvcvideo virtvideo

### DIFF
--- a/groups/camera-ext/aaos_iasw/ueventd.rc
+++ b/groups/camera-ext/aaos_iasw/ueventd.rc
@@ -1,2 +1,4 @@
 # Camera
 /dev/video*       0660  system  camera
+/dev/uvcvideo*       0660  system  camera
+/dev/virtvideo*       0660  system  camera

--- a/groups/camera-ext/base_aaos/ueventd.rc
+++ b/groups/camera-ext/base_aaos/ueventd.rc
@@ -1,2 +1,4 @@
 # Camera
 /dev/video*       0660  system  camera
+/dev/uvcvideo*       0660  system  camera
+/dev/virtvideo*       0660  system  camera

--- a/groups/camera-ext/ext-camera-only/ueventd.rc
+++ b/groups/camera-ext/ext-camera-only/ueventd.rc
@@ -1,2 +1,4 @@
 # Camera
 /dev/video*       0660  system  camera
+/dev/uvcvideo*       0660  system  camera
+/dev/virtvideo*       0660  system  camera

--- a/groups/camera-ext/true/ueventd.rc
+++ b/groups/camera-ext/true/ueventd.rc
@@ -1,2 +1,4 @@
 # Camera
 /dev/video*       0660  system  camera
+/dev/uvcvideo*       0660  system  camera
+/dev/virtvideo*       0660  system  camera


### PR DESCRIPTION
Issue-Detailed: Renamed virtiocamera device to virtvideo.

Issue-Fixed: add the sepolicy for /dev/virtvideo* device.

Tested-On: Camera preview/capture/record works.

Tracked-On: OAM-129620