### PR TITLE
Fix for "no exclusive media control UI"

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -31,7 +31,6 @@
                             <device address="bus0_media_CARD_0_DEV_1">
                                 <context context="music"/>
                                 <context context="announcement"/>
-                                <context context="call"/>
                             </device>
                             <device address="bus6_notification_CARD_0_DEV_1">
                                 <context context="notification"/>
@@ -47,7 +46,8 @@
                         </group>
                         <group>
                             <device address="bus3_call_ring_CARD_0_DEV_1">
-                                <context context="call_ring"/>
+				    <context context="call_ring"/>
+				    <context context="call"/>
                             </device>
                         </group>
                         <group>


### PR DESCRIPTION
- Previously, in-call volume was used for media control, causing the absence of a dedicated UI for media controls.
- The fix separates the media and in-call volume controls by creating distinct groups for each in the XML configuration.

Tests conducted:
1.Boot check is ok.
2.Playing sound from setting bar is ok.
3.Verified the reported issue.
4.Playback & recording is fine.

Tracked-On: OAM-129575