### PR TITLE
Add btusb dev path for celadon target

### DIFF
--- a/groups/bluetooth/btusb/ueventd.rc
+++ b/groups/bluetooth/btusb/ueventd.rc
@@ -2,4 +2,5 @@
 /sys/devices/pci*/0000:00:*/usb*/*/*/*/bluetooth/hci0/rfkill* state  0660 bluetooth bluetooth
 /sys/devices/pci*/0000:00:*/usb*/*/*/*/bluetooth/hci0/rfkill* type   0440 bluetooth bluetooth
 /dev/rfkill                   0660   root       bluetooth
+/dev/bus/usb/00*/00*               0660 bluetooth bluetooth
 /dev/bus/usb/00*/btusb               0660 bluetooth bluetooth


### PR DESCRIPTION
Add btusb dev path for celadon target

HFP playback and capture not working, as BT HAL failed to
send HFP sco handle to btusb sco snd driver.

Add corresponding ueventd rules for btusb device path.
/dev/bus/usb/00*/00*   

Tests done:
1. Connect BT headset
2. Make HFP SCO call
3. Verify BT HAL logs for sco handle
4. tinycap and tinyplay working

Tracked-On: OAM-129787
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
