### PR TITLE
Allow thermal-daemon to start in caas

### DIFF
--- a/groups/device-specific/caas/system.prop
+++ b/groups/device-specific/caas/system.prop
@@ -12,6 +12,8 @@ debug.nn.cpuonly=0
 camera.disable_treble=false
 ro.incremental.enable=yes
 
+persist.vendor.thermal.daemon.supported=1
+
 # Set the Bluetooth Class of Device
 # Service Field: 0x5A -> 90
 #    Bit 17: Networking

--- a/groups/thermal/thermal-daemon/init.rc
+++ b/groups/thermal/thermal-daemon/init.rc
@@ -20,5 +20,8 @@ on post-fs-data
     setprop persist.vendor.thermal.mode thermal-daemon
     mkdir /data/vendor/thermal-daemon 0660 system system
 
-# on property:sys.boot_completed=1 && property:vendor.thermal.enable=1
-#    start thermal-daemon
+on property:sys.boot_completed=1 && property:vendor.thermal.enable=1
+    start thermal-daemon
+
+on property:persist.vendor.thermal.daemon.supported=0
+    stop thermal-daemon


### PR DESCRIPTION
This change allows thermal-daemon to automatically start
during bootup

Tracked-On: OAM-129813