### PR TITLE
enabling mouse to wakeup device after suspend.

### DIFF
--- a/groups/usb/host/init.rc
+++ b/groups/usb/host/init.rc
@@ -1,5 +1,6 @@
 on boot
     write /sys/devices/pci0000\:00/0000\:00\:14.0/power/control auto
+    write /sys/devices/pci0000\:00/0000\:00\:14.0/usb3/3-*/power/wakeup enabled
 
 on charger
     write /sys/devices/pci0000\:00/0000\:00\:14.0/power/control auto


### PR DESCRIPTION
when devices goes on suspend state, mouse click will resume the device from suspend state.

Tracked-On:OAM-129415