### PR TITLE
Bluetooth fix clearSignalStrengthUpdateRequest is unsupported issue

### DIFF
--- a/groups/bluetooth/btusb/android.hardware.telephony.automotive.xml
+++ b/groups/bluetooth/btusb/android.hardware.telephony.automotive.xml
@@ -17,4 +17,7 @@
 <!-- This is the standard set of features for devices to support Telephony Subscription API. -->
 <permissions>
   <feature name="android.hardware.telephony.subscription" />
+  <feature name="android.hardware.telephony.radio.access" />
+  <feature name="android.hardware.telephony.messaging" />
+  <feature name="android.hardware.telephony.data" />
 </permissions>


### PR DESCRIPTION
Fix below issue in logcat:
"clearSignalStrengthUpdateRequest is unsupported
without android.hardware.telephony.radio.access"

Test:
open bluetooth, connect phone to ivi, all work

Tracked-On: OAM-129994