### PR TITLE
Fix for ATS AtsFeatureDeviceTestCases failure

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/android.hardware.audio.xml
+++ b/groups/audio/audio_base_aaos/default/policy/android.hardware.audio.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2024 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<permissions>
+    <!-- This feature indicates that the system can safely allow audio while
+    driving for ndo apps. This flag is intended to be removed once all NDO
+    certified OEMs have adopted this feature b/331812589 -->
+    <feature name="com.android.car.background_audio_while_driving"/>
+</permissions>

--- a/groups/audio/audio_base_aaos/product.mk
+++ b/groups/audio/audio_base_aaos/product.mk
@@ -57,6 +57,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/default/policy/hdmi_audio_policy_configuration.xml:vendor/etc/hdmi_audio_policy_configuration.xml \
     $(LOCAL_PATH)/audio/default/policy/audio_policy_volumes.xml:vendor/etc/audio_policy_volumes.xml \
     $(LOCAL_PATH)/audio/default/policy/default_volume_tables.xml:vendor/etc/default_volume_tables.xml \
+    $(LOCAL_PATH)/audio/default/policy/android.hardware.audio.xml:vendor/etc/permissions/android.hardware.audio.xml \
     $(LOCAL_PATH)/audio/default/effect/audio_effects.xml:vendor/etc/audio_effects.xml \
     $(LOCAL_PATH)/audio/default/effect/audio_effects_config.xml:vendor/etc/audio_effects_config.xml
 


### PR DESCRIPTION
Add permission for com.android.car.background_audio_while_driving

Test Done:
- Boot check
- Audio Sanity
- Run ATS Test: com.google.android.feature.ats.AtsFeatureDeviceTest#testFeatureAlternativeAppControls

Tracked-On: OAM-129333