### PR TITLE
Do Not Merge: force has_virgl return false for sw rendering

### DIFF
--- a/groups/graphics/auto/auto_hal.in
+++ b/groups/graphics/auto/auto_hal.in
@@ -15,7 +15,7 @@ has_intel_gpu() {
 
 has_virgl() {
         # Assume that virgl is always available unless it's explicitly ruled out.
-        local found=1
+        local found=0
         for f in /sys/kernel/debug/dri/*; do
                 if [ ! -e "$f/virtio-gpu-features" ]; then
                         continue


### PR DESCRIPTION
To WA vendor.egl.set is mesa instead of angel on board that doesn't have SRIOV enabled in BIOS.