### PR TITLE
Fix to improve Android alarm context switch latency

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
@@ -17,23 +17,36 @@
 
     <!-- Audio Zone 0 -->
     <item>bus0_media_CARD_0_DEV_1</item>
-    <item>bus1_navigation_CARD_0_DEV_1</item>
-    <item>bus2_voice_command_CARD_0_DEV_1</item>
-    <item>bus3_call_ring_CARD_0_DEV_1</item>
-    <item>bus4_call_CARD_0_DEV_1</item>
-    <item>bus5_alarm_CARD_0_DEV_1</item>
+    <item>bus1_navigation_CARD_0_DEV_5</item>
+    <item>bus2_voice_command_CARD_0_DEV_5</item>
+    <item>bus3_call_ring_CARD_0_DEV_6</item>
+    <item>bus4_call_CARD_0_DEV_6</item>
+    <item>bus5_alarm_CARD_0_DEV_7</item>
     <item>bus6_notification_CARD_0_DEV_1</item>
-    <item>bus7_system_sound_CARD_0_DEV_1</item>
+    <item>bus7_system_sound_CARD_0_DEV_7</item>
 
-    <item>Built-In Mic</item>
-    <item>Built-In Back Mic</item>
+    <item>bottom</item>
+    <!-- back mic pcm6-->
+    <item>back</item>
     <item>Echo-Reference Mic</item>
-    <item>i_bus1_CARD_0_DEV_1</item>
+    <!-- voice assistant pcm 5-->
+    <item>i_bus1_CARD_0_DEV_5</item>
     
     <!-- Audio Zone 1 -->
     <item>bus100_CARD_0_DEV_2</item>
-    <item>bus101_CARD_0_DEV_3</item>
-    
+    <!-- In Call-->
+    <item>bus101_CARD_0_DEV_8</item>
+
     <item>i_bus100_CARD_0_DEV_2</item>
-    
+
+    <!-- Audio Zone 2-->
+    <item>bus200_CARD_0_DEV_3</item>
+
+    <item>i_bus200_CARD_0_DEV_3</item>
+
+    <!-- Audio Zone 3-->
+    <item>bus300_CARD_0_DEV_4</item>
+
+    <item>i_bus300_CARD_0_DEV_4</item>
+
 </attachedDevices>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
@@ -25,8 +25,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus1_navigation_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus1_navigation_CARD_0_DEV_1">
+    <devicePort tagName="bus1_navigation_CARD_0_DEV_5" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus1_navigation_CARD_0_DEV_5">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -35,8 +35,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus2_voice_command_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus2_voice_command_CARD_0_DEV_1">
+    <devicePort tagName="bus2_voice_command_CARD_0_DEV_5" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus2_voice_command_CARD_0_DEV_5">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -45,8 +45,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus3_call_ring_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus3_call_ring_CARD_0_DEV_1">
+    <devicePort tagName="bus3_call_ring_CARD_0_DEV_6" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus3_call_ring_CARD_0_DEV_6">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -55,8 +55,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus4_call_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus4_call_CARD_0_DEV_1">
+    <devicePort tagName="bus4_call_CARD_0_DEV_6" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus4_call_CARD_0_DEV_6">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -65,8 +65,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus5_alarm_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus5_alarm_CARD_0_DEV_1">
+    <devicePort tagName="bus5_alarm_CARD_0_DEV_7" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus5_alarm_CARD_0_DEV_7">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -85,8 +85,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus7_system_sound_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus7_system_sound_CARD_0_DEV_1">
+    <devicePort tagName="bus7_system_sound_CARD_0_DEV_7" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus7_system_sound_CARD_0_DEV_7">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -96,14 +96,14 @@
         </gains>
     </devicePort>
 
-    <devicePort tagName="Built-In Mic" type="AUDIO_DEVICE_IN_BUILTIN_MIC" role="source"
-                address="Built-In Mic" >
+    <devicePort tagName="bottom" type="AUDIO_DEVICE_IN_BUILTIN_MIC" role="source"
+                address="bottom" >
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="8000 11025 12000 16000 22050 24000 32000 44100 48000"
                  channelMasks="AUDIO_CHANNEL_IN_MONO AUDIO_CHANNEL_IN_STEREO AUDIO_CHANNEL_IN_FRONT_BACK"/>
     </devicePort>
-    <devicePort tagName="Built-In Back Mic" type="AUDIO_DEVICE_IN_BACK_MIC"
-                role="source" address="Built-In Back Mic">
+    <devicePort tagName="back" type="AUDIO_DEVICE_IN_BACK_MIC"
+                role="source" address="back">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="8000 11025 12000 16000 22050 24000 32000 44100 48000"
                  channelMasks="AUDIO_CHANNEL_IN_MONO AUDIO_CHANNEL_IN_STEREO AUDIO_CHANNEL_IN_FRONT_BACK"/>
@@ -114,8 +114,8 @@
                  samplingRates="8000 11025 12000 16000 22050 24000 32000 44100 48000"
                  channelMasks="AUDIO_CHANNEL_IN_MONO AUDIO_CHANNEL_IN_STEREO AUDIO_CHANNEL_IN_FRONT_BACK"/>
     </devicePort>
-    <devicePort tagName="i_bus1_CARD_0_DEV_1" type="AUDIO_DEVICE_IN_BUS"
-            role="source" address="i_bus1_CARD_0_DEV_1">
+    <devicePort tagName="i_bus1_CARD_0_DEV_5" type="AUDIO_DEVICE_IN_BUS"
+            role="source" address="i_bus1_CARD_0_DEV_5">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                     samplingRates="48000"
                     channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
@@ -137,8 +137,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
             </gains>
     </devicePort>
-    <devicePort tagName="bus101_CARD_0_DEV_3" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus101_CARD_0_DEV_3">
+    <devicePort tagName="bus101_CARD_0_DEV_8" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus101_CARD_0_DEV_8">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -159,4 +159,53 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
+
+    <!-- Audio zone 2 -->
+    <devicePort tagName="bus200_CARD_0_DEV_3" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus200_CARD_0_DEV_3">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+        <gains>
+            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
+                  minValueMB="-3200" maxValueMB="600"
+                  defaultValueMB="0" stepValueMB="100"/>
+            </gains>
+    </devicePort>
+
+    <devicePort tagName="i_bus200_CARD_0_DEV_3" type="AUDIO_DEVICE_IN_BUS"
+                role="source" address="i_bus200_CARD_0_DEV_3">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+        <gains>
+            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
+                  minValueMB="-3200" maxValueMB="600"
+                  defaultValueMB="0" stepValueMB="100"/>
+        </gains>
+    </devicePort>
+
+    <!-- Audio zone 3-->
+    <devicePort tagName="bus300_CARD_0_DEV_4" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus300_CARD_0_DEV_4">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+        <gains>
+            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
+                  minValueMB="-3200" maxValueMB="600"
+                  defaultValueMB="0" stepValueMB="100"/>
+            </gains>
+    </devicePort>
+
+    <devicePort tagName="i_bus300_CARD_0_DEV_4" type="AUDIO_DEVICE_IN_BUS"
+                role="source" address="i_bus300_CARD_0_DEV_4">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+        <gains>
+            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
+                  minValueMB="-3200" maxValueMB="600"
+                  defaultValueMB="0" stepValueMB="100"/>
+        </gains>
+    </devicePort>
+
 </devicePorts>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_mixports.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_mixports.xml
@@ -63,6 +63,21 @@
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
     </mixPort>
+    <mixPort name="Built-In Mic" role="sink">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+    </mixPort>
+    <mixPort name="Built-In Back Mic" role="sink">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+    </mixPort>
+    <mixPort name="Echo-Reference" role="sink">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+    </mixPort>
     <mixPort name="mixport_input_bus1_zone_0" role="sink">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
@@ -84,6 +99,34 @@
     </mixPort>
 
     <mixPort name="mixport_input_bus100_zone_1" role="sink">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+    </mixPort>
+
+    <!-- Audio Zone 2-->
+    <mixPort name="mixport_bus200_CARD_0_DEV_3" role="source"
+             flags="AUDIO_OUTPUT_FLAG_PRIMARY">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+    </mixPort>
+
+    <mixPort name="mixport_input_bus200_zone_2" role="sink">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+    </mixPort>
+
+    <!-- Audio Zone 3-->
+    <mixPort name="mixport_bus101_audio_zone_1" role="source"
+             flags="AUDIO_OUTPUT_FLAG_PRIMARY">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+    </mixPort>
+
+    <mixPort name="mixport_input_bus300_zone_3" role="sink">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_IN_STEREO"/>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
@@ -17,23 +17,33 @@
 
     <!-- Audio Zone 0-->
     <route type="mix" sink="bus0_media_CARD_0_DEV_1" sources="mixport_bus0_media_out"/>
-    <route type="mix" sink="bus1_navigation_CARD_0_DEV_1" sources="mixport_bus1_navigation_out"/>
-    <route type="mix" sink="bus2_voice_command_CARD_0_DEV_1"
+    <route type="mix" sink="bus1_navigation_CARD_0_DEV_5" sources="mixport_bus1_navigation_out"/>
+    <route type="mix" sink="bus2_voice_command_CARD_0_DEV_5"
            sources="mixport_bus2_voice_command_out"/>
-    <route type="mix" sink="bus3_call_ring_CARD_0_DEV_1" sources="mixport_bus3_call_ring_out"/>
-    <route type="mix" sink="bus4_call_CARD_0_DEV_1" sources="mixport_bus4_call_out"/>
-    <route type="mix" sink="bus5_alarm_CARD_0_DEV_1" sources="mixport_bus5_alarm_out"/>
+    <route type="mix" sink="bus3_call_ring_CARD_0_DEV_6" sources="mixport_bus3_call_ring_out"/>
+    <route type="mix" sink="bus4_call_CARD_0_DEV_6" sources="mixport_bus4_call_out"/>
+    <route type="mix" sink="bus5_alarm_CARD_0_DEV_7" sources="mixport_bus5_alarm_out"/>
     <route type="mix" sink="bus6_notification_CARD_0_DEV_1"
            sources="mixport_bus6_notification_out"/>
-    <route type="mix" sink="bus7_system_sound_CARD_0_DEV_1"
+    <route type="mix" sink="bus7_system_sound_CARD_0_DEV_7"
            sources="mixport_bus7_system_sound_out"/>
     
-    <route type="mix" sink="primary input"
-           sources="Built-In Mic,Built-In Back Mic,Echo-Reference Mic"/>
-    <route type="mix" sink="mixport_input_bus1_zone_0" sources="i_bus1_CARD_0_DEV_1"/>
+    <route type="mix" sink="primary input" sources="bottom"/>
+    <route type="mix" sink="Built-In Back Mic" sources="back"/>
+    <route type="mix" sink="Echo-Reference" sources="Echo-Reference Mic"/>
+    <route type="mix" sink="mixport_input_bus1_zone_0" sources="i_bus1_CARD_0_DEV_5"/>
     
     <!-- Audio Zone 1-->
     <route type="mix" sink="bus100_CARD_0_DEV_2" sources="mixport_bus100_audio_zone_1"/>
-    <route type="mix" sink="bus101_CARD_0_DEV_3" sources="mixport_bus101_audio_zone_1"/>
+    <route type="mix" sink="bus101_CARD_0_DEV_8" sources="mixport_bus101_audio_zone_1"/>
     <route type="mix" sink="mixport_input_bus100_zone_1" sources="i_bus100_CARD_0_DEV_2"/>
+
+    <!-- Audio Zone 2-->
+    <route type="mix" sink="bus200_CARD_0_DEV_3" sources="mixport_bus200_CARD_0_DEV_3"/>
+    <route type="mix" sink="mixport_input_bus200_zone_2" sources="i_bus200_CARD_0_DEV_3"/>
+
+    <!-- Audio Zone 3-->
+    <route type="mix" sink="bus300_CARD_0_DEV_4" sources="mixport_bus101_audio_zone_1"/>
+    <route type="mix" sink="mixport_input_bus300_zone_3" sources="i_bus300_CARD_0_DEV_4"/>
+
 </routes>

--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -37,24 +37,26 @@
                             </device>
                         </group>
                         <group>
-                            <device address="bus1_navigation_CARD_0_DEV_1">
+                            <device address="bus1_navigation_CARD_0_DEV_5">
                                 <context context="navigation"/>
                             </device>
-                            <device address="bus2_voice_command_CARD_0_DEV_1">
+                            <device address="bus2_voice_command_CARD_0_DEV_5">
                                 <context context="voice_command"/>
                             </device>
                         </group>
                         <group>
-                            <device address="bus3_call_ring_CARD_0_DEV_1">
-				    <context context="call_ring"/>
-				    <context context="call"/>
+                            <device address="bus3_call_ring_CARD_0_DEV_6">
+				                <context context="call_ring"/>
+                            </device>
+                            <device address="bus4_call_CARD_0_DEV_6">
+				                <context context="call"/>
                             </device>
                         </group>
                         <group>
-                            <device address="bus5_alarm_CARD_0_DEV_1">
+                            <device address="bus5_alarm_CARD_0_DEV_7">
                                 <context context="alarm"/>
                             </device>
-                            <device address="bus7_system_sound_CARD_0_DEV_1">
+                            <device address="bus7_system_sound_CARD_0_DEV_7">
                                 <context context="system_sound"/>
                                 <context context="emergency"/>
                                 <context context="safety"/>
@@ -65,9 +67,9 @@
                 </zoneConfig>
             </zoneConfigs>
             <inputDevices>
-                <!-- <inputDevice address="Built-In Mic"/>
-                <inputDevice address="Built-In Back Mic"/> -->
-                <inputDevice address="i_bus1_CARD_0_DEV_1"/>
+                <inputDevice address="bottom"/>
+                <inputDevice address="back"/>
+                <inputDevice address="i_bus1_CARD_0_DEV_5"/>
             </inputDevices>
         </zone>
         <zone name="front passenger zone 1" audioZoneId="1" occupantZoneId="1">
@@ -95,7 +97,7 @@
                 <zoneConfig name="front passenger zone 1 config 1">
                     <volumeGroups>
                         <group>
-                            <device address="bus101_CARD_0_DEV_3">
+                            <device address="bus101_CARD_0_DEV_8">
                             <context context="music"/>
                             <context context="navigation"/>
                             <context context="voice_command"/>
@@ -115,6 +117,60 @@
             </zoneConfigs>
             <inputDevices>
                 <inputDevice address="i_bus100_CARD_0_DEV_2"/>
+            </inputDevices>
+       </zone>
+       <zone name="front passenger zone 2" audioZoneId="2" occupantZoneId="2">
+            <zoneConfigs>
+                <zoneConfig name="front passenger zone 2 config 0" isDefault="true">
+                    <volumeGroups>
+                        <group>
+                            <device address="bus200_CARD_0_DEV_3">
+                            <context context="music"/>
+                            <context context="navigation"/>
+                            <context context="voice_command"/>
+                            <context context="call_ring"/>
+                            <context context="call"/>
+                            <context context="alarm"/>
+                            <context context="notification"/>
+                            <context context="system_sound"/>
+                            <context context="emergency"/>
+                            <context context="safety"/>
+                            <context context="vehicle_status"/>
+                            <context context="announcement"/>
+                            </device>
+                        </group>
+                    </volumeGroups>
+                </zoneConfig>
+            </zoneConfigs>
+            <inputDevices>
+                <inputDevice address="i_bus200_CARD_0_DEV_3"/>
+            </inputDevices>
+       </zone>
+       <zone name="front passenger zone 3" audioZoneId="3" occupantZoneId="3">
+            <zoneConfigs>
+                <zoneConfig name="front passenger zone 3 config 0" isDefault="true">
+                    <volumeGroups>
+                        <group>
+                            <device address="bus300_CARD_0_DEV_4">
+                            <context context="music"/>
+                            <context context="navigation"/>
+                            <context context="voice_command"/>
+                            <context context="call_ring"/>
+                            <context context="call"/>
+                            <context context="alarm"/>
+                            <context context="notification"/>
+                            <context context="system_sound"/>
+                            <context context="emergency"/>
+                            <context context="safety"/>
+                            <context context="vehicle_status"/>
+                            <context context="announcement"/>
+                            </device>
+                        </group>
+                    </volumeGroups>
+                </zoneConfig>
+            </zoneConfigs>
+            <inputDevices>
+                <inputDevice address="i_bus300_CARD_0_DEV_4"/>
             </inputDevices>
        </zone>
     </zones>


### PR DESCRIPTION
Allocate different pcm devices for each context used in Android.

Test-done:
- Play different context simulatenously and no audio loss seen

Tracked-On: OAM-129522