### PR TITLE
Add support for pre-built kernel based on kleaf build

### DIFF
--- a/groups/kernel/AndroidBoard.mk
+++ b/groups/kernel/AndroidBoard.mk
@@ -1,26 +1,10 @@
-ifneq ($(wildcard $(INTEL_PATH_PREKERNEL)/$(TARGET_KERNEL_ARCH)/kernel), )
-TARGET_PREBUILT_KERNEL := $(INTEL_PATH_PREKERNEL)/$(TARGET_KERNEL_ARCH)/kernel
-endif
-
-ifneq ($(TARGET_PREBUILT_KERNEL), )
-
-TARGET_PREBUILT_KERNEL_MODULE := $(INTEL_PATH_PREKERNEL)/modules
-LOCAL_KERNEL := $(TARGET_PREBUILT_KERNEL)
-
-$(PRODUCT_OUT)/kernel: $(LOCAL_KERNEL) $(wildcard $(TARGET_PREBUILT_KERNEL_MODULE)/*)
-	  $(hide) echo "Copy prebuilt kernel from $(LOCAL_KERNEL) into $@"
-	  $(hide) cp $(LOCAL_KERNEL) $@
-	  $(hide) echo "Copy modules from $(TARGET_PREBUILT_KERNEL_MODULE) into $(PRODUCT_OUT)/$(KERNEL_MODULES_ROOT)"
-	  $(hide) mkdir -p $(PRODUCT_OUT)/$(KERNEL_MODULES_ROOT)
-	  $(hide) cp -r $(TARGET_PREBUILT_KERNEL_MODULE)/* $(PRODUCT_OUT)/$(KERNEL_MODULES_ROOT)/
-
-# kernel modules must be copied before ramdisk is generated
-$(PRODUCT_OUT)/ramdisk.img: $(PRODUCT_OUT)/kernel
-
-.PHONY: kernel
-kernel: $(PRODUCT_OUT)/kernel
-
+ifeq ($(TARGET_PREBUILT_KERNEL), true)
+ifeq ($(TARGET_BUILD_VARIANT), user)
+PREBUILT_KERNEL_ROOT := vendor/intel/utils_priv/kernel/prebuilts/6.6/{{{prebuilt_kernel_target}}}/user
 else
+PREBUILT_KERNEL_ROOT := vendor/intel/utils_priv/kernel/prebuilts/6.6/{{{prebuilt_kernel_target}}}/userdebug
+endif
+endif
 
 TARGET_KERNEL_CLANG_VERSION := r530567
 CLANG_PREBUILTS_PATH := $(abspath $(INTEL_PATH_DEVICE)/../../../prebuilts/clang)
@@ -60,6 +44,7 @@ ifeq ($(BASE_LTS2023_CHROMIUM_KERNEL), true)
 else ifeq ($(BASE_LINUX_INTEL_LTS2023_KERNEL), true)
   LOCAL_KERNEL_SRC := {{{linux_intel_lts2023_src_path}}}
   KERNEL_CONFIG_PATH := $(TARGET_DEVICE_DIR)/{{{linux_intel_lts2023_cfg_path}}}
+  ENABLE_I915_OOT_MODULE_LOADING := true
 else ifeq ($(BASE_LTS2024_ANDROID_KERNEL), true)
   LOCAL_KERNEL_SRC := {{{lts2024_android_src_path}}}
   KERNEL_CONFIG_PATH := $(TARGET_DEVICE_DIR)/{{{lts2024_android_cfg_path}}}
@@ -205,6 +190,7 @@ $(PRODUCT_OUT)/vendor.img: $(LOCAL_KERNEL_PATH)/copy_modules
 # Second, create flat hierarchy for insmod linking to previous hierarchy
 $(LOCAL_KERNEL_PATH)/copy_modules: $(LOCAL_KERNEL)
 	@echo Copy modules from $(LOCAL_KERNEL_PATH)/lib/modules/$(KERNELRELEASE) into $(PRODUCT_OUT)/$(KERNEL_MODULES_ROOT)
+ifneq ($(TARGET_PREBUILT_KERNEL), true)
 	$(hide) rm -rf $(PRODUCT_OUT)/$(KERNEL_MODULES_ROOT)
 	$(hide) rm -rf $(TARGET_RECOVERY_ROOT_OUT)/$(KERNEL_MODULES_ROOT)
 	$(hide) mkdir -p $(PRODUCT_OUT)/$(KERNEL_MODULES_ROOT)
@@ -213,6 +199,7 @@ $(LOCAL_KERNEL_PATH)/copy_modules: $(LOCAL_KERNEL)
 		mkdir -p $(PWD)/$(PRODUCT_OUT)/$(KERNEL_MODULES_ROOT)/$(KERNELRELEASE)/$$(dirname $$f) ; \
 		ln -s /$(KERNEL_MODULES_ROOT_PATH)/$$(basename $$f) $(PWD)/$(PRODUCT_OUT)/$(KERNEL_MODULES_ROOT)/$(KERNELRELEASE)/$$f || exit 1; \
 		done
+endif
 	$(hide) cd $(LOCAL_KERNEL_PATH)/lib/modules/$(KERNELRELEASE) && for f in `find . -name 'compat.ko'`; do \
 		cp $$f $(PWD)/$(PRODUCT_OUT)/vendor/firmware/i915/ || exit 1; \
 		done
@@ -230,10 +217,28 @@ $(LOCAL_KERNEL_PATH)/copy_modules: $(LOCAL_KERNEL)
 	$(hide) for f in dwc3.ko dwc3-pci.ko xhci-hcd.ko xhci-pci.ko; do \
 		find $(LOCAL_KERNEL_PATH)/lib/modules/ -name $$f -exec cp {} $(TARGET_RECOVERY_ROOT_OUT)/$(KERNEL_MODULES_ROOT)/ \; ;\
 		done
+ifneq ($(BASE_LTS2024_ANDROID_KERNEL), true)
+ifeq ($(TARGET_PREBUILT_KERNEL), true)
+	echo "Copying mei modules from prebuilt"
+#mei for recovery
+	$(hide) mkdir -p $(TARGET_RECOVERY_ROOT_OUT)/$(KERNEL_MODULES_ROOT)
+	$(hide) for f in mei.ko mei-me.ko mei-txe.ko mei-gsc.ko mei_pxp.ko mei_hdcp.ko; do \
+		find $(PREBUILT_KERNEL_ROOT)/vendor_dlkm/ -name $$f -exec cp {} $(TARGET_RECOVERY_ROOT_OUT)/$(KERNEL_MODULES_ROOT)/ \; ;\
+		done
+	$(hide) cp $(PRODUCT_OUT)/obj/modules/intel-gpu-i915-backports/compat/compat.ko $(PRODUCT_OUT)/vendor_dlkm/lib/modules/
+	$(hide) cp $(PRODUCT_OUT)/obj/modules/intel-gpu-i915-backports/drivers/gpu/drm/i915/i915_ag.ko $(PRODUCT_OUT)/vendor_dlkm/lib/modules/
+	$(hide) cp $(PRODUCT_OUT)/obj/modules/intel-gpu-i915-backports/drivers/platform/x86/intel/intel_vsec.ko $(PRODUCT_OUT)/vendor_dlkm/lib/modules/
+	rm -rf out/target/product/base_aaos/obj/kernel
+	rm -rf out/target/product/base_aaos/obj/modules
+else
+	echo "Copying mei modules from legacy kernel"
 #mei for recovery
 	$(hide) for f in mei.ko mei-me.ko mei-txe.ko mei-gsc.ko mei_pxp.ko mei_hdcp.ko; do \
 		find $(LOCAL_KERNEL_PATH)/lib/modules/ -name $$f -exec cp {} $(TARGET_RECOVERY_ROOT_OUT)/$(KERNEL_MODULES_ROOT)/ \; ;\
 		done
+endif
+endif
+
 {{#camera_cos_hack}}
 ifeq ($(KERNEL_MODULES_ROOT),vendor/lib/modules)
 	$(hide) mkdir -p $(PRODUCT_OUT)/root/vendor/lib/modules/
@@ -333,5 +338,4 @@ endif
 .PHONY: kernel
 kernel: $(LOCAL_KERNEL_PATH)/copy_modules $(PRODUCT_OUT)/kernel
 
-endif
 

--- a/groups/kernel/BoardConfig.mk
+++ b/groups/kernel/BoardConfig.mk
@@ -9,6 +9,11 @@ else
   TARGET_BOARD_KERNEL_HEADERS := $(INTEL_PATH_COMMON)/{{{src_path}}}/kernel-headers
 endif
 
+ifeq ($(TARGET_PREBUILT_KERNEL), true)
+BOARD_VENDOR_KERNEL_MODULES := \
+        $(wildcard $(PREBUILT_KERNEL_ROOT)/vendor_dlkm/*.ko)
+endif
+
 ifneq ($(TARGET_BUILD_VARIANT),user)
 KERNEL_LOGLEVEL ?= {{{loglevel}}}
 else

--- a/groups/kernel/init.rc
+++ b/groups/kernel/init.rc
@@ -84,3 +84,8 @@ on property:sys.boot_completed=1
 
 on early-init
 	mount proc proc /proc remount hidepid=2,gid=3009
+
+on fs
+	insmod /vendor/lib/modules/compat.ko
+	insmod /vendor/lib/modules/intel_vsec.ko
+	insmod /vendor/lib/modules/i915_ag.ko

--- a/groups/kernel/option.spec-gmin
+++ b/groups/kernel/option.spec-gmin
@@ -37,3 +37,4 @@ branch =
 kmi_generation =
 i915_ag_mods_version = false
 use_prebuilt_kernel = false
+prebuilt_kernel_target = client_x86_64

--- a/groups/kernel/product.mk
+++ b/groups/kernel/product.mk
@@ -3,6 +3,18 @@
   KERNEL_MODULES_ROOT := root/$(KERNEL_MODULES_ROOT_PATH)
 {{/modules_in_bootimg}}
 
+ifeq ($(TARGET_PREBUILT_KERNEL), true)
+ifeq ($(TARGET_BUILD_VARIANT),user)
+PREBUILT_KERNEL_ROOT := vendor/intel/utils_priv/kernel/prebuilts/6.6/{{{prebuilt_kernel_target}}}/user
+else
+PREBUILT_KERNEL_ROOT := vendor/intel/utils_priv/kernel/prebuilts/6.6/{{{prebuilt_kernel_target}}}/userdebug
+endif
+
+PRODUCT_COPY_FILES += \
+    $(PREBUILT_KERNEL_ROOT)/bzImage:kernel
+
+endif
+
 KERNEL_MODULES_ROOT_PATH ?= vendor_dlkm/lib/modules
 KERNEL_MODULES_ROOT ?= $(KERNEL_MODULES_ROOT_PATH)
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.vendor.boot.moduleslocation=/$(KERNEL_MODULES_ROOT_PATH)


### PR DESCRIPTION
As 1st stage, modules built are made as part of vendor_dlkm. Once gki is enabled, system_dlkm and vendor_dlkm split will be done.

Tests done:
- Android UI boot
- Audio playback and recording
- Video playback and recording
- Shutdown and reboot
- Browsing
- Wifi and Bluetooth connect/disconnect

Tracked-On: OAM-130469