### PR TITLE
Fix for CTS CtsVirtualDevicesTestCases

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -67,7 +67,8 @@
             <inputDevices>
                 <!-- <inputDevice address="Built-In Mic"/>
                 <inputDevice address="Built-In Back Mic"/> -->
-                <inputDevice address="i_bus1_CARD_0_DEV_1"/>
+		<inputDevice address="i_bus1_CARD_0_DEV_1"/>
+		<inputDevice address="r_submix input" type="TYPE_REMOTE_SUBMIX"/>
             </inputDevices>
         </zone>
         <zone name="front passenger zone 1" audioZoneId="1" occupantZoneId="1">


### PR DESCRIPTION
Ensure we add entry for r_submix input
in car audio policy config

Tracked-On: OAM-129408