### PR TITLE
Revert "Bluetooth fix clearSignalStrengthUpdateRequest is unsupported…

### DIFF
--- a/groups/bluetooth/btusb/android.hardware.telephony.automotive.xml
+++ b/groups/bluetooth/btusb/android.hardware.telephony.automotive.xml
@@ -17,7 +17,4 @@
 <!-- This is the standard set of features for devices to support Telephony Subscription API. -->
 <permissions>
   <feature name="android.hardware.telephony.subscription" />
-  <feature name="android.hardware.telephony.radio.access" />
-  <feature name="android.hardware.telephony.messaging" />
-  <feature name="android.hardware.telephony.data" />
 </permissions>


### PR DESCRIPTION
… issue"

this issue will fixed by
https://github.com/intel-innersource/os.android.bsp.utils-aosp-aaos-iasw/pull/166

and this patch will cause more CTS fail.

Test:
Bluetooth on/off working.
Bludtooth connect to phone, working.

Tracked-On: OAM-130831