### PR TITLE
Add support for pre-built kernel based on kleaf build

### DIFF
--- a/groups/kernel/BoardConfig.mk
+++ b/groups/kernel/BoardConfig.mk
@@ -9,6 +9,11 @@ else
   TARGET_BOARD_KERNEL_HEADERS := $(INTEL_PATH_COMMON)/{{{src_path}}}/kernel-headers
 endif
 
+ifeq ($(TARGET_PREBUILT_KERNEL), true)
+BOARD_VENDOR_KERNEL_MODULES := \
+        $(wildcard $(PREBUILT_KERNEL_ROOT)/vendor_dlkm/*.ko)
+endif
+
 ifneq ($(TARGET_BUILD_VARIANT),user)
 KERNEL_LOGLEVEL ?= {{{loglevel}}}
 else

--- a/groups/kernel/product.mk
+++ b/groups/kernel/product.mk
@@ -3,6 +3,18 @@
   KERNEL_MODULES_ROOT := root/$(KERNEL_MODULES_ROOT_PATH)
 {{/modules_in_bootimg}}
 
+ifeq ($(TARGET_PREBUILT_KERNEL), true)
+ifeq ($(TARGET_BUILD_VARIANT),user)
+PREBUILT_KERNEL_ROOT := device/intel/common/kernel/prebuilts/6.6/aaos_x86_64/user
+else
+PREBUILT_KERNEL_ROOT := device/intel/common/kernel/prebuilts/6.6/aaos_x86_64/userdebug
+endif
+
+PRODUCT_COPY_FILES += \
+    $(PREBUILT_KERNEL_ROOT)/bzImage:kernel
+
+endif
+
 KERNEL_MODULES_ROOT_PATH ?= vendor_dlkm/lib/modules
 KERNEL_MODULES_ROOT ?= $(KERNEL_MODULES_ROOT_PATH)
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.vendor.boot.moduleslocation=/$(KERNEL_MODULES_ROOT_PATH)


### PR DESCRIPTION
As 1st stage, modules built are made as part of vendor_dlkm. Once gki is enabled, system_dlkm and vendor_dlkm split will be done.

Tests done:
- Android UI boot
- Audio playback and recording
- Video playback and recording
- Shutdown and reboot
- Browsing
- Wifi and Bluetooth connect/disconnect

Tracked-On: OAM-130469