### PR TITLE
Update group for audio contexts

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
@@ -18,12 +18,8 @@
     <!-- Audio Zone 0 -->
     <item>bus0_media_CARD_0_DEV_1</item>
     <item>bus1_navigation_CARD_0_DEV_5</item>
-    <item>bus2_voice_command_CARD_0_DEV_5</item>
-    <item>bus3_call_ring_CARD_0_DEV_6</item>
-    <item>bus4_call_CARD_0_DEV_6</item>
-    <item>bus5_alarm_CARD_0_DEV_7</item>
-    <item>bus6_notification_CARD_0_DEV_1</item>
-    <item>bus7_system_sound_CARD_0_DEV_7</item>
+    <item>bus2_call_CARD_0_DEV_6</item>
+    <item>bus3_alarm_CARD_0_DEV_7</item>
 
     <item>bottom</item>
     <!-- back mic pcm6-->

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
@@ -35,28 +35,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus2_voice_command_CARD_0_DEV_5" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus2_voice_command_CARD_0_DEV_5">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus3_call_ring_CARD_0_DEV_6" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus3_call_ring_CARD_0_DEV_6">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus4_call_CARD_0_DEV_6" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus4_call_CARD_0_DEV_6">
+    <devicePort tagName="bus2_call_CARD_0_DEV_6" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus2_call_CARD_0_DEV_6">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -65,30 +45,10 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus5_alarm_CARD_0_DEV_7" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus5_alarm_CARD_0_DEV_7">
+    <devicePort tagName="bus3_alarm_CARD_0_DEV_7" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus3_alarm_CARD_0_DEV_7">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus6_notification_CARD_0_DEV_1" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus6_notification_CARD_0_DEV_1">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-    <devicePort tagName="bus7_system_sound_CARD_0_DEV_7" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus7_system_sound_CARD_0_DEV_7">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
                   minValueMB="-3200" maxValueMB="600"

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_mixports.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_mixports.xml
@@ -27,32 +27,12 @@
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
     </mixPort>
-    <mixPort name="mixport_bus2_voice_command_out" role="source">
+    <mixPort name="mixport_bus2_call_out" role="source">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
     </mixPort>
-    <mixPort name="mixport_bus3_call_ring_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus4_call_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus5_alarm_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus6_notification_out" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-    <mixPort name="mixport_bus7_system_sound_out" role="source">
+    <mixPort name="mixport_bus3_alarm_out" role="source">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
@@ -18,15 +18,8 @@
     <!-- Audio Zone 0-->
     <route type="mix" sink="bus0_media_CARD_0_DEV_1" sources="mixport_bus0_media_out"/>
     <route type="mix" sink="bus1_navigation_CARD_0_DEV_5" sources="mixport_bus1_navigation_out"/>
-    <route type="mix" sink="bus2_voice_command_CARD_0_DEV_5"
-           sources="mixport_bus2_voice_command_out"/>
-    <route type="mix" sink="bus3_call_ring_CARD_0_DEV_6" sources="mixport_bus3_call_ring_out"/>
-    <route type="mix" sink="bus4_call_CARD_0_DEV_6" sources="mixport_bus4_call_out"/>
-    <route type="mix" sink="bus5_alarm_CARD_0_DEV_7" sources="mixport_bus5_alarm_out"/>
-    <route type="mix" sink="bus6_notification_CARD_0_DEV_1"
-           sources="mixport_bus6_notification_out"/>
-    <route type="mix" sink="bus7_system_sound_CARD_0_DEV_7"
-           sources="mixport_bus7_system_sound_out"/>
+    <route type="mix" sink="bus2_call_CARD_0_DEV_6" sources="mixport_bus2_call_out"/>
+    <route type="mix" sink="bus3_alarm_CARD_0_DEV_7" sources="mixport_bus3_alarm_out"/>
     
     <route type="mix" sink="primary input" sources="bottom"/>
     <route type="mix" sink="Built-In Back Mic" sources="back"/>

--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -31,32 +31,24 @@
                             <device address="bus0_media_CARD_0_DEV_1">
                                 <context context="music"/>
                                 <context context="announcement"/>
-                            </device>
-                            <device address="bus6_notification_CARD_0_DEV_1">
                                 <context context="notification"/>
                             </device>
                         </group>
                         <group>
                             <device address="bus1_navigation_CARD_0_DEV_5">
                                 <context context="navigation"/>
-                            </device>
-                            <device address="bus2_voice_command_CARD_0_DEV_5">
                                 <context context="voice_command"/>
                             </device>
                         </group>
                         <group>
-                            <device address="bus3_call_ring_CARD_0_DEV_6">
-				                <context context="call_ring"/>
-                            </device>
-                            <device address="bus4_call_CARD_0_DEV_6">
-				                <context context="call"/>
+                            <device address="bus2_call_CARD_0_DEV_6">
+		                <context context="call_ring"/>
+				<context context="call"/>
                             </device>
                         </group>
                         <group>
-                            <device address="bus5_alarm_CARD_0_DEV_7">
+                            <device address="bus3_alarm_CARD_0_DEV_7">
                                 <context context="alarm"/>
-                            </device>
-                            <device address="bus7_system_sound_CARD_0_DEV_7">
                                 <context context="system_sound"/>
                                 <context context="emergency"/>
                                 <context context="safety"/>


### PR DESCRIPTION
This patch keeps different contexts using same pcm device in same group. Otherwise there is delay while switching from one context to other as it tries to close same pcm device and open same pcm device again and also this avoids resource busy issue, which happens when card is opened by one context and for other context it is trying to open same card again.

Tracked-On: AM-127799