### PR TITLE
Support 1600x1300 as quality high for video codec

### DIFF
--- a/groups/codec2/true/media_profiles_1080p.xml
+++ b/groups/codec2/true/media_profiles_1080p.xml
@@ -119,8 +119,8 @@
         <EncoderProfile quality="high" fileFormat="mp4" duration="30">
             <Video codec="h264"
                    bitRate="15000000"
-                   width="1920"
-                   height="1080"
+                   width="1600"
+                   height="1300"
                    frameRate="30" />
             <Audio codec="aac"
                    bitRate="192000"


### PR DESCRIPTION
Issue Detailed: Camera recorder does not support the resolution of 1600x1300.

Issue Fixed: Change quality_high to 1600x1300

Tested-On: camera2 app can record based on 1600x1300

Tracked-On: OAM-131394