### PR TITLE
Define the system_ext sepolicy related dirs

### DIFF
--- a/groups/sepolicy/BoardConfig.mk
+++ b/groups/sepolicy/BoardConfig.mk
@@ -3,3 +3,6 @@ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)
 
 # Pass device target to build in
 BOARD_SEPOLICY_M4DEFS += board_sepolicy_target_product=$(TARGET_PRODUCT)
+
+SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/system_ext/public
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/system_ext/private


### PR DESCRIPTION
During boot, init will compare the system_ext sepolicy rules' hash value stored in system_ext and odm partitions, if they don't match, init won't adopt the precompiled_sepolicy stored in odm partition, it will compile the sepolicy binary from the intermediate cil files and this will take 100+ ms boot time. Currently system_ext sepolicy dir is not defined, so there is no corresponding system_ext sepolicy hash file in odm partition, and init will compile the sepolicy rules on every boot.

Tracked-On: OAM-131314