### PR TITLE
Fix incomplete media_profiles modification issue

### DIFF
--- a/groups/codec2/true/media_profiles_1080p.xml
+++ b/groups/codec2/true/media_profiles_1080p.xml
@@ -178,8 +178,8 @@
         <EncoderProfile quality="high" fileFormat="mp4" duration="60">
             <Video codec="h264"
                    bitRate="15000000"
-                   width="1920"
-                   height="1080"
+                   width="1600"
+                   height="1300"
                    frameRate="30" />
 
             <Audio codec="aac"
@@ -387,8 +387,8 @@
     -->
     <VideoEncoderCap name="h264" enabled="true"
         minBitRate="64000" maxBitRate="13000000"
-        minFrameWidth="176" maxFrameWidth="1920"
-        minFrameHeight="144" maxFrameHeight="1080"
+        minFrameWidth="176" maxFrameWidth="3840"
+        minFrameHeight="144" maxFrameHeight="2160"
         minFrameRate="1" maxFrameRate="30" />
 
     <VideoEncoderCap name="h263" enabled="true"


### PR DESCRIPTION
Issue: /vendor/etc/media_profiles_V1.0.xml is not completely changed to support 1600x1300 record.

Issue Fixed: extend the maxFrameWidth and Height to 3840x2160 in h26 encoder.

Tested-On: video record works in 1600x1300 resolution.

Tracked-On: OAM-131502