### PR TITLE
Fixed for crash in cluster package.

### DIFF
--- a/groups/googleservice/gas/product.mk
+++ b/groups/googleservice/gas/product.mk
@@ -1,4 +1,9 @@
 FLAG_GAS_AVAILABLE ?= true
 ifeq ($(FLAG_GAS_AVAILABLE),true)
 $(call inherit-product-if-exists, vendor/google/gas/products/gms.mk)
+
+#Cluster config overlay package
+PRODUCT_PACKAGES += \
+    ClusterConfigOverlay
+
 endif


### PR DESCRIPTION
Crash is observed in cluster app due to missing Google Map app, as NON-GAS image does not have gas binaries. Using google map app in cluster package only for image having gas binaries.

Created Overlay package to add google map activity in cluster app, which is part of image having gas binaries.

Tests done: Checked in GAS and Non-GAS image, in both cluster is working fine.

Tracked-On: OAM-130877