### PR TITLE
Store the dgpu-renderwlocal.cfg to /vendor/etc/

### DIFF
--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -71,6 +71,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/{{_extra_dir}}/intel.icd:vendor/Khronos/OpenCL/vendors/intel.icd
 
+PRODUCT_COPY_FILES += \
+    vendor/intel/hardware/interfaces/graphic/dgpu-renderwlocal.cfg:vendor/etc/dgpu-renderwlocal.cfg
+
 # DRM HWComposer
 PRODUCT_PACKAGES += \
     hwcomposer.drm_minigbm


### PR DESCRIPTION
The dgpu-renderwlocal.cfg is used to save the process that need use dgpu render and local memory.

Tracked-On: OAM-130613