### PR TITLE
[WA] Fix build issue for audio module.

### DIFF
--- a/groups/audio/audio_base_aaos/product.mk
+++ b/groups/audio/audio_base_aaos/product.mk
@@ -30,7 +30,7 @@ PRODUCT_PACKAGES += \
 
 # Audio HAL
 PRODUCT_PACKAGES += \
-    com.android.hardware.audio.intel \
+    com.android.hardware.audio \
     android.hardware.automotive.audiocontrol-service.example
 
 # rro overlay for audioUseDynamicRouting


### PR DESCRIPTION
When updating aosp tag to r20, observed build issue in audio module moving to default native hal for now, later will enable back after fixing build issue.

Tests Done: Build and boot

Tracked-On: OAM-131768