### PR TITLE
Removed Instrument cluster configuration for IASW.

### DIFF
--- a/groups/googleservice/gas/product.mk
+++ b/groups/googleservice/gas/product.mk
@@ -2,8 +2,4 @@ FLAG_GAS_AVAILABLE ?= true
 ifeq ($(FLAG_GAS_AVAILABLE),true)
 $(call inherit-product-if-exists, vendor/google/gas/products/gms.mk)
 
-#Cluster config overlay package
-PRODUCT_PACKAGES += \
-    ClusterConfigOverlay
-
 endif


### PR DESCRIPTION
Removing instrument cluster configuration from common project. Having targeted only for base_aaos target as diff patch.

Tests done: Device is booted successfully. Showing cluster app only for base_aaos target.

Tracked-On: OAM-131887