### PR TITLE
usb: adapt otg switch config to new role switch driver

### DIFF
--- a/groups/usb-init/true/init.recovery.rc
+++ b/groups/usb-init/true/init.recovery.rc
@@ -4,4 +4,4 @@ on boot
     insmod ${ro.vendor.boot.moduleslocation}/xhci-hcd.ko
     insmod ${ro.vendor.boot.moduleslocation}/xhci-pci.ko
 on property:sys.usb.ffs.ready=1
-    write /sys/class/usb_role/intel_xhci_usb_sw-role-switch/role "device"
+    write /sys/class/usb_role/intel_xhci_usb_sw.1.auto-role-switch/role "device"

--- a/groups/usb-otg-switch/doc.spec
+++ b/groups/usb-otg-switch/doc.spec
@@ -10,6 +10,9 @@ enable SW OTG port switching.
 --- false
 empty dir.
 
+    --- parameters
+        - port:     select the port to switch (0 based index)
+
 --- default
 when not explicitly selected in mixin spec file, the default option will be used.
 

--- a/groups/usb-otg-switch/true/init.rc
+++ b/groups/usb-otg-switch/true/init.rc
@@ -5,7 +5,7 @@ on property:sys.boot_completed=1
     setprop vendor.sys.usb.role device
 
 on property:vendor.sys.usb.role=host
-    exec - system system -- /vendor/bin/usb_otg_switch.sh h
+    exec - system system -- /vendor/bin/usb_otg_switch.sh h {{port}}
 
 on property:vendor.sys.usb.role=device
-    exec - system system -- /vendor/bin/usb_otg_switch.sh p
+    exec - system system -- /vendor/bin/usb_otg_switch.sh p {{port}}

--- a/groups/usb-otg-switch/true/option.spec
+++ b/groups/usb-otg-switch/true/option.spec
@@ -1,2 +1,3 @@
 [defaults]
 ioc = false
+port = 4

--- a/groups/usb-otg-switch/true/ueventd.rc
+++ b/groups/usb-otg-switch/true/ueventd.rc
@@ -1,1 +1,2 @@
-/sys/devices/pci0000:00/0000:00:*.0/intel_xhci_usb_sw/usb_role/intel_xhci_usb_sw-role-switch role 0664 system system
+/sys/devices/pci0000:00/0000:00:*.0/intel_xhci_usb_sw*/usb_role/intel_xhci_usb_sw*-role-switch role 0664 system system
+/sys/devices/pci0000:00/0000:00:*.0/intel_xhci_usb_sw* port 0664 system system

--- a/groups/usb-otg-switch/true/usb_otg_switch.sh
+++ b/groups/usb-otg-switch/true/usb_otg_switch.sh
@@ -7,19 +7,21 @@ if [[ $1 = "h" ]]; then
   case "$KERNEL_VERSION" in
     4.4*) echo h > /sys/bus/platform/devices/intel-cht-otg.0/mux_state ;;
     4.9*) echo h > /sys/bus/platform/drivers/intel_usb_dr_phy/intel_usb_dr_phy.0/mux_state ;;
-       *) echo "host" > /sys/class/usb_role/intel_xhci_usb_sw-role-switch/role ;;
+    *) for role in `ls /sys/bus/platform/devices/intel_xhci_usb_sw*/port`; do echo $2 > $role; done
+     for role in `ls /sys/class/usb_role/intel_xhci_usb_sw*-role-switch/role`; do echo host > $role; done;;
   esac
 
 elif [[ $1 = "p" ]]; then
   case "$KERNEL_VERSION" in
     4.4*) echo p > /sys/bus/platform/devices/intel-cht-otg.0/mux_state ;;
     4.9*) echo p > /sys/bus/platform/drivers/intel_usb_dr_phy/intel_usb_dr_phy.0/mux_state ;;
-       *) echo "device" > /sys/class/usb_role/intel_xhci_usb_sw-role-switch/role ;;
+    *) for role in `ls /sys/bus/platform/devices/intel_xhci_usb_sw*/port`; do echo $2 > $role; done
+     for role in `ls /sys/class/usb_role/intel_xhci_usb_sw*-role-switch/role`; do echo device > $role; done;;
   esac
 
 else
   echo "Please input h to swith to USB OTG mode"
-  echo "usb_otg_switch.sh h"
+  echo "usb_otg_switch.sh h <port>"
   echo "Please input p to swith USB device mode"
-  echo "usb_otg_switch.sh p"
+  echo "usb_otg_switch.sh p <port>"
 fi


### PR DESCRIPTION
New role switch driver exposes a port sysfs file and the platform device name includes a dynamically allocated id, e.g. intel_xhci_usb_sw.1.auto

Assumptions:

Currently only one role switch device is allowed which means only one passthrough or virtual xhci controller. This assumption is similar to the device mode controller name dwc3.0.auto.
These platform device IDs are allocated dynamically and may change with a different board device configuration.

Tracked-On: OAM-131966