### PR TITLE
Fix for Factory Reset and Screen lock not working after trusty and Enable mock rpmb package

### DIFF
--- a/groups/tee/trusty/BoardConfig.mk
+++ b/groups/tee/trusty/BoardConfig.mk
@@ -7,6 +7,7 @@ endif
 BOARD_USES_TRUSTY := true
 BOARD_USES_KEYMASTER1 := true
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/tee/trusty
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/tee/trusty/mock_rpmb
 BOARD_SEPOLICY_M4DEFS += module_trusty=true
 
 TRUSTY_BUILDROOT = $(PWD)/$(PRODUCT_OUT)/obj/trusty/

--- a/groups/tee/trusty/fstab
+++ b/groups/tee/trusty/fstab
@@ -1,0 +1,1 @@
+/dev/block/by-name/teedata       /mnt/vendor/persist         ext4    discard,noatime,noauto_da_alloc,nosuid,nodev,data=ordered,user_xattr,barrier=1          wait,formattable

--- a/groups/tee/trusty/fstab.recovery
+++ b/groups/tee/trusty/fstab.recovery
@@ -1,0 +1,1 @@
+/dev/block/by-name/teedata       /mnt/vendor/persist         ext4    discard,noatime,noauto_da_alloc,nosuid,nodev,data=ordered,user_xattr,barrier=1          wait,formattable

--- a/groups/tee/trusty/init.rc
+++ b/groups/tee/trusty/init.rc
@@ -1,13 +1,5 @@
 on post-fs-data
     mkdir /data/vendor/securestorage 0700 system system
-    chmod 666 /dev/rpmb0
-
-on early-fs
-    start storageproxyd
-
-service storageproxyd /vendor/bin/storageproxyd -d /dev/trusty-ipc-dev0 -p /data/vendor/securestorage -r /dev/vport0p1 -t virt
-    user system
-    group system
 
 on boot
     start keyboxd
@@ -19,5 +11,4 @@ service keyboxd /vendor/bin/keybox_provisioning -d /dev/trusty-ipc-dev0 -p /dev/
 
 on post-fs
     wait_for_prop vendor.modules.trusty.ready true
-    chmod 666 /dev/vport0p1
     chmod 666 /dev/trusty-ipc-dev0

--- a/groups/tee/trusty/product.mk
+++ b/groups/tee/trusty/product.mk
@@ -4,8 +4,9 @@ PRODUCT_PACKAGES += \
 	storageproxyd \
 	libinteltrustystorage \
 	libinteltrustystorageinterface \
-	android.hardware.gatekeeper-service.trusty \
-	android.hardware.security.keymint-service.trusty \
+	android.hardware.gatekeeper-service.nonsecure \
+	com.android.hardware.gatekeeper.nonsecure \
+        android.hardware.security.keymint-service \
 	keybox_provisioning \
 	RemoteProvisioner
 
@@ -16,10 +17,6 @@ PRODUCT_PACKAGES_DEBUG += \
 	scrypt_test \
 	RemoteProvisionerUnitTests \
 	libkeymint_remote_prov_support_test
-
-PRODUCT_PROPERTY_OVERRIDES += \
-	ro.hardware.gatekeeper=trusty \
-	ro.hardware.keystore=trusty
 
 PRODUCT_COPY_FILES += \
 	frameworks/native/data/etc/android.hardware.keystore.app_attest_key.xml:vendor/etc/permissions/android.hardware.keystore.app_attest_key.xml

--- a/groups/tee/trusty/product.mk
+++ b/groups/tee/trusty/product.mk
@@ -8,7 +8,8 @@ PRODUCT_PACKAGES += \
 	com.android.hardware.gatekeeper.nonsecure \
         android.hardware.security.keymint-service \
 	keybox_provisioning \
-	RemoteProvisioner
+	RemoteProvisioner \
+	rpmb_dev
 
 PRODUCT_PACKAGES_DEBUG += \
 	intel-secure-storage-unit-test \


### PR DESCRIPTION
Fix for Factory Reset and Screen lock not working after trusty and Enable mock RPMB package

RPMB: Enable mock rpmb package

Celadon BM doest not support rpmb on nvme, storageproxyd
will fail and keep restarting.rpmb_dev packge is enabled.

Enabling sepolicy for the rpmb_dev package. Mounting teedata
on /mnt/vendor/persist for the rpmb_dev requirement.

Tests Done:
    1. Boot the device in MTL nuc.
    2. storageproxyd service is running.
    3. Screen lock/ unlock working fine using 'input keyevent 26'
       command and After reboot
    4. Factory reset working properly.

 Tracked-On: OAM-132238
