### PR TITLE
Update max volume to avoid glitch.

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
@@ -21,7 +21,7 @@
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
+                  minValueMB="-4400" maxValueMB="0"
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
@@ -93,7 +93,7 @@
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
+                  minValueMB="-4400" maxValueMB="0"
                   defaultValueMB="0" stepValueMB="100"/>
             </gains>
     </devicePort>


### PR DESCRIPTION
This patch changes maximum vloume from 6db to 0db. Glitch was observed as gain value at maximum volume as reaching 1.7 which should be ideally 1.0. With keeping it as 0db, gain is coming as expecetd that is 1.0 and hence glitch is not observed.

Tracked-On: OAM-129796