### PR TITLE
Revert "increase health check interval in carwatchdogd"

### DIFF
--- a/groups/device-type/car/product.mk
+++ b/groups/device-type/car/product.mk
@@ -42,7 +42,4 @@ VEHICLE_HAL_PROTO_TYPE += {{ioc}}
 
 PRODUCT_PROPERTY_OVERRIDES += telephony.active_modems.max_count=2
 
-PRODUCT_PRODUCT_PROPERTIES += \
-    ro.vendor.fake_vhal.ap_power_state_req.config=1 \
-    ro.carwatchdog.vhal_healthcheck.interval=10 \
-    ro.carwatchdog.client_healthcheck.interval=20 \
+PRODUCT_PRODUCT_PROPERTIES += ro.vendor.fake_vhal.ap_power_state_req.config=1


### PR DESCRIPTION
Set a long health check interval will cause ats test failed, this reverts commit 213da5c3f0a4741e223eec25c4d40dc544ac4b5c.

Still use the default health check interval in car watchdogd.

Tracked-On: OAM-132222