### PR TITLE
Update gain value to avoid glitch

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
@@ -31,7 +31,7 @@
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
+                  minValueMB="-4400" maxValueMB="0"
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
@@ -41,7 +41,7 @@
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
+                  minValueMB="-4400" maxValueMB="0"
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
@@ -51,7 +51,7 @@
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
+                  minValueMB="-4400" maxValueMB="0"
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
@@ -103,7 +103,7 @@
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
+                  minValueMB="-4400" maxValueMB="0"
                   defaultValueMB="0" stepValueMB="100"/>
             </gains>
     </devicePort>
@@ -127,7 +127,7 @@
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
+                  minValueMB="-4400" maxValueMB="0"
                   defaultValueMB="0" stepValueMB="100"/>
             </gains>
     </devicePort>
@@ -151,7 +151,7 @@
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
             <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
+                  minValueMB="-4400" maxValueMB="0"
                   defaultValueMB="0" stepValueMB="100"/>
             </gains>
     </devicePort>


### PR DESCRIPTION
Adjusted min and max gain values to avoid glitch
when volume in the settings is maximum. Now gain
at maximum volume is 1.0 and hence no glitch is
observed and gain at 0 volume will be negligible
and hence stream will be muted.

Test Done:
- Boot Test
- Audio playback is fine
- No glitch is observed at mximum volume in Settings UI
- played audio from player, verified if the volume for alarm, ringtone and other playback streams applied correctly.
- Checked if audio is muted when volume is kept at minimun in UI for all playback streams.

Tracked-On: OAM-132480