### PR TITLE
Set BOARD_USES_RECOVERY_AS_BOOT empty if enable init boot partition

### DIFF
--- a/groups/slot-ab/true/BoardConfig.mk
+++ b/groups/slot-ab/true/BoardConfig.mk
@@ -6,7 +6,13 @@ AB_OTA_PARTITIONS := \
 BOARD_BUILD_SYSTEM_ROOT_IMAGE := true
 {{/dynamic-partitions}}
 TARGET_NO_RECOVERY := true
+{{^init-boot}}
 BOARD_USES_RECOVERY_AS_BOOT := true
+{{/init-boot}}
+{{#init-boot}}
+BOARD_USES_RECOVERY_AS_BOOT :=
+{{/init-boot}}
+
 BOARD_SLOT_AB_ENABLE := true
 BOARD_KERNEL_CMDLINE += rootfstype=ext4
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/slot-ab


### PR DESCRIPTION
https://source.android.com/docs/core/architecture/ partitions/generic-boot#option-1

BOARD_USES_RECOVERY_AS_BOOT should be empty if enalbe init boot partition according to google allowed configurations

Test Done: boot

Tracked-On: OAM-132645