### PR TITLE
Add in call scenarios to zone1 to align with the architecture

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -73,8 +73,6 @@
                             <context context="music"/>
                             <context context="navigation"/>
                             <context context="voice_command"/>
-                            <context context="call_ring"/>
-                            <context context="call"/>
                             <context context="alarm"/>
                             <context context="notification"/>
                             <context context="system_sound"/>
@@ -84,11 +82,19 @@
                             <context context="announcement"/>
                             </device>
                         </group>
+                        <group>
+                            <device address="bus101_CARD_0_DEV_8">
+                                <context context="call_ring"/>
+                                <context context="call"/>
+                            </device>
+                        </group>
                     </volumeGroups>
                 </zoneConfig>
                 <zoneConfig name="front passenger zone 1 config 1">
                     <volumeGroups>
                         <group>
+                            <!-- Due to a shortage of devices and devices in different zoneconfigs 
+                            is exclusive, temporarily use the same device as config 0 in call. -->
                             <device address="bus101_CARD_0_DEV_8">
                             <context context="music"/>
                             <context context="navigation"/>


### PR DESCRIPTION
Add in call scenarios in zone1 to align with the architecture diagram and to fix the sound comes out from zone 1 instead of zone 0 when adjust volume bar in zone 0.

Tracked-On: OAM-131181