### PR TITLE
Generate boot-debug.img in non-GKI config

### DIFF
--- a/groups/gptbuild/mixinfo.spec
+++ b/groups/gptbuild/mixinfo.spec
@@ -1,2 +1,2 @@
 [mixinfo]
-deps = tee vendor-partition product-partition odm-partition acpi-partition acpio-partition dynamic-partitions vendor-boot
+deps = tee vendor-partition product-partition odm-partition acpi-partition acpio-partition dynamic-partitions vendor-boot init-boot

--- a/groups/gptbuild/true/AndroidBoard.mk
+++ b/groups/gptbuild/true/AndroidBoard.mk
@@ -161,6 +161,9 @@ $(GPTIMAGE_BIN): \
 	{{#vendor-boot}}
 		--vendor_boot $(TARGET_IMAGE_PATH)/vendor_boot.img \
 	{{/vendor-boot}}
+	{{#init-boot}}
+		--init_boot $(TARGET_IMAGE_PATH)/init_boot.img \
+	{{/init-boot}}
 		--config $(raw_config) \
 		--factory $(raw_factory)
 

--- a/groups/init-boot/false/BoardConfig.mk
+++ b/groups/init-boot/false/BoardConfig.mk
@@ -1,0 +1,8 @@
+BOARD_USES_RECOVERY_AS_BOOT := true
+
+# Enable debug boot image for GSI testing
+# For Generic Kernel Image (GKI) using devices that have a vendor_boot partition,
+# boot-debug.img mustn't be flashed, as the boot partition must be flashed with
+# a certified GKI image. Instead vendor_boot-debug.img should be flashed
+# onto the vendor_boot partition in order to facilitate debug ramdisk.
+PRODUCT_BUILD_DEBUG_BOOT_IMAGE := true

--- a/groups/init-boot/false/BoardConfig.mk
+++ b/groups/init-boot/false/BoardConfig.mk
@@ -1,8 +1,2 @@
 BOARD_USES_RECOVERY_AS_BOOT := true
-
-# Enable debug boot image for GSI testing
-# For Generic Kernel Image (GKI) using devices that have a vendor_boot partition,
-# boot-debug.img mustn't be flashed, as the boot partition must be flashed with
-# a certified GKI image. Instead vendor_boot-debug.img should be flashed
-# onto the vendor_boot partition in order to facilitate debug ramdisk.
-PRODUCT_BUILD_DEBUG_BOOT_IMAGE := true
+BOARD_FLASHFILES += $(PRODUCT_OUT)/boot-debug.img

--- a/groups/init-boot/false/flashfiles.ini
+++ b/groups/init-boot/false/flashfiles.ini
@@ -1,0 +1,2 @@
+[output.installer.cmd]
+additional-files += provdatazip:boot-debug.img

--- a/groups/init-boot/false/product.mk
+++ b/groups/init-boot/false/product.mk
@@ -1,13 +1,6 @@
-{{#initboot_enable}}
-INITBOOT_ENABLE := true
-{{/initboot_enable}}
-{{^initboot_enable}}
-INITBOOT_ENABLE := false
-{{/initboot_enable}}
-
 # disable debug boot image for GSI testing
 # For Generic Kernel Image (GKI) using devices that have a vendor_boot partition,
 # boot-debug.img mustn't be flashed, as the boot partition must be flashed with
 # a certified GKI image. Instead vendor_boot-debug.img should be flashed
 # onto the vendor_boot partition in order to facilitate debug ramdisk.
-PRODUCT_BUILD_DEBUG_BOOT_IMAGE := false
+PRODUCT_BUILD_DEBUG_BOOT_IMAGE := true

--- a/groups/init-boot/true/BoardConfig.mk
+++ b/groups/init-boot/true/BoardConfig.mk
@@ -22,3 +22,10 @@ BOARD_MOVE_RECOVERY_RESOURCES_TO_VENDOR_BOOT := true
 BOARD_EXCLUDE_KERNEL_FROM_RECOVERY_IMAGE :=
 BOARD_MOVE_GSI_AVB_KEYS_TO_VENDOR_BOOT := true
 BOOT_SECURITY_PATCH := $(PLATFORM_SECURITY_PATCH)
+
+# disable debug boot image for GSI testing
+# For Generic Kernel Image (GKI) using devices that have a vendor_boot partition,
+# boot-debug.img mustn't be flashed, as the boot partition must be flashed with
+# a certified GKI image. Instead vendor_boot-debug.img should be flashed
+# onto the vendor_boot partition in order to facilitate debug ramdisk.
+PRODUCT_BUILD_DEBUG_BOOT_IMAGE := false

--- a/groups/init-boot/true/BoardConfig.mk
+++ b/groups/init-boot/true/BoardConfig.mk
@@ -22,10 +22,3 @@ BOARD_MOVE_RECOVERY_RESOURCES_TO_VENDOR_BOOT := true
 BOARD_EXCLUDE_KERNEL_FROM_RECOVERY_IMAGE :=
 BOARD_MOVE_GSI_AVB_KEYS_TO_VENDOR_BOOT := true
 BOOT_SECURITY_PATCH := $(PLATFORM_SECURITY_PATCH)
-
-# disable debug boot image for GSI testing
-# For Generic Kernel Image (GKI) using devices that have a vendor_boot partition,
-# boot-debug.img mustn't be flashed, as the boot partition must be flashed with
-# a certified GKI image. Instead vendor_boot-debug.img should be flashed
-# onto the vendor_boot partition in order to facilitate debug ramdisk.
-PRODUCT_BUILD_DEBUG_BOOT_IMAGE := false

--- a/groups/slot-ab/true/BoardConfig.mk
+++ b/groups/slot-ab/true/BoardConfig.mk
@@ -6,12 +6,6 @@ AB_OTA_PARTITIONS := \
 BOARD_BUILD_SYSTEM_ROOT_IMAGE := true
 {{/dynamic-partitions}}
 TARGET_NO_RECOVERY := true
-{{^init-boot}}
-BOARD_USES_RECOVERY_AS_BOOT := true
-{{/init-boot}}
-{{#init-boot}}
-BOARD_USES_RECOVERY_AS_BOOT :=
-{{/init-boot}}
 
 BOARD_SLOT_AB_ENABLE := true
 BOARD_KERNEL_CMDLINE += rootfstype=ext4


### PR DESCRIPTION
For Generic Kernel Image (GKI) using devices that have a vendor_boot partition, boot-debug.img mustn't be flashed, as the boot partition must be flashed with a certified GKI image.
Instead vendor_boot-debug.img should be flashed onto the vendor_boot partition in order to facilitate debug ramdisk.

Test Done:
Boot

Traked-On: OAM-132990