### PR TITLE
Align the audio architecture with defined document

### DIFF
--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_attached_devices.xml
@@ -18,8 +18,9 @@
     <!-- Audio Zone 0 -->
     <item>bus0_media_CARD_0_DEV_1</item>
     <item>bus1_navigation_CARD_0_DEV_5</item>
-    <item>bus2_call_CARD_0_DEV_6</item>
-    <item>bus3_alarm_CARD_0_DEV_7</item>
+    <!-- CARD 0 device 6 used for hfp -->
+    <item>bus2_call_CARD_0_DEV_7</item>
+    <item>bus3_alarm_CARD_0_DEV_8</item>
 
     <item>bottom</item>
     <!-- back mic pcm6-->
@@ -29,20 +30,12 @@
     <item>i_bus1_CARD_0_DEV_5</item>
     
     <!-- Audio Zone 1 -->
+    <!-- Zone 1 Media -->
     <item>bus100_CARD_0_DEV_2</item>
-    <!-- In Call-->
-    <item>bus101_CARD_0_DEV_8</item>
-
+    <!-- Zone 1 In Call-->
+    <item>bus101_CARD_0_DEV_9</item>
+    <!-- Zone 1 Config 1-->
+    <item>bus102_CARD_0_DEV_10</item>
     <item>i_bus100_CARD_0_DEV_2</item>
-
-    <!-- Audio Zone 2-->
-    <item>bus200_CARD_0_DEV_3</item>
-
-    <item>i_bus200_CARD_0_DEV_3</item>
-
-    <!-- Audio Zone 3-->
-    <item>bus300_CARD_0_DEV_4</item>
-
-    <item>i_bus300_CARD_0_DEV_4</item>
 
 </attachedDevices>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_devices.xml
@@ -35,8 +35,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus2_call_CARD_0_DEV_6" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus2_call_CARD_0_DEV_6">
+    <devicePort tagName="bus2_call_CARD_0_DEV_7" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus2_call_CARD_0_DEV_7">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -45,8 +45,8 @@
                   defaultValueMB="0" stepValueMB="100"/>
         </gains>
     </devicePort>
-    <devicePort tagName="bus3_alarm_CARD_0_DEV_7" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus3_alarm_CARD_0_DEV_7">
+    <devicePort tagName="bus3_alarm_CARD_0_DEV_8" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus3_alarm_CARD_0_DEV_8">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -97,8 +97,18 @@
                   defaultValueMB="0" stepValueMB="100"/>
             </gains>
     </devicePort>
-    <devicePort tagName="bus101_CARD_0_DEV_8" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus101_CARD_0_DEV_8">
+    <devicePort tagName="bus101_CARD_0_DEV_9" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus101_CARD_0_DEV_9">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+        <gains>
+            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
+                  minValueMB="-4400" maxValueMB="0"
+                  defaultValueMB="0" stepValueMB="100"/>
+            </gains>
+    </devicePort>
+    <devicePort tagName="bus102_CARD_0_DEV_10" role="sink" type="AUDIO_DEVICE_OUT_BUS"
+                address="bus102_CARD_0_DEV_10">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         <gains>
@@ -110,54 +120,6 @@
 
     <devicePort tagName="i_bus100_CARD_0_DEV_2" type="AUDIO_DEVICE_IN_BUS"
                 role="source" address="i_bus100_CARD_0_DEV_2">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-
-    <!-- Audio zone 2 -->
-    <devicePort tagName="bus200_CARD_0_DEV_3" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus200_CARD_0_DEV_3">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-4400" maxValueMB="0"
-                  defaultValueMB="0" stepValueMB="100"/>
-            </gains>
-    </devicePort>
-
-    <devicePort tagName="i_bus200_CARD_0_DEV_3" type="AUDIO_DEVICE_IN_BUS"
-                role="source" address="i_bus200_CARD_0_DEV_3">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-3200" maxValueMB="600"
-                  defaultValueMB="0" stepValueMB="100"/>
-        </gains>
-    </devicePort>
-
-    <!-- Audio zone 3-->
-    <devicePort tagName="bus300_CARD_0_DEV_4" role="sink" type="AUDIO_DEVICE_OUT_BUS"
-                address="bus300_CARD_0_DEV_4">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-        <gains>
-            <gain name="" mode="AUDIO_GAIN_MODE_JOINT"
-                  minValueMB="-4400" maxValueMB="0"
-                  defaultValueMB="0" stepValueMB="100"/>
-            </gains>
-    </devicePort>
-
-    <devicePort tagName="i_bus300_CARD_0_DEV_4" type="AUDIO_DEVICE_IN_BUS"
-                role="source" address="i_bus300_CARD_0_DEV_4">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_IN_STEREO"/>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_mixports.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_mixports.xml
@@ -74,34 +74,13 @@
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
     </mixPort>
+    <mixPort name="mixport_bus102_audio_zone_1" role="source">
+        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+                 samplingRates="48000"
+                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+    </mixPort>
 
     <mixPort name="mixport_input_bus100_zone_1" role="sink">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
-    </mixPort>
-
-    <!-- Audio Zone 2-->
-    <mixPort name="mixport_bus200_CARD_0_DEV_3" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-
-    <mixPort name="mixport_input_bus200_zone_2" role="sink">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
-    </mixPort>
-
-    <!-- Audio Zone 3-->
-    <mixPort name="mixport_bus101_audio_zone_1" role="source">
-        <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
-                 samplingRates="48000"
-                 channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
-    </mixPort>
-
-    <mixPort name="mixport_input_bus300_zone_3" role="sink">
         <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
                  samplingRates="48000"
                  channelMasks="AUDIO_CHANNEL_IN_STEREO"/>

--- a/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
+++ b/groups/audio/audio_base_aaos/default/policy/audio_policy_configuration_routes.xml
@@ -18,8 +18,8 @@
     <!-- Audio Zone 0-->
     <route type="mix" sink="bus0_media_CARD_0_DEV_1" sources="mixport_bus0_media_out"/>
     <route type="mix" sink="bus1_navigation_CARD_0_DEV_5" sources="mixport_bus1_navigation_out"/>
-    <route type="mix" sink="bus2_call_CARD_0_DEV_6" sources="mixport_bus2_call_out"/>
-    <route type="mix" sink="bus3_alarm_CARD_0_DEV_7" sources="mixport_bus3_alarm_out"/>
+    <route type="mix" sink="bus2_call_CARD_0_DEV_7" sources="mixport_bus2_call_out"/>
+    <route type="mix" sink="bus3_alarm_CARD_0_DEV_8" sources="mixport_bus3_alarm_out"/>
     
     <route type="mix" sink="primary input" sources="bottom"/>
     <route type="mix" sink="Built-In Back Mic" sources="back"/>
@@ -28,15 +28,8 @@
     
     <!-- Audio Zone 1-->
     <route type="mix" sink="bus100_CARD_0_DEV_2" sources="mixport_bus100_audio_zone_1"/>
-    <route type="mix" sink="bus101_CARD_0_DEV_8" sources="mixport_bus101_audio_zone_1"/>
+    <route type="mix" sink="bus101_CARD_0_DEV_9" sources="mixport_bus101_audio_zone_1"/>
+    <route type="mix" sink="bus102_CARD_0_DEV_10" sources="mixport_bus102_audio_zone_1"/>
     <route type="mix" sink="mixport_input_bus100_zone_1" sources="i_bus100_CARD_0_DEV_2"/>
-
-    <!-- Audio Zone 2-->
-    <route type="mix" sink="bus200_CARD_0_DEV_3" sources="mixport_bus200_CARD_0_DEV_3"/>
-    <route type="mix" sink="mixport_input_bus200_zone_2" sources="i_bus200_CARD_0_DEV_3"/>
-
-    <!-- Audio Zone 3-->
-    <route type="mix" sink="bus300_CARD_0_DEV_4" sources="mixport_bus101_audio_zone_1"/>
-    <route type="mix" sink="mixport_input_bus300_zone_3" sources="i_bus300_CARD_0_DEV_4"/>
 
 </routes>

--- a/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
+++ b/groups/audio/audio_base_aaos/default/policy/car_audio_configuration.xml
@@ -41,13 +41,13 @@
                             </device>
                         </group>
                         <group>
-                            <device address="bus2_call_CARD_0_DEV_6">
+                            <device address="bus2_call_CARD_0_DEV_7">
 		                <context context="call_ring"/>
 				<context context="call"/>
                             </device>
                         </group>
                         <group>
-                            <device address="bus3_alarm_CARD_0_DEV_7">
+                            <device address="bus3_alarm_CARD_0_DEV_8">
                                 <context context="alarm"/>
                                 <context context="system_sound"/>
                                 <context context="emergency"/>
@@ -83,7 +83,7 @@
                             </device>
                         </group>
                         <group>
-                            <device address="bus101_CARD_0_DEV_8">
+                            <device address="bus101_CARD_0_DEV_9">
                                 <context context="call_ring"/>
                                 <context context="call"/>
                             </device>
@@ -95,7 +95,7 @@
                         <group>
                             <!-- Due to a shortage of devices and devices in different zoneconfigs 
                             is exclusive, temporarily use the same device as config 0 in call. -->
-                            <device address="bus101_CARD_0_DEV_8">
+                            <device address="bus102_CARD_0_DEV_10">
                             <context context="music"/>
                             <context context="navigation"/>
                             <context context="voice_command"/>
@@ -115,60 +115,6 @@
             </zoneConfigs>
             <inputDevices>
                 <inputDevice address="i_bus100_CARD_0_DEV_2"/>
-            </inputDevices>
-       </zone>
-       <zone name="front passenger zone 2" audioZoneId="2" occupantZoneId="2">
-            <zoneConfigs>
-                <zoneConfig name="front passenger zone 2 config 0" isDefault="true">
-                    <volumeGroups>
-                        <group>
-                            <device address="bus200_CARD_0_DEV_3">
-                            <context context="music"/>
-                            <context context="navigation"/>
-                            <context context="voice_command"/>
-                            <context context="call_ring"/>
-                            <context context="call"/>
-                            <context context="alarm"/>
-                            <context context="notification"/>
-                            <context context="system_sound"/>
-                            <context context="emergency"/>
-                            <context context="safety"/>
-                            <context context="vehicle_status"/>
-                            <context context="announcement"/>
-                            </device>
-                        </group>
-                    </volumeGroups>
-                </zoneConfig>
-            </zoneConfigs>
-            <inputDevices>
-                <inputDevice address="i_bus200_CARD_0_DEV_3"/>
-            </inputDevices>
-       </zone>
-       <zone name="front passenger zone 3" audioZoneId="3" occupantZoneId="3">
-            <zoneConfigs>
-                <zoneConfig name="front passenger zone 3 config 0" isDefault="true">
-                    <volumeGroups>
-                        <group>
-                            <device address="bus300_CARD_0_DEV_4">
-                            <context context="music"/>
-                            <context context="navigation"/>
-                            <context context="voice_command"/>
-                            <context context="call_ring"/>
-                            <context context="call"/>
-                            <context context="alarm"/>
-                            <context context="notification"/>
-                            <context context="system_sound"/>
-                            <context context="emergency"/>
-                            <context context="safety"/>
-                            <context context="vehicle_status"/>
-                            <context context="announcement"/>
-                            </device>
-                        </group>
-                    </volumeGroups>
-                </zoneConfig>
-            </zoneConfigs>
-            <inputDevices>
-                <inputDevice address="i_bus300_CARD_0_DEV_4"/>
             </inputDevices>
        </zone>
     </zones>


### PR DESCRIPTION
- Removed unused audio zones, only keep the first two.
- Fix device contention issue between hfp and call.

Tracked-On: OAM-133028