### PR TITLE
Change package modules

### DIFF
--- a/groups/graphics/auto/product.mk
+++ b/groups/graphics/auto/product.mk
@@ -73,7 +73,8 @@ PRODUCT_COPY_FILES += \
 
 # DRM HWComposer
 PRODUCT_PACKAGES += \
-    hwcomposer.drm_minigbm
+    libhwcservice \
+    libhwcservicelib
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.hwcomposer=drm_minigbm


### PR DESCRIPTION
Since hwc sync upstream, hwcomposer.drm_minigbm will be deleted, libhwcservice(for client) and libhwcservicelib (hwc info service lib) will be added.

Tracked-On: OAM-131262