### PR TITLE
RPMB: Enable mock rpmb package

### DIFF
--- a/groups/trusty/true/BoardConfig.mk
+++ b/groups/trusty/true/BoardConfig.mk
@@ -7,6 +7,7 @@ endif
 BOARD_USES_TRUSTY := true
 BOARD_USES_KEYMASTER1 := true
 BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/trusty/enabled
+BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/trusty/enabled/mock_rpmb
 BOARD_SEPOLICY_M4DEFS += module_trusty=true
 
 TRUSTY_BUILDROOT = $(PWD)/$(PRODUCT_OUT)/obj/trusty/

--- a/groups/trusty/true/init.rc
+++ b/groups/trusty/true/init.rc
@@ -2,13 +2,6 @@ on post-fs-data
     mkdir /data/vendor/securestorage 0700 system system
     chmod 666 /dev/rpmb0
 
-on early-fs
-    start storageproxyd
-
-service storageproxyd /vendor/bin/storageproxyd -d /dev/trusty-ipc-dev0 -p /data/vendor/securestorage -r /dev/vport0p1 -t virt
-    user system
-    group system
-
 on boot
     start keyboxd
 

--- a/groups/trusty/true/product.mk
+++ b/groups/trusty/true/product.mk
@@ -7,6 +7,7 @@ PRODUCT_PACKAGES += \
 	android.hardware.gatekeeper@1.0-service.trusty \
 	android.hardware.security.keymint-service.trusty \
 	keybox_provisioning \
+	rpmb_dev \
 	RemoteProvisioner
 
 PRODUCT_PACKAGES_DEBUG += \


### PR DESCRIPTION
Celadon BM doest not support rpmb on nvme, storageproxyd will fail and keep restarting.rpmb_dev packge is enabled.

Enabling sepolicy for the rpmb_dev package.

    Tests Done:
    1. Boot the device in ADL nuc.
    2. storageproxyd service is running.
    3. Screen lock/ unlock working fine using 'input keyevent 26' command and After reboot
    4. Factory reset working properly.

Tracked-On: OAM-133240