### PR TITLE
Fix the treble violations for bluetooth

### DIFF
--- a/groups/bluetooth/ag620/init.rc
+++ b/groups/bluetooth/ag620/init.rc
@@ -1,9 +1,6 @@
 on boot
     insmod ${ro.vendor.boot.moduleslocation}/btif_drv.ko
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 service dhcpcd_bt-pan /system/bin/dhcpcd -ABKL
     disabled
     oneshot

--- a/groups/bluetooth/auto/product.mk
+++ b/groups/bluetooth/auto/product.mk
@@ -12,7 +12,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.bluetooth.xml:vendor/etc/permissions/android.hardware.bluetooth.xml \
     frameworks/native/data/etc/android.hardware.bluetooth_le.xml:vendor/etc/permissions/android.hardware.bluetooth_le.xml
 
-PRODUCT_PROPERTY_OVERRIDES += bluetooth.rfkill=1
+PRODUCT_PROPERTY_OVERRIDES += vendor.bluetooth.rfkill=1
 
 PRODUCT_PACKAGES += \
     android.hardware.bluetooth@1.0-service.vbt \

--- a/groups/bluetooth/autodetect/init.rc
+++ b/groups/bluetooth/autodetect/init.rc
@@ -6,9 +6,6 @@ on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 service dhcpcd_bt-pan /system/bin/dhcpcd -d -aABKL
     disabled
     oneshot

--- a/groups/bluetooth/bcm43241/init.rc
+++ b/groups/bluetooth/bcm43241/init.rc
@@ -55,9 +55,6 @@ on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 on property:vendor.bluetooth.hwcfg=start
     start vendor.btcfg
 

--- a/groups/bluetooth/bcm43241/product.mk
+++ b/groups/bluetooth/bcm43241/product.mk
@@ -17,7 +17,7 @@ PRODUCT_COPY_FILES += frameworks/native/data/etc/android.hardware.bluetooth.xml:
 
 {{^hsu}}
 PRODUCT_PROPERTY_OVERRIDES += vendor.bluetooth.hwcfg=stop \
-                bluetooth.rfkill=1
+                vendor.bluetooth.rfkill=1
 
 # Bluetooth eng / userdebug
 ifneq ($(TARGET_BUILD_VARIANT),user)

--- a/groups/bluetooth/bcm43340/init.rc
+++ b/groups/bluetooth/bcm43340/init.rc
@@ -12,9 +12,6 @@ on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 on property:vendor.bluetooth.hwcfg=start
     start vendor.btcfg
 

--- a/groups/bluetooth/bcm43340/product.mk
+++ b/groups/bluetooth/bcm43340/product.mk
@@ -7,7 +7,7 @@ PRODUCT_COPY_FILES += frameworks/native/data/etc/android.hardware.bluetooth.xml:
 		frameworks/native/data/etc/android.hardware.bluetooth_le.xml:vendor/etc/permissions/android.hardware.bluetooth_le.xml
 
 PRODUCT_PROPERTY_OVERRIDES += vendor.bluetooth.hwcfg=stop \
-                bluetooth.rfkill=1
+                vendor.bluetooth.rfkill=1
 
 # Bluetooth eng / userdebug
 ifneq ($(TARGET_BUILD_VARIANT),user)

--- a/groups/bluetooth/bcm4339/init.rc
+++ b/groups/bluetooth/bcm4339/init.rc
@@ -12,9 +12,6 @@ on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 on property:vendor.bluetooth.hwcfg=start
     start vendor.btcfg
 

--- a/groups/bluetooth/bcm4339/product.mk
+++ b/groups/bluetooth/bcm4339/product.mk
@@ -7,7 +7,7 @@ PRODUCT_COPY_FILES += frameworks/native/data/etc/android.hardware.bluetooth.xml:
 		frameworks/native/data/etc/android.hardware.bluetooth_le.xml:vendor/etc/permissions/android.hardware.bluetooth_le.xml
 
 PRODUCT_PROPERTY_OVERRIDES += vendor.bluetooth.hwcfg=stop \
-                bluetooth.rfkill=1
+                vendor.bluetooth.rfkill=1
 
 # Bluetooth eng / userdebug
 ifneq ($(TARGET_BUILD_VARIANT),user)

--- a/groups/bluetooth/bcm43430/init.rc
+++ b/groups/bluetooth/bcm43430/init.rc
@@ -12,9 +12,6 @@ on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 on property:vendor.bluetooth.hwcfg=start
     start vendor.btcfg
 

--- a/groups/bluetooth/bcm43430/product.mk
+++ b/groups/bluetooth/bcm43430/product.mk
@@ -7,7 +7,7 @@ PRODUCT_COPY_FILES += frameworks/native/data/etc/android.hardware.bluetooth.xml:
 		frameworks/native/data/etc/android.hardware.bluetooth_le.xml:vendor/etc/permissions/android.hardware.bluetooth_le.xml
 
 PRODUCT_PROPERTY_OVERRIDES += vendor.bluetooth.hwcfg=stop \
-                bluetooth.rfkill=1
+                vendor.bluetooth.rfkill=1
 
 # Bluetooth eng / userdebug
 ifneq ($(TARGET_BUILD_VARIANT),user)

--- a/groups/bluetooth/bcm4356/init.rc
+++ b/groups/bluetooth/bcm4356/init.rc
@@ -55,9 +55,6 @@ on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 on property:vendor.bluetooth.hwcfg=start
     start vendor.btcfg
 

--- a/groups/bluetooth/bcm4356/product.mk
+++ b/groups/bluetooth/bcm4356/product.mk
@@ -16,7 +16,7 @@ PRODUCT_COPY_FILES += frameworks/native/data/etc/android.hardware.bluetooth.xml:
 
 {{^hsu}}
 PRODUCT_PROPERTY_OVERRIDES += vendor.bluetooth.hwcfg=stop \
-                bluetooth.rfkill=1
+                vendor.bluetooth.rfkill=1
 
 # Bluetooth eng / userdebug
 ifneq ($(TARGET_BUILD_VARIANT),user)

--- a/groups/bluetooth/btusb/init.rc
+++ b/groups/bluetooth/btusb/init.rc
@@ -16,9 +16,6 @@ on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 service dhcpcd_bt-pan /system/bin/dhcpcd -ABKL
     class main
     user bluetooth

--- a/groups/bluetooth/btusb/product.mk
+++ b/groups/bluetooth/btusb/product.mk
@@ -3,7 +3,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.bluetooth.xml:vendor/etc/permissions/android.hardware.bluetooth.xml \
     frameworks/native/data/etc/android.hardware.bluetooth_le.xml:vendor/etc/permissions/android.hardware.bluetooth_le.xml
 
-PRODUCT_PROPERTY_OVERRIDES += bluetooth.rfkill=1
+PRODUCT_PROPERTY_OVERRIDES += vendor.bluetooth.rfkill=1
 
 PRODUCT_PACKAGES += \
     android.hardware.bluetooth-service.default.vbt 

--- a/groups/bluetooth/rtl8723bs/init.rc
+++ b/groups/bluetooth/rtl8723bs/init.rc
@@ -54,9 +54,6 @@ on boot
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 on property:vendor.bluetooth.hwcfg=start
     start vendor.btcfg
 

--- a/groups/bluetooth/rtl8723bs/product.mk
+++ b/groups/bluetooth/rtl8723bs/product.mk
@@ -23,7 +23,7 @@ PRODUCT_COPY_FILES += frameworks/native/data/etc/android.hardware.bluetooth.xml:
 
 {{^hsu}}
 PRODUCT_PROPERTY_OVERRIDES += vendor.bluetooth.hwcfg=stop \
-                bluetooth.rfkill=1
+                vendor.bluetooth.rfkill=1
 
 # Bluetooth eng / userdebug
 ifneq ($(TARGET_BUILD_VARIANT),user)

--- a/groups/bluetooth/stonepeak/init.rc
+++ b/groups/bluetooth/stonepeak/init.rc
@@ -9,9 +9,6 @@ on boot
     insmod ${ro.vendor.boot.moduleslocation}/bluetooth.ko
     insmod ${ro.vendor.boot.moduleslocation}/btusb.ko
 
-on post-fs-data
-    mkdir /data/misc/dhcp 0770 dhcp system
-
 service dhcpcd_bt-pan /system/bin/dhcpcd -ABKL
     disabled
     oneshot


### PR DESCRIPTION
1. Based on treble requirements, vendor defined properties should be prefixed with vendor, or the property will be by default a system property which cannot be accessed by vendor domains.
2. /data/misc/dhcp is already created in system etc init.rc, and it belongs to system data file which cannot be modified or created by vendor domains.

Test done: Bluetooth function works normally.

Tracked-On: OAM-133295