### PR TITLE
Update VINTF manifest to support iacamera on CAAS Previously CAAS uti…

### DIFF
--- a/groups/device-specific/caas/manifest.xml
+++ b/groups/device-specific/caas/manifest.xml
@@ -33,7 +33,7 @@
     </hal-->
     <hal format="aidl">
         <name>android.hardware.camera.provider</name>
-	<fqname>ICameraProvider/external/0</fqname>
+	<fqname>ICameraProvider/ivi/0</fqname>
     </hal>
     <!--<kernel target-level="5"/>-->
     <sepolicy>


### PR DESCRIPTION
…lises Google Camera HAL. Use our solution instead.

Tests Done: iacamera will be enabled.
Tracked-On: OAM-134061